### PR TITLE
[FEATURE][FAC-WEB-02] Add multi-role switching and support course/faculty images

### DIFF
--- a/app/(dashboard)/_guards/auth-guard.tsx
+++ b/app/(dashboard)/_guards/auth-guard.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { useActiveRole } from "@/hooks/auth/use-active-role";
 import { useMe } from "@/hooks/auth/use-me";
-import { resolveHomeFromRoles } from "@/lib/auth/role-route";
 import { useAuthStore } from "@/stores/auth-store";
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 
 type AuthGuardProps = {
   children: ReactNode;
@@ -16,8 +16,8 @@ export function AuthGuard({ children }: AuthGuardProps) {
   const hydrated = useAuthStore((state) => state.hydrated);
   const token = useAuthStore((state) => state.token);
   const clearSession = useAuthStore((state) => state.clearSession);
-  const { data: me, isPending: isMePending, isError: isMeError } = useMe();
-  const roleHome = useMemo(() => resolveHomeFromRoles(me?.roles), [me?.roles]);
+  const { isPending: isMePending, isError: isMeError } = useMe();
+  const { activeRole, roleHome } = useActiveRole();
 
   useEffect(() => {
     if (!hydrated) return;
@@ -34,12 +34,12 @@ export function AuthGuard({ children }: AuthGuardProps) {
       return;
     }
 
-    if (!roleHome) {
+    if (!activeRole || !roleHome) {
       clearSession();
     }
-  }, [clearSession, hydrated, isMeError, isMePending, roleHome, router, token]);
+  }, [activeRole, clearSession, hydrated, isMeError, isMePending, roleHome, router, token]);
 
-  if (!hydrated || !token || isMePending || isMeError || !roleHome) {
+  if (!hydrated || !token || isMePending || isMeError || !activeRole || !roleHome) {
     return null;
   }
 

--- a/app/(dashboard)/_guards/role-guard.tsx
+++ b/app/(dashboard)/_guards/role-guard.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { useActiveRole } from "@/hooks/auth/use-active-role";
 import { useMe } from "@/hooks/auth/use-me";
-import { resolveHomeFromRoles } from "@/lib/auth/role-route";
 import { useAuthStore } from "@/stores/auth-store";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import type { ReactNode } from "react";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 
 type RoleGuardProps = {
   allowedRoles: string[];
@@ -14,12 +14,13 @@ type RoleGuardProps = {
 
 export function RoleGuard({ allowedRoles, children }: RoleGuardProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const clearSession = useAuthStore((state) => state.clearSession);
   const { data: me, isPending: isMePending, isError: isMeError } = useMe();
-
-  const roles = useMemo(() => me?.roles ?? [], [me?.roles]);
-  const roleHome = resolveHomeFromRoles(roles);
-  const isAllowed = roles.some((role) => allowedRoles.includes(role));
+  const { activeRole, roleHome } = useActiveRole();
+  const roles = me?.roles ?? [];
+  const hasAnyAllowedRole = roles.some((role) => allowedRoles.includes(role));
+  const isAllowed = Boolean(activeRole && allowedRoles.includes(activeRole));
 
   useEffect(() => {
     if (isMePending) return;
@@ -36,10 +37,15 @@ export function RoleGuard({ allowedRoles, children }: RoleGuardProps) {
       return;
     }
 
-    if (!isAllowed) {
+    if (!hasAnyAllowedRole) {
+      router.replace(roleHome);
+      return;
+    }
+
+    if (!isAllowed && pathname !== roleHome) {
       router.replace(roleHome);
     }
-  }, [clearSession, isAllowed, isMeError, isMePending, roleHome, router]);
+  }, [clearSession, hasAnyAllowedRole, isAllowed, isMeError, isMePending, pathname, roleHome, router]);
 
   if (isMePending || isMeError || !roleHome || !isAllowed) {
     return null;

--- a/app/(dashboard)/dean/faculties/page.tsx
+++ b/app/(dashboard)/dean/faculties/page.tsx
@@ -1,6 +1,6 @@
 export default function DeanFacultiesPage() {
   return (
-    <section className="p-8">
+    <section className="md:p-8">
       <h1 className="text-2xl font-semibold">Dean Faculties</h1>
       <p className="mt-2 text-sm text-muted-foreground">
         Placeholder page for dean faculties.

--- a/app/(dashboard)/faculty/analytics/page.tsx
+++ b/app/(dashboard)/faculty/analytics/page.tsx
@@ -1,6 +1,6 @@
 export default function FacultyAnalyticsPage() {
   return (
-    <section className="p-8">
+    <section className="md:p-8">
       <h1 className="text-2xl font-semibold">Faculty Analytics</h1>
       <p className="mt-2 text-sm text-muted-foreground">
         Placeholder page for faculty analytics.

--- a/app/(dashboard)/faculty/courses/page.tsx
+++ b/app/(dashboard)/faculty/courses/page.tsx
@@ -1,6 +1,6 @@
 export default function FacultyCoursesPage() {
   return (
-    <section className="p-8">
+    <section className="md:p-8">
       <h1 className="text-2xl font-semibold">Faculty Courses</h1>
       <p className="mt-2 text-sm text-muted-foreground">
         Placeholder page for faculty courses.

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,78 +1,15 @@
-"use client";
-
 import { AppSidebar } from "@/components/app-sidebar";
 import { AuthGuard } from "@/app/(dashboard)/_guards/auth-guard";
-import { RoleSwitcher } from "@/components/role-switcher";
-import { ThemeToggle } from "@/components/theme-toggle";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
-import { Separator } from "@/components/ui/separator";
-import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import React from "react";
+import { DashboardHeader } from "@/components/dashboard-header";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  const segments = pathname.split("/").filter(Boolean);
-  const idLikeSegmentPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-  const crumbs = segments
-    .map((segment, index) => {
-      const href = `/${segments.slice(0, index + 1).join("/")}`;
-      const isIdLikeSegment = idLikeSegmentPattern.test(segment) || segment.length > 24;
-      if (isIdLikeSegment) return null;
-
-      const label = segment
-        .split("-")
-        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-        .join(" ");
-      return { href, label };
-    })
-    .filter((crumb): crumb is { href: string; label: string } => Boolean(crumb));
-
   return (
     <AuthGuard>
       <SidebarProvider>
         <AppSidebar />
         <SidebarInset>
-          <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
-            <SidebarTrigger className="-ml-1" />
-            <Separator orientation="vertical" className="h-4" />
-            <div className="flex flex-1 items-center justify-between gap-4">
-              <Breadcrumb>
-                <BreadcrumbList>
-                  {crumbs.map((crumb, index) => {
-                    const isLast = index === crumbs.length - 1;
-                    return (
-                      <React.Fragment key={crumb.href}>
-                        <BreadcrumbItem>
-                          {isLast ? (
-                            <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
-                          ) : (
-                            <BreadcrumbLink asChild>
-                              <Link href={crumb.href}>{crumb.label}</Link>
-                            </BreadcrumbLink>
-                          )}
-                        </BreadcrumbItem>
-                        {!isLast && <BreadcrumbSeparator />}
-                      </React.Fragment>
-                    );
-                  })}
-                </BreadcrumbList>
-              </Breadcrumb>
-              <div className="flex items-center gap-2">
-                <RoleSwitcher />
-                <ThemeToggle />
-              </div>
-            </div>
-          </header>
+          <DashboardHeader />
           <div className="flex flex-1 flex-col">{children}</div>
         </SidebarInset>
       </SidebarProvider>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { AppSidebar } from "@/components/app-sidebar";
 import { AuthGuard } from "@/app/(dashboard)/_guards/auth-guard";
+import { RoleSwitcher } from "@/components/role-switcher";
 import { ThemeToggle } from "@/components/theme-toggle";
 import {
   Breadcrumb,
@@ -66,7 +67,10 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                   })}
                 </BreadcrumbList>
               </Breadcrumb>
-              <ThemeToggle />
+              <div className="flex items-center gap-2">
+                <RoleSwitcher />
+                <ThemeToggle />
+              </div>
             </div>
           </header>
           <div className="flex flex-1 flex-col">{children}</div>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -10,7 +10,9 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         <AppSidebar />
         <SidebarInset>
           <DashboardHeader />
-          <div className="flex flex-1 flex-col">{children}</div>
+          <div className="flex flex-1 flex-col px-4 py-4 md:px-0 md:py-0">
+            {children}
+          </div>
         </SidebarInset>
       </SidebarProvider>
     </AuthGuard>

--- a/app/(dashboard)/student/courses/[courseId]/evaluation/page.tsx
+++ b/app/(dashboard)/student/courses/[courseId]/evaluation/page.tsx
@@ -39,7 +39,7 @@ export default function FacultyEvaluationPage() {
   const facultyId = selectedFaculty?.id || null;
 
   return (
-    <section className="px-16 py-12">
+    <section className="md:px-16 md:py-12">
       <h1 className="font-playfair text-3xl font-bold">Faculty Evaluation Questionnaire</h1>
       <p className="mt-2 text-sm text-muted-foreground">
         Your honest feedback helps improve the quality of education.

--- a/app/(dashboard)/student/courses/page.tsx
+++ b/app/(dashboard)/student/courses/page.tsx
@@ -11,7 +11,7 @@ export default function StudentCoursesPage() {
   const enrolledCourses = data?.data ?? [];
 
   return (
-    <section className="px-16 py-12">
+    <section className="md:px-16 md:py-12">
       <h1 className="text-3xl font-bold font-playfair">Courses</h1>
       <p className="mt-2 text-sm text-muted-foreground">
         You are currently enrolled in {enrolledCourses.length} courses this

--- a/app/(dashboard)/student/courses/page.tsx
+++ b/app/(dashboard)/student/courses/page.tsx
@@ -37,6 +37,8 @@ export default function StudentCoursesPage() {
               shortname={enrollment.course.shortname}
               fullname={enrollment.course.fullname}
               teacherName={enrollment.faculty?.fullName ?? "Teacher unavailable"}
+              teacherImageSrc={enrollment.faculty?.profilePicture}
+              imageSrc={enrollment.course.courseImage}
               feedbackHref={`/student/courses/${enrollment.course.id}/evaluation`}
               onGiveFeedback={() => setSelectedCourse(enrollment)}
             />

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -12,8 +12,9 @@ import { loginRequestSchema } from "@/schemas/auth";
 import { useAuthStore } from "@/stores/auth-store";
 import { LoginRequest } from "@/types/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Eye, EyeOff } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 export default function AuthPage() {
@@ -23,6 +24,7 @@ export default function AuthPage() {
   const { roleHome } = useActiveRole();
   const clearSession = useAuthStore((state) => state.clearSession);
   const token = useAuthStore((state) => state.token);
+  const [showPassword, setShowPassword] = useState(false);
 
   const form = useForm<LoginRequest>({
     resolver: zodResolver(loginRequestSchema),
@@ -152,11 +154,24 @@ export default function AuthPage() {
                           Forgot Password?
                         </FieldLabel>
                       </div>
-                      <Input
-                        {...field}
-                        id="password"
-                        type="password"
-                      />
+                      <div className="relative">
+                        <Input
+                          {...field}
+                          id="password"
+                          type={showPassword ? "text" : "password"}
+                          className="pr-10"
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          className="absolute right-1 top-1/2 -translate-y-1/2"
+                          onClick={() => setShowPassword((current) => !current)}
+                          aria-label={showPassword ? "Hide password" : "Show password"}
+                        >
+                          {showPassword ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+                        </Button>
+                      </div>
                       {fieldState.error && (
                         <FieldError>
                           {fieldState.error.message}

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -5,9 +5,9 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { useActiveRole } from "@/hooks/auth/use-active-role";
 import { useLogin } from "@/hooks/auth/use-login";
 import { useMe } from "@/hooks/auth/use-me";
-import { resolveHomeFromRoles } from "@/lib/auth/role-route";
 import { loginRequestSchema } from "@/schemas/auth";
 import { useAuthStore } from "@/stores/auth-store";
 import { LoginRequest } from "@/types/auth";
@@ -20,6 +20,7 @@ export default function AuthPage() {
   const router = useRouter();
   const { mutate, isPending } = useLogin();
   const { data: me, isPending: isMePending, isError: isMeError } = useMe();
+  const { roleHome } = useActiveRole();
   const clearSession = useAuthStore((state) => state.clearSession);
   const token = useAuthStore((state) => state.token);
 
@@ -43,16 +44,15 @@ export default function AuthPage() {
       return;
     }
 
-    const nextPath = resolveHomeFromRoles(me?.roles);
-    if (nextPath) {
-      router.replace(nextPath);
+    if (roleHome) {
+      router.replace(roleHome);
       return;
     }
 
     if (me) {
       clearSession();
     }
-  }, [clearSession, isMeError, isMePending, me, router, token]);
+  }, [clearSession, isMeError, isMePending, me, roleHome, router, token]);
 
   if (token && isMePending) {
     return (

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,10 +1,11 @@
 "use client"
 
 import * as React from "react"
-import { BarChart3, BookOpen, Building2, GraduationCap } from "lucide-react"
+import { GraduationCap } from "lucide-react"
 import Link from "next/link"
 
-import { useMe } from "@/hooks/auth/use-me"
+import { useActiveRole } from "@/hooks/auth/use-active-role"
+import { getNavItemsForRole, getRoleConfig } from "@/lib/auth/role-route"
 import { NavMain } from "@/components/nav-main"
 import { NavUser } from "@/components/nav-user"
 import {
@@ -18,35 +19,11 @@ import {
   SidebarRail,
 } from "@/components/ui/sidebar"
 
-const data = {
-  navMain: [
-    {
-      title: "Courses",
-      url: "/student/courses",
-      allowedRoles: ["STUDENT", "FACULTY"],
-      icon: BookOpen,
-    },
-    {
-      title: "Analytics",
-      url: "/faculty/analytics",
-      allowedRoles: ["FACULTY"],
-      icon: BarChart3,
-    },
-    {
-      title: "Faculties",
-      url: "/dean/faculties",
-      allowedRoles: ["DEAN"],
-      icon: Building2,
-    },
-  ],
-}
-
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
-  const { data: me } = useMe()
-  const roles = me?.roles ?? []
-  const navItems = data.navMain.filter((item) =>
-    item.allowedRoles.some((role) => roles.includes(role)),
-  )
+  const { activeRole, roleHome } = useActiveRole()
+  const navItems = getNavItemsForRole(activeRole)
+  const logoHref = roleHome ?? "/"
+  const roleLabel = activeRole ? getRoleConfig(activeRole).label : null
 
   return (
     <Sidebar collapsible="icon" {...props}>
@@ -54,12 +31,15 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton size="lg" asChild>
-              <Link href="/student/courses">
+              <Link href={logoHref}>
                 <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-brand-blue text-sidebar-primary-foreground">
                   <GraduationCap className="size-4" />
                 </div>
                 <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
                   <span className="truncate font-semibold">Faculytics</span>
+                  {roleLabel ? (
+                    <span className="truncate text-xs text-muted-foreground">{roleLabel} Mode</span>
+                  ) : null}
                 </div>
               </Link>
             </SidebarMenuButton>

--- a/components/dashboard-header.tsx
+++ b/components/dashboard-header.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import React from "react";
+
+import { RoleSwitcher } from "@/components/role-switcher";
+import { ThemeToggle } from "@/components/theme-toggle";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+
+export function DashboardHeader() {
+  const pathname = usePathname();
+  const segments = pathname.split("/").filter(Boolean);
+  const idLikeSegmentPattern =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+  const crumbs = segments
+    .map((segment, index) => {
+      const href = `/${segments.slice(0, index + 1).join("/")}`;
+      const isIdLikeSegment = idLikeSegmentPattern.test(segment) || segment.length > 24;
+      if (isIdLikeSegment) return null;
+
+      const label = segment
+        .split("-")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(" ");
+
+      return { href, label };
+    })
+    .filter((crumb): crumb is { href: string; label: string } => Boolean(crumb));
+
+  return (
+    <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
+      <SidebarTrigger className="-ml-1" />
+      <Separator orientation="vertical" className="h-4" />
+      <div className="flex flex-1 items-center justify-between gap-4">
+        <Breadcrumb>
+          <BreadcrumbList>
+            {crumbs.map((crumb, index) => {
+              const isLast = index === crumbs.length - 1;
+
+              return (
+                <React.Fragment key={crumb.href}>
+                  <BreadcrumbItem>
+                    {isLast ? (
+                      <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                    ) : (
+                      <BreadcrumbLink asChild>
+                        <Link href={crumb.href}>{crumb.label}</Link>
+                      </BreadcrumbLink>
+                    )}
+                  </BreadcrumbItem>
+                  {!isLast && <BreadcrumbSeparator />}
+                </React.Fragment>
+              );
+            })}
+          </BreadcrumbList>
+        </Breadcrumb>
+        <div className="flex items-center gap-2">
+          <RoleSwitcher />
+          <ThemeToggle />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/faculytics/course-card.tsx
+++ b/components/faculytics/course-card.tsx
@@ -1,14 +1,15 @@
 import Image from "next/image";
 import Link from "next/link";
-import { UserRound } from "lucide-react";
 
 import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
 
 export type CourseCardProps = {
   shortname: string;
   fullname: string;
   teacherName: string;
+  teacherImageSrc?: string;
   feedbackHref: string;
   onGiveFeedback?: () => void;
   imageSrc?: string;
@@ -18,6 +19,7 @@ export default function CourseCard({
   shortname,
   fullname,
   teacherName,
+  teacherImageSrc,
   feedbackHref,
   onGiveFeedback,
   imageSrc,
@@ -25,6 +27,12 @@ export default function CourseCard({
   const titleSizeClass =
     fullname.length > 64 ? "text-base" : fullname.length > 40 ? "text-lg" : "text-xl";
   const resolvedImageSrc = imageSrc?.trim() ? imageSrc : "/course-placeholder.svg";
+  const teacherInitials = teacherName
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
 
   return (
     <Card className="overflow-hidden py-0 gap-0 h-full">
@@ -47,10 +55,13 @@ export default function CourseCard({
             {fullname}
           </h2>
         </div>
-        <p className="my-2 flex items-center gap-2 text-sm text-muted-foreground">
-          <UserRound className="size-4" />
-          {teacherName}
-        </p>
+        <div className="my-2 flex items-center gap-2 text-sm text-muted-foreground">
+          <Avatar className="size-7">
+            {teacherImageSrc ? <AvatarImage src={teacherImageSrc} alt={teacherName} /> : null}
+            <AvatarFallback className="text-[10px]">{teacherInitials || "T"}</AvatarFallback>
+          </Avatar>
+          <p className="line-clamp-1">{teacherName}</p>
+        </div>
         <Button
           asChild
           className="mt-auto w-full bg-brand-blue hover:bg-brand-blue/90 cursor-pointer"

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation"
 
 import { useMe } from "@/hooks/auth/use-me"
 import { logout } from "@/network/requests/auth"
+import { useSelectedCourseStore } from "@/stores/selected-course-store"
 import { useAuthStore } from "@/stores/auth-store"
 import { Button } from "@/components/ui/button"
 import {
@@ -23,6 +24,7 @@ export function NavUser() {
   const router = useRouter()
   const queryClient = useQueryClient()
   const clearSession = useAuthStore((state) => state.clearSession)
+  const clearSelectedCourse = useSelectedCourseStore((state) => state.clearSelectedCourse)
   const { data: me } = useMe()
 
   const userName = me?.fullName || me?.userName || "User"
@@ -42,7 +44,9 @@ export function NavUser() {
       // Proceed with local logout even if API logout fails.
     } finally {
       clearSession()
-      queryClient.removeQueries({ queryKey: ["auth", "me"] })
+      clearSelectedCourse()
+      queryClient.removeQueries({ queryKey: ["auth"] })
+      queryClient.removeQueries({ queryKey: ["enrollments"] })
       router.replace("/auth")
     }
   }

--- a/components/role-switcher.tsx
+++ b/components/role-switcher.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+
+import type { AppRole } from "@/constants/roles";
+import { useActiveRole } from "@/hooks/auth/use-active-role";
+import { getRoleLabel } from "@/lib/auth/role-route";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function RoleSwitcher() {
+  const { activeRole, availableRoles, setActiveRole } = useActiveRole();
+
+  if (!activeRole || availableRoles.length < 2) {
+    return null;
+  }
+
+  const handleRoleChange = (nextRole: string) => {
+    const nextActiveRole = nextRole as AppRole;
+
+    if (nextRole === activeRole) return;
+
+    setActiveRole(nextActiveRole);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="min-w-32 justify-between">
+          <span>{getRoleLabel(activeRole)}</span>
+          <ChevronDown className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-40">
+        <DropdownMenuRadioGroup value={activeRole} onValueChange={handleRoleChange}>
+          {availableRoles.map((role) => (
+            <DropdownMenuRadioItem key={role} value={role}>
+              {getRoleLabel(role)}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -25,7 +25,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
-const SIDEBAR_COOKIE_NAME = "sidebar_state"
+export const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = "16rem"
 const SIDEBAR_WIDTH_MOBILE = "18rem"
@@ -53,6 +53,30 @@ function useSidebar() {
   return context
 }
 
+function getSidebarOpenFromCookie() {
+  if (typeof document === "undefined") {
+    return undefined
+  }
+
+  const sidebarCookie = document.cookie
+    .split("; ")
+    .find((cookie) => cookie.startsWith(`${SIDEBAR_COOKIE_NAME}=`))
+
+  if (!sidebarCookie) {
+    return undefined
+  }
+
+  return sidebarCookie.split("=")[1] === "true"
+}
+
+export function persistSidebarOpenState(open: boolean) {
+  if (typeof document === "undefined") {
+    return
+  }
+
+  document.cookie = `${SIDEBAR_COOKIE_NAME}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+}
+
 function SidebarProvider({
   defaultOpen = true,
   open: openProp,
@@ -67,11 +91,11 @@ function SidebarProvider({
   onOpenChange?: (open: boolean) => void
 }) {
   const isMobile = useIsMobile()
-  const [openMobile, setOpenMobile] = React.useState(false)
+  const [openMobile, setOpenMobile] = React.useState(() => getSidebarOpenFromCookie() ?? false)
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
-  const [_open, _setOpen] = React.useState(defaultOpen)
+  const [_open, _setOpen] = React.useState(() => getSidebarOpenFromCookie() ?? defaultOpen)
   const open = openProp ?? _open
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
@@ -81,12 +105,14 @@ function SidebarProvider({
       } else {
         _setOpen(openState)
       }
-
-      // This sets the cookie to keep the sidebar state.
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
     },
     [setOpenProp, open]
   )
+
+  React.useEffect(() => {
+    const persistedOpen = isMobile ? openMobile : open
+    persistSidebarOpenState(persistedOpen)
+  }, [isMobile, open, openMobile])
 
   // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {

--- a/constants/roles.ts
+++ b/constants/roles.ts
@@ -1,1 +1,3 @@
 export const ROLES = ["STUDENT", "FACULTY", "DEAN", "ADMIN", "SUPER_ADMIN"] as const;
+
+export type AppRole = (typeof ROLES)[number];

--- a/hooks/auth/use-active-role.ts
+++ b/hooks/auth/use-active-role.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+
+import { resolveActiveRole, resolveHomeFromRoles, getAvailableRoles } from "@/lib/auth/role-route";
+import { useAuthStore } from "@/stores/auth-store";
+
+import { useMe } from "./use-me";
+
+export function useActiveRole() {
+  const { data: me, isPending, isError } = useMe();
+  const storedActiveRole = useAuthStore((state) => state.activeRole);
+  const setActiveRole = useAuthStore((state) => state.setActiveRole);
+
+  const availableRoles = useMemo(() => getAvailableRoles(me?.roles), [me?.roles]);
+  const activeRole = useMemo(
+    () => resolveActiveRole(me?.roles, storedActiveRole),
+    [me?.roles, storedActiveRole],
+  );
+  const roleHome = useMemo(
+    () => resolveHomeFromRoles(me?.roles, storedActiveRole),
+    [me?.roles, storedActiveRole],
+  );
+
+  useEffect(() => {
+    if (isPending || isError) return;
+
+    if (storedActiveRole !== activeRole) {
+      setActiveRole(activeRole);
+    }
+  }, [activeRole, isError, isPending, setActiveRole, storedActiveRole]);
+
+  return {
+    activeRole,
+    availableRoles,
+    roleHome,
+    setActiveRole,
+  };
+}

--- a/hooks/auth/use-login.ts
+++ b/hooks/auth/use-login.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { persistSidebarOpenState } from "@/components/ui/sidebar";
 import { login } from "@/network/requests/auth";
 import { useAuthStore } from "@/stores/auth-store";
 import { useMutation } from "@tanstack/react-query";
@@ -14,6 +15,7 @@ export function useLogin() {
   return useMutation({
     mutationFn: login,
     onSuccess: (data) => {
+      persistSidebarOpenState(false);
       setSession(data.token, data.refreshToken);
     },
   });

--- a/hooks/auth/use-login.ts
+++ b/hooks/auth/use-login.ts
@@ -2,7 +2,9 @@
 
 import { persistSidebarOpenState } from "@/components/ui/sidebar";
 import { login } from "@/network/requests/auth";
+import { useSelectedCourseStore } from "@/stores/selected-course-store";
 import { useAuthStore } from "@/stores/auth-store";
+import { useQueryClient } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 
 /**
@@ -10,11 +12,16 @@ import { useMutation } from "@tanstack/react-query";
  * Handles API call, validation of token payload, and session persistence to Zustand.
  */
 export function useLogin() {
+  const queryClient = useQueryClient();
   const setSession = useAuthStore((state) => state.setSession);
+  const clearSelectedCourse = useSelectedCourseStore((state) => state.clearSelectedCourse);
 
   return useMutation({
     mutationFn: login,
     onSuccess: (data) => {
+      queryClient.removeQueries({ queryKey: ["auth"] });
+      queryClient.removeQueries({ queryKey: ["enrollments"] });
+      clearSelectedCourse();
       persistSidebarOpenState(false);
       setSession(data.token, data.refreshToken);
     },

--- a/hooks/enrollments/use-my-enrollments.ts
+++ b/hooks/enrollments/use-my-enrollments.ts
@@ -20,7 +20,7 @@ export function useMyEnrollments(
   const isEnabled = options?.enabled ?? true;
 
   return useQuery({
-    queryKey: ["enrollments", "me", page, limit],
+    queryKey: ["enrollments", "me", token, page, limit],
     enabled: Boolean(token) && isEnabled,
     queryFn: () => fetchMyEnrollments({ page, limit }),
   });

--- a/lib/auth/role-route.ts
+++ b/lib/auth/role-route.ts
@@ -1,16 +1,105 @@
-import { ROLES } from "@/constants/roles";
+import { BarChart3, BookOpen, Building2, Shield, type LucideIcon } from "lucide-react";
 
-const ROLE_HOME_PATH: Record<(typeof ROLES)[number], string> = {
-  STUDENT: "/student/courses",
-  FACULTY: "/faculty/courses",
-  DEAN: "/dean/faculties",
-  ADMIN: "/admin",
-  SUPER_ADMIN: "/superadmin",
+import { ROLES, type AppRole } from "@/constants/roles";
+
+type NavItem = {
+  title: string;
+  url: string;
+  icon: LucideIcon;
 };
 
-export function resolveHomeFromRoles(roles?: string[] | null) {
-  if (!roles?.length) return null;
+type RoleConfig = {
+  label: string;
+  homePath: string;
+  routePrefix: string;
+  navItems: NavItem[];
+};
 
-  const match = ROLES.find((role) => roles.includes(role));
-  return match ? ROLE_HOME_PATH[match] : null;
+const ROLE_CONFIG: Record<AppRole, RoleConfig> = {
+  STUDENT: {
+    label: "Student",
+    homePath: "/student/courses",
+    routePrefix: "/student",
+    navItems: [{ title: "Courses", url: "/student/courses", icon: BookOpen }],
+  },
+  FACULTY: {
+    label: "Faculty",
+    homePath: "/faculty/courses",
+    routePrefix: "/faculty",
+    navItems: [
+      { title: "Courses", url: "/faculty/courses", icon: BookOpen },
+      { title: "Analytics", url: "/faculty/analytics", icon: BarChart3 },
+    ],
+  },
+  DEAN: {
+    label: "Dean",
+    homePath: "/dean/faculties",
+    routePrefix: "/dean",
+    navItems: [{ title: "Faculties", url: "/dean/faculties", icon: Building2 }],
+  },
+  ADMIN: {
+    label: "Admin",
+    homePath: "/admin",
+    routePrefix: "/admin",
+    navItems: [{ title: "Admin", url: "/admin", icon: Shield }],
+  },
+  SUPER_ADMIN: {
+    label: "Super Admin",
+    homePath: "/superadmin",
+    routePrefix: "/superadmin",
+    navItems: [{ title: "Super Admin", url: "/superadmin", icon: Shield }],
+  },
+};
+
+export function getAvailableRoles(roles?: string[] | null): AppRole[] {
+  if (!roles?.length) return [];
+
+  return ROLES.filter((role) => roles.includes(role));
+}
+
+export function resolveActiveRole(
+  roles?: string[] | null,
+  activeRole?: AppRole | null,
+) {
+  const availableRoles = getAvailableRoles(roles);
+  if (!availableRoles.length) return null;
+
+  if (activeRole && availableRoles.includes(activeRole)) {
+    return activeRole;
+  }
+
+  return availableRoles[0];
+}
+
+export function resolveHomeFromRoles(
+  roles?: string[] | null,
+  activeRole?: AppRole | null,
+) {
+  const role = resolveActiveRole(roles, activeRole);
+  return role ? ROLE_CONFIG[role].homePath : null;
+}
+
+export function getRoleConfig(role: AppRole) {
+  return ROLE_CONFIG[role];
+}
+
+export function getRoleLabel(role: AppRole) {
+  return ROLE_CONFIG[role].label;
+}
+
+export function getNavItemsForRole(role: AppRole | null) {
+  return role ? ROLE_CONFIG[role].navItems : [];
+}
+
+export function getRoutePrefixForRole(role: AppRole) {
+  return ROLE_CONFIG[role].routePrefix;
+}
+
+export function getRoleFromPathname(pathname: string): AppRole | null {
+  const match = ROLES.find((role) => {
+    const routePrefix = ROLE_CONFIG[role].routePrefix;
+    return pathname === routePrefix || pathname.startsWith(`${routePrefix}/`);
+  });
+
+  return match ?? null;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "moodle.faculytics.ctr3.org",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/stores/auth-store.ts
+++ b/stores/auth-store.ts
@@ -1,13 +1,17 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
+import type { AppRole } from "@/constants/roles";
+
 type AuthStore = {
   token: string | null;
   refreshToken: string | null;
   isAuthenticated: boolean;
   hydrated: boolean;
+  activeRole: AppRole | null;
   setHydrated: (hydrated: boolean) => void;
   setSession: (token: string, refreshToken: string) => void;
+  setActiveRole: (activeRole: AppRole | null) => void;
   clearSession: () => void;
 };
 
@@ -18,6 +22,7 @@ export const useAuthStore = create<AuthStore>()(
       refreshToken: null,
       isAuthenticated: false,
       hydrated: false,
+      activeRole: null,
       setHydrated: (hydrated) => set({ hydrated }),
 
       setSession: (token, refreshToken) =>
@@ -27,12 +32,14 @@ export const useAuthStore = create<AuthStore>()(
           isAuthenticated: Boolean(token),
           hydrated: true,
         }),
+      setActiveRole: (activeRole) => set({ activeRole }),
       clearSession: () =>
         set({
           token: null,
           refreshToken: null,
           isAuthenticated: false,
           hydrated: true,
+          activeRole: null,
         }),
     }),
     {
@@ -42,6 +49,7 @@ export const useAuthStore = create<AuthStore>()(
         token: state.token,
         refreshToken: state.refreshToken,
         isAuthenticated: state.isAuthenticated,
+        activeRole: state.activeRole,
       }),
       onRehydrateStorage: () => (state) => {
         state?.setHydrated(true);

--- a/stores/selected-course-store.ts
+++ b/stores/selected-course-store.ts
@@ -5,9 +5,11 @@ import type { EnrollmentResponseDto } from "@/types/enrollments";
 type SelectedCourseStore = {
   selectedCourse: EnrollmentResponseDto | null;
   setSelectedCourse: (course: EnrollmentResponseDto) => void;
+  clearSelectedCourse: () => void;
 };
 
 export const useSelectedCourseStore = create<SelectedCourseStore>((set) => ({
   selectedCourse: null,
   setSelectedCourse: (course) => set({ selectedCourse: course }),
+  clearSelectedCourse: () => set({ selectedCourse: null }),
 }));

--- a/types/enrollments/index.ts
+++ b/types/enrollments/index.ts
@@ -8,6 +8,7 @@ export type CourseShortResponseDto = {
   moodleCourseId: number;
   shortname: string;
   fullname: string;
+  courseImage?: string;
 };
 
 export type FacultyShortResponseDto = {


### PR DESCRIPTION
## Summary

  This PR adds frontend support for multi-role users by introducing an active role switcher in the dashboard. Users such as deans who also have the FACULTY role can now switch
  modes without breaking route protection or navigation behavior.

  This PR also updates the student course UI to render backend-provided course images and faculty avatar images.

  ## Changes

  - Added persisted activeRole state in auth storage
  - Added shared role config and role resolution helpers
  - Updated auth and role guards to respect the selected active role
  - Added a dashboard header role switcher for multi-role users
  - Updated sidebar navigation to show items for the active role only
  - Updated login/dashboard redirects to use the resolved active role
  - Added support for courseImage in handwritten enrollment types
  - Updated student course cards to display:
      - course cover images
      - faculty avatar/profile picture with initials fallback
  - Allowed moodle.faculytics.ctr3.org in next.config.ts for next/image

  ## Verification

  - Verified role switching works without duplicate redirects/fetches
  - Verified student course cards render fallback images when remote images are missing