### PR TITLE
[FEATURE][FAC-WEB-07] Add support editing questionnaire title in builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,20 @@
 
 ## Project Structure & Module Organization
 - `app/`: Next.js App Router pages and layouts (e.g., `app/(dashboard)/student/courses/page.tsx`).
-- `components/`: Shared UI and feature components.
-  - `components/ui/`: shadcn-based primitives.
-  - `components/faculytics/`: domain UI (course cards, etc.).
-- `hooks/`: React Query and feature hooks (auth, enrollments).
+- `app/**/_components/`: route-local UI used by exactly one route.
+- `components/`: shared components only.
+  - `components/ui/`: shadcn-based primitives and generic controls.
+  - `components/layout/`: app shell components such as sidebar, header, nav, role switcher, and theme controls.
+- `features/`: domain slices that own feature logic and reusable feature code.
+  - `features/auth/`: auth API, hooks, schemas, role helpers, and types.
+  - `features/enrollments/`: enrollment API, hooks, and types.
+  - `features/questionnaires/`: questionnaire API, reusable components, hooks, schemas, store, types, and builder logic.
+- `lib/`: cross-feature pure utilities.
 - `network/`: API client, endpoints, and request functions.
-- `types/`: handwritten TypeScript API/request/response shapes.
 - `stores/`: Zustand state stores.
 - `providers/`: app-level providers (React Query, theme, etc.).
 - `public/`: static assets and images.
+- `docs/ARCHITECTURE.md`: source of truth for file placement, ownership boundaries, and state placement rules. Agents should follow this when adding or moving code.
 
 ## Build, Test, and Development Commands
 - `npm run dev`: start local dev server at `http://localhost:3000`.
@@ -23,9 +28,18 @@
 - Language: TypeScript with `strict` mode enabled.
 - Indentation: 2 spaces; prefer semicolons and double quotes only when already established in file.
 - Components: PascalCase (`CourseCard`), hooks: `useXxx`, request functions: verb-first (`fetchMyEnrollments`).
-- Keep API types in `types/*` (do not import from `context/index.d.ts`).
+- Keep API types inside their owning feature slice (for example `features/auth/types`).
 - Use `@/*` path alias for internal imports.
 - Favor small, composable components and colocate feature logic by domain.
+- Default to `@/*` imports across folders and feature boundaries; use relative imports only for tightly colocated route-local files inside the same route subtree.
+
+## Architecture Rules
+- Treat `docs/ARCHITECTURE.md` as the governing policy for LLM agents and humans during development.
+- Keep `app/` focused on routing, guards, redirects, route composition, and route-local `_components/`.
+- Put shared shell UI in `components/layout/` and low-level reusable primitives in `components/ui/`.
+- Put domain logic, request functions, reusable feature UI, schemas, and feature types in `features/<feature>/`.
+- Use route-local `_components/` when UI is used by exactly one route and does not justify a shared feature component.
+- Keep state in the lowest component that owns the behavior. Do not lift form, filter, search, or toggle state into page files unless it affects route orchestration.
 
 ## Testing Guidelines
 - No dedicated test framework is currently configured.

--- a/app/(dashboard)/superadmin/questionnaires/new/page.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/new/page.tsx
@@ -3,17 +3,17 @@
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
+import {
+  DEFAULT_QUESTIONNAIRE_TYPE,
+  QUESTIONNAIRE_TYPES,
+} from "@/features/questionnaires/constants";
 import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
 import {
   useQuestionnaireVersion,
   useQuestionnaireVersions,
 } from "@/features/questionnaires/hooks/use-questionnaire-versions";
 import { useQuestionnaireBuilderStore } from "@/features/questionnaires/store/questionnaire-builder-store";
-import {
-  QUESTIONNAIRE_TYPES,
-  DEFAULT_QUESTIONNAIRE_TYPE,
-  resolveQuestionnaireType,
-} from "@/features/questionnaires/types";
+import { resolveQuestionnaireType } from "@/features/questionnaires/types";
 
 import { QuestionnaireBuilderDiscardDialog } from "./_components/questionnaire-builder-discard-dialog";
 import { QuestionnaireBuilderPageHeader } from "./_components/questionnaire-builder-page-header";

--- a/app/(dashboard)/superadmin/questionnaires/page.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/page.tsx
@@ -4,11 +4,13 @@ import { useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
+import {
+  DEFAULT_QUESTIONNAIRE_TYPE,
+  QUESTIONNAIRE_TYPES,
+} from "@/features/questionnaires/constants";
 import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
 import { useQuestionnaireVersions } from "@/features/questionnaires/hooks/use-questionnaire-versions";
 import {
-  QUESTIONNAIRE_TYPES,
-  DEFAULT_QUESTIONNAIRE_TYPE,
   resolveQuestionnaireType,
   type QuestionnaireVersionItem,
   type QuestionnaireType,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,7 @@ High-level rules:
 - `app/` owns routing, layouts, guards, and route-level composition
 - `components/ui/` owns low-level reusable UI primitives
 - `components/layout/` owns the app shell
+- `constants/` owns app-wide shared constants only
 - `features/<feature>/` owns domain code
 - `lib/` owns cross-feature pure utilities
 - `network/` owns shared transport setup only
@@ -126,6 +127,7 @@ features/
       index.ts
     index.ts
   questionnaires/
+    constants/
     api/
       questionnaire.requests.ts
     components/
@@ -217,6 +219,19 @@ stores/
 - role switcher
 - theme controls
 - app shell composition
+
+### `constants/`
+
+**Owns**
+
+- app-wide shared constants reused across multiple features
+- global role lists and other cross-slice static values
+
+**Does not own**
+
+- feature-specific enums, labels, or builder defaults
+- route-local display maps
+- transport-layer endpoints owned by `network/`
 
 **Does not own**
 

--- a/features/questionnaires/components/builder/questionnaire-builder-shell.tsx
+++ b/features/questionnaires/components/builder/questionnaire-builder-shell.tsx
@@ -11,7 +11,7 @@ import { QuestionnaireQualitativeEditor } from "@/features/questionnaires/compon
 import { QuestionnaireSectionEditor } from "@/features/questionnaires/components/builder/questionnaire-section-editor";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { InlineEditInput } from "@/components/ui/inline-edit-input";
 import { Separator } from "@/components/ui/separator";
 import { useQuestionnaireBuilderController } from "@/features/questionnaires/hooks/use-questionnaire-builder-controller";
@@ -61,6 +61,8 @@ export function QuestionnaireBuilderShell({
     return <Card className="p-6 text-sm text-muted-foreground">Loading builder draft...</Card>;
   }
 
+  const hasExistingQuestionnaire = Boolean(draft.metadata.questionnaireId);
+
   const renderStatusBadge = () => {
     if (isDirty) {
       return (
@@ -87,32 +89,29 @@ export function QuestionnaireBuilderShell({
           <CardHeader className="space-y-4">
             <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
               <div className="space-y-4">
-                {draft.metadata.titleLocked ? (
-                  <div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <CardTitle className="font-playfair text-xl">
-                        {draft.metadata.questionnaireTitle || "Untitled questionnaire"}
-                      </CardTitle>
-                      {renderStatusBadge()}
-                    </div>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      This title is inherited from the questionnaire root and cannot be renamed
-                      from the version builder.
-                    </p>
-                  </div>
-                ) : (
+                <div>
                   <div className="flex flex-wrap items-center gap-2">
-                    <InlineEditInput
-                      id="questionnaire-title"
-                      value={draft.metadata.title}
-                      placeholder="Enter the questionnaire title"
-                      textClassName="min-h-11 bg-transparent px-0 text-xl font-semibold hover:bg-transparent"
-                      inputClassName="h-11 px-0 text-xl font-semibold"
-                      onChange={updateTitle}
-                    />
+                    <div className="min-w-0 flex-1">
+                      <InlineEditInput
+                        id="questionnaire-title"
+                        value={draft.metadata.title}
+                        placeholder="Enter the questionnaire title"
+                        ariaInvalid={Boolean(
+                          validation.issues.some((issue) => issue.code === "metadata.title.required")
+                        )}
+                        textClassName="min-h-11 bg-transparent px-0 text-xl font-semibold hover:bg-transparent"
+                        inputClassName="h-11 px-0 text-xl font-semibold"
+                        onChange={updateTitle}
+                      />
+                    </div>
                     {renderStatusBadge()}
                   </div>
-                )}
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {hasExistingQuestionnaire
+                      ? "Changes to the questionnaire title will be saved to the parent questionnaire."
+                      : "Set the questionnaire title before creating the first draft version."}
+                  </p>
+                </div>
               </div>
 
               <div className="flex flex-col gap-3 xl:items-end">

--- a/features/questionnaires/components/builder/questionnaire-outline-panel.tsx
+++ b/features/questionnaires/components/builder/questionnaire-outline-panel.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowDown, ArrowUp, ChevronDown, ChevronRight, Plus, Trash2 } from "lucide-react";
 
+import { MAX_SECTION_NESTING_LEVEL } from "@/features/questionnaires/constants/builder";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -11,7 +12,6 @@ import type {
   QuestionnaireBuilderSectionNode,
   QuestionnaireBuilderValidationIssue,
 } from "@/features/questionnaires/types";
-import { MAX_SECTION_NESTING_LEVEL } from "@/features/questionnaires/types";
 
 type QuestionnaireOutlinePanelProps = {
   sections: QuestionnaireBuilderSectionNode[];

--- a/features/questionnaires/components/builder/questionnaire-qualitative-editor.tsx
+++ b/features/questionnaires/components/builder/questionnaire-qualitative-editor.tsx
@@ -3,6 +3,7 @@
 import { Trash2 } from "lucide-react";
 
 import { QuestionnaireAddActionButton } from "@/features/questionnaires/components/builder/questionnaire-add-action-button";
+import { DEFAULT_QUALITATIVE_MAX_LENGTH } from "@/features/questionnaires/constants/builder";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -24,7 +25,7 @@ export function QuestionnaireQualitativeEditor({
   issues,
   onChange,
 }: QuestionnaireQualitativeEditorProps) {
-  const maxLength = value.maxLength ?? 1000;
+  const maxLength = value.maxLength ?? DEFAULT_QUALITATIVE_MAX_LENGTH;
   const maxLengthIssue = issues.find(
     (issue) => issue.target.type === "qualitative" && issue.target.field === "maxLength"
   );
@@ -91,7 +92,10 @@ export function QuestionnaireQualitativeEditor({
               aria-invalid={Boolean(maxLengthIssue)}
               onChange={(event) =>
                 onChange({
-                  maxLength: event.target.value === "" ? 1000 : Number(event.target.value),
+                  maxLength:
+                    event.target.value === ""
+                      ? DEFAULT_QUALITATIVE_MAX_LENGTH
+                      : Number(event.target.value),
                 })
               }
             />

--- a/features/questionnaires/components/builder/questionnaire-section-editor.tsx
+++ b/features/questionnaires/components/builder/questionnaire-section-editor.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, ArrowDown, ArrowUp, ChevronDown, MoreVertical, Trash2 } 
 
 import { QuestionnaireAddActionButton } from "@/features/questionnaires/components/builder/questionnaire-add-action-button";
 import { QuestionnaireQuestionEditor } from "@/features/questionnaires/components/builder/questionnaire-question-editor";
+import { MAX_SECTION_NESTING_LEVEL } from "@/features/questionnaires/constants/builder";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -24,7 +25,6 @@ import type {
   QuestionnaireBuilderSectionNode,
   QuestionnaireBuilderValidationIssue,
 } from "@/features/questionnaires/types";
-import { MAX_SECTION_NESTING_LEVEL } from "@/features/questionnaires/types";
 
 type QuestionnaireSectionEditorProps = {
   section: QuestionnaireBuilderSectionNode;

--- a/features/questionnaires/components/questionnaire-status-filter.tsx
+++ b/features/questionnaires/components/questionnaire-status-filter.tsx
@@ -13,8 +13,8 @@ import {
 import {
   QUESTIONNAIRE_STATUS_FILTER_LABELS,
   QUESTIONNAIRE_STATUSES,
-  type QuestionnaireStatusFilter,
-} from "@/features/questionnaires/types";
+} from "@/features/questionnaires/constants";
+import type { QuestionnaireStatusFilter } from "@/features/questionnaires/types";
 
 type QuestionnaireStatusFilterProps = {
   value: QuestionnaireStatusFilter;

--- a/features/questionnaires/components/questionnaire-type-button-group.tsx
+++ b/features/questionnaires/components/questionnaire-type-button-group.tsx
@@ -12,10 +12,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
-import {
-  QUESTIONNAIRE_TYPE_LABELS,
-  type QuestionnaireType,
-} from "@/features/questionnaires/types";
+import { QUESTIONNAIRE_TYPE_LABELS } from "@/features/questionnaires/constants";
+import type { QuestionnaireType } from "@/features/questionnaires/types";
 
 type QuestionnaireTypeButtonGroupProps = {
   types: QuestionnaireType[];

--- a/features/questionnaires/constants/builder.ts
+++ b/features/questionnaires/constants/builder.ts
@@ -1,0 +1,7 @@
+export const BUILDER_QUESTION_TYPES = ["LIKERT_1_5", "YES_NO"] as const;
+
+export const DEFAULT_BUILDER_QUESTION_TYPE = "LIKERT_1_5";
+
+export const MAX_SECTION_NESTING_LEVEL = 4;
+
+export const DEFAULT_QUALITATIVE_MAX_LENGTH = 1000;

--- a/features/questionnaires/constants/index.ts
+++ b/features/questionnaires/constants/index.ts
@@ -1,0 +1,22 @@
+export const QUESTIONNAIRE_TYPES = [
+  "FACULTY_FEEDBACK",
+  "FACULTY_IN_CLASSROOM",
+  "FACULTY_OUT_OF_CLASSROOM",
+] as const;
+
+export const QUESTIONNAIRE_STATUSES = ["DRAFT", "ACTIVE", "DEPRECATED"] as const;
+
+export const DEFAULT_QUESTIONNAIRE_TYPE = "FACULTY_FEEDBACK";
+
+export const QUESTIONNAIRE_TYPE_LABELS = {
+  FACULTY_IN_CLASSROOM: "Faculty In Classroom",
+  FACULTY_OUT_OF_CLASSROOM: "Faculty Out of Classroom",
+  FACULTY_FEEDBACK: "Faculty Feedback",
+} as const satisfies Record<(typeof QUESTIONNAIRE_TYPES)[number], string>;
+
+export const QUESTIONNAIRE_STATUS_FILTER_LABELS = {
+  ALL: "All statuses",
+  DRAFT: "Draft",
+  ACTIVE: "Active",
+  DEPRECATED: "Deprecated",
+} as const satisfies Record<(typeof QUESTIONNAIRE_STATUSES)[number] | "ALL", string>;

--- a/features/questionnaires/hooks/use-questionnaire-builder-controller.ts
+++ b/features/questionnaires/hooks/use-questionnaire-builder-controller.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 
+import { MAX_SECTION_NESTING_LEVEL } from "@/features/questionnaires/constants/builder";
 import { useSaveQuestionnaireBuilder } from "@/features/questionnaires/hooks/use-save-questionnaire-builder";
 import { buildQuestionnairePreviewModel } from "@/features/questionnaires/lib/builder-serializer";
 import {
@@ -16,7 +17,6 @@ import type {
   QuestionnaireBuilderSectionNode,
   QuestionnaireType,
 } from "@/features/questionnaires/types";
-import { MAX_SECTION_NESTING_LEVEL } from "@/features/questionnaires/types";
 
 type UseQuestionnaireBuilderControllerOptions = {
   activeType: QuestionnaireType;

--- a/features/questionnaires/hooks/use-save-questionnaire-builder.ts
+++ b/features/questionnaires/hooks/use-save-questionnaire-builder.ts
@@ -41,6 +41,7 @@ export function useSaveQuestionnaireBuilder() {
       return;
     }
 
+    const trimmedTitle = draft.metadata.title.trim();
     const payload = serializeQuestionnaireBuilderDraft(draft);
 
     try {
@@ -49,7 +50,7 @@ export function useSaveQuestionnaireBuilder() {
 
       if (!questionnaireId) {
         const createdQuestionnaire = await createQuestionnaireMutation.mutateAsync({
-          title: draft.metadata.title.trim(),
+          title: trimmedTitle,
           type: draft.metadata.type,
         });
         questionnaireId = createdQuestionnaire.id;
@@ -57,10 +58,13 @@ export function useSaveQuestionnaireBuilder() {
       }
 
       if (draft.metadata.versionId) {
+        const shouldSendTitle =
+          draft.metadata.questionnaireTitle === null || trimmedTitle !== draft.metadata.questionnaireTitle.trim();
         const updatedVersion = await updateQuestionnaireVersionMutation.mutateAsync({
           versionId: draft.metadata.versionId,
           payload: {
             schema: payload,
+            ...(shouldSendTitle ? { title: trimmedTitle } : {}),
           },
         });
         savedVersionId = updatedVersion.id;

--- a/features/questionnaires/index.ts
+++ b/features/questionnaires/index.ts
@@ -1,4 +1,6 @@
 export * from "@/features/questionnaires/api/questionnaire.requests";
+export * from "@/features/questionnaires/constants";
+export * from "@/features/questionnaires/constants/builder";
 export * from "@/features/questionnaires/hooks/use-create-questionnaire";
 export * from "@/features/questionnaires/hooks/use-create-questionnaire-version";
 export * from "@/features/questionnaires/hooks/use-questionnaire-builder-controller";

--- a/features/questionnaires/lib/builder-deserializer.ts
+++ b/features/questionnaires/lib/builder-deserializer.ts
@@ -1,3 +1,7 @@
+import {
+  DEFAULT_BUILDER_QUESTION_TYPE,
+  DEFAULT_QUALITATIVE_MAX_LENGTH,
+} from "@/features/questionnaires/constants/builder";
 import type {
   BuilderQuestionType,
   QuestionnaireBuilderDraft,
@@ -10,15 +14,13 @@ import type {
   QuestionnaireVersionSchema,
 } from "@/features/questionnaires/types";
 
-const DEFAULT_QUESTION_TYPE: BuilderQuestionType = "LIKERT_1_5";
-
 function normalizeQualitativeConfig(
   qualitative?: Partial<QuestionnaireBuilderQualitativeConfig>
 ): QuestionnaireBuilderQualitativeConfig {
   return {
     enabled: qualitative?.enabled ?? false,
     required: qualitative?.required ?? false,
-    maxLength: qualitative?.maxLength ?? 1000,
+    maxLength: qualitative?.maxLength ?? DEFAULT_QUALITATIVE_MAX_LENGTH,
   };
 }
 
@@ -42,7 +44,7 @@ function mapQuestion(
 
 function inferQuestionType(section: QuestionnaireBuilderSectionNode): BuilderQuestionType {
   if (section.questions.length > 0) {
-    return section.questions[0]?.type ?? DEFAULT_QUESTION_TYPE;
+    return section.questions[0]?.type ?? DEFAULT_BUILDER_QUESTION_TYPE;
   }
 
   for (const child of section.children) {
@@ -52,7 +54,7 @@ function inferQuestionType(section: QuestionnaireBuilderSectionNode): BuilderQue
     }
   }
 
-  return DEFAULT_QUESTION_TYPE;
+  return DEFAULT_BUILDER_QUESTION_TYPE;
 }
 
 function mapSectionTreeNode(node: QuestionnaireSchemaSectionTreeNode): QuestionnaireBuilderSectionNode {
@@ -63,7 +65,8 @@ function mapSectionTreeNode(node: QuestionnaireSchemaSectionTreeNode): Questionn
         mapQuestion(question, index + 1, question.type)
       )
     : [];
-  const questionType = questions[0]?.type ?? children[0]?.questionType ?? DEFAULT_QUESTION_TYPE;
+  const questionType =
+    questions[0]?.type ?? children[0]?.questionType ?? DEFAULT_BUILDER_QUESTION_TYPE;
 
   return {
     id: node.id,
@@ -83,7 +86,7 @@ function buildSectionsFromFlatSchema(
     const questions = sortByOrder(section.questions).map((question, questionIndex) =>
       mapQuestion(question, questionIndex + 1, question.type)
     );
-    const questionType = questions[0]?.type ?? DEFAULT_QUESTION_TYPE;
+    const questionType = questions[0]?.type ?? DEFAULT_BUILDER_QUESTION_TYPE;
 
     return {
       id: section.id,

--- a/features/questionnaires/lib/builder-deserializer.ts
+++ b/features/questionnaires/lib/builder-deserializer.ts
@@ -128,7 +128,7 @@ export function deserializeQuestionnaireVersionToDraft(
       title: version.questionnaireTitle,
       questionnaireId: version.questionnaireId,
       versionId: version.id,
-      titleLocked: true,
+      titleLocked: false,
       questionnaireTitle: version.questionnaireTitle,
     },
     sections: normalizedSections,

--- a/features/questionnaires/lib/builder-serializer.ts
+++ b/features/questionnaires/lib/builder-serializer.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_QUALITATIVE_MAX_LENGTH } from "@/features/questionnaires/constants/builder";
 import {
   isLeafSection,
   sortSections,
@@ -152,7 +153,7 @@ export function serializeQuestionnaireBuilderDraft(
     qualitativeFeedback: {
       enabled: draft.qualitative.enabled,
       required: draft.qualitative.required,
-      maxLength: draft.qualitative.maxLength ?? 1000,
+      maxLength: draft.qualitative.maxLength ?? DEFAULT_QUALITATIVE_MAX_LENGTH,
     },
   };
 }

--- a/features/questionnaires/lib/builder-validator.ts
+++ b/features/questionnaires/lib/builder-validator.ts
@@ -82,8 +82,7 @@ export function hasMeaningfulDraftContent(draft: QuestionnaireBuilderDraft | nul
 
   const hasSections = draft.sections.length > 0;
   const hasQualitative = draft.qualitative.enabled;
-  const hasEditableTitle =
-    !draft.metadata.titleLocked && draft.metadata.title.trim().length > 0;
+  const hasEditableTitle = draft.metadata.title.trim().length > 0;
 
   return hasSections || hasQualitative || hasEditableTitle;
 }
@@ -122,7 +121,7 @@ export function validateQuestionnaireBuilderDraft(
   let totalLeafWeight = 0;
   let leafSectionCount = 0;
 
-  if (!draft.metadata.titleLocked && draft.metadata.title.trim().length === 0) {
+  if (draft.metadata.title.trim().length === 0) {
     appendIssue(issues, {
       code: "metadata.title.required",
       message: "Questionnaire title is required before saving.",

--- a/features/questionnaires/schemas/questionnaire-builder.schema.ts
+++ b/features/questionnaires/schemas/questionnaire-builder.schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
-import { BUILDER_QUESTION_TYPES, QUESTIONNAIRE_TYPES } from "@/features/questionnaires/types";
+import { QUESTIONNAIRE_TYPES } from "@/features/questionnaires/constants";
+import { BUILDER_QUESTION_TYPES } from "@/features/questionnaires/constants/builder";
 
 export const questionnaireBuilderMetadataSchema = z.object({
   title: z

--- a/features/questionnaires/store/questionnaire-builder-store.ts
+++ b/features/questionnaires/store/questionnaire-builder-store.ts
@@ -334,7 +334,7 @@ export const useQuestionnaireBuilderStore = create<QuestionnaireBuilderStore>()(
               questionnaireId,
               questionnaireTitle: title,
               title: title,
-              titleLocked: true,
+              titleLocked: false,
             },
           }))
         ),
@@ -372,7 +372,7 @@ export const useQuestionnaireBuilderStore = create<QuestionnaireBuilderStore>()(
               title: context.questionnaireId !== null ? context.questionnaireTitle ?? "" : "",
               questionnaireId: context.questionnaireId,
               versionId: null,
-              titleLocked: Boolean(context.questionnaireId),
+              titleLocked: false,
               questionnaireTitle: context.questionnaireTitle,
             },
             hydratedFromServer: true,
@@ -408,12 +408,10 @@ export const useQuestionnaireBuilderStore = create<QuestionnaireBuilderStore>()(
         set((state) =>
           replaceActiveDraft(state, (draft) => ({
             ...draft,
-            metadata: draft.metadata.titleLocked
-              ? draft.metadata
-              : {
-                  ...draft.metadata,
-                  title,
-                },
+            metadata: {
+              ...draft.metadata,
+              title,
+            },
           }))
         ),
       selectSection: (sectionId) =>
@@ -611,9 +609,7 @@ export const useQuestionnaireBuilderStore = create<QuestionnaireBuilderStore>()(
               [state.activeType]: createDraft(state.activeType, {
                 metadata: {
                   ...activeDraft.metadata,
-                  title: activeDraft.metadata.titleLocked
-                    ? activeDraft.metadata.questionnaireTitle ?? ""
-                    : "",
+                  title: activeDraft.metadata.questionnaireTitle ?? "",
                 },
                 hydratedFromServer: activeDraft.hydratedFromServer,
               }),

--- a/features/questionnaires/store/questionnaire-builder-store.ts
+++ b/features/questionnaires/store/questionnaire-builder-store.ts
@@ -1,6 +1,11 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
+import {
+  DEFAULT_BUILDER_QUESTION_TYPE,
+  DEFAULT_QUALITATIVE_MAX_LENGTH,
+  MAX_SECTION_NESTING_LEVEL,
+} from "@/features/questionnaires/constants/builder";
 import { deserializeQuestionnaireVersionToDraft } from "@/features/questionnaires/lib/builder-deserializer";
 import {
   findSectionById,
@@ -18,7 +23,6 @@ import type {
   QuestionnaireType,
   QuestionnaireVersionDetail,
 } from "@/features/questionnaires/types";
-import { MAX_SECTION_NESTING_LEVEL } from "@/features/questionnaires/types";
 
 type QuestionnaireBuilderStore = {
   hydrated: boolean;
@@ -63,7 +67,7 @@ function createEmptyQualitativeConfig(): QuestionnaireBuilderQualitativeConfig {
   return {
     enabled: false,
     required: false,
-    maxLength: 1000,
+    maxLength: DEFAULT_QUALITATIVE_MAX_LENGTH,
   };
 }
 
@@ -73,12 +77,12 @@ function normalizeQualitativeConfig(
   return {
     ...createEmptyQualitativeConfig(),
     ...qualitative,
-    maxLength: qualitative?.maxLength ?? 1000,
+    maxLength: qualitative?.maxLength ?? DEFAULT_QUALITATIVE_MAX_LENGTH,
   };
 }
 
 function createSection(order: number): QuestionnaireBuilderSectionNode {
-  const questionType: QuestionnaireBuilderQuestionNode["type"] = "LIKERT_1_5";
+  const questionType: QuestionnaireBuilderQuestionNode["type"] = DEFAULT_BUILDER_QUESTION_TYPE;
 
   return {
     id: createId("section"),
@@ -110,7 +114,7 @@ function normalizeSections(
       section.questions
         .slice()
         .sort((left, right) => left.order - right.order)[0]?.type ??
-      "LIKERT_1_5";
+      DEFAULT_BUILDER_QUESTION_TYPE;
 
     return {
       ...section,
@@ -575,7 +579,10 @@ export const useQuestionnaireBuilderStore = create<QuestionnaireBuilderStore>()(
             qualitative: {
               ...normalizeQualitativeConfig(draft.qualitative),
               ...updates,
-              maxLength: updates.maxLength ?? draft.qualitative.maxLength ?? 1000,
+              maxLength:
+                updates.maxLength ??
+                draft.qualitative.maxLength ??
+                DEFAULT_QUALITATIVE_MAX_LENGTH,
             },
           }))
         ),

--- a/features/questionnaires/types/builder.ts
+++ b/features/questionnaires/types/builder.ts
@@ -1,11 +1,14 @@
+import {
+  BUILDER_QUESTION_TYPES,
+  DEFAULT_BUILDER_QUESTION_TYPE,
+  DEFAULT_QUALITATIVE_MAX_LENGTH,
+  MAX_SECTION_NESTING_LEVEL,
+} from "@/features/questionnaires/constants/builder";
 import type {
   QuestionnaireType,
   QuestionnaireVersionDetail,
   QuestionnaireVersionItem,
 } from "@/features/questionnaires/types";
-
-export const BUILDER_QUESTION_TYPES = ["LIKERT_1_5", "YES_NO"] as const;
-export const MAX_SECTION_NESTING_LEVEL = 4;
 
 export type BuilderQuestionType = (typeof BUILDER_QUESTION_TYPES)[number];
 
@@ -160,4 +163,11 @@ export type QuestionnaireBuilderValidationResult = {
   qualitativeIssues: QuestionnaireBuilderValidationIssue[];
   totalLeafWeight: number;
   leafSectionCount: number;
+};
+
+export {
+  BUILDER_QUESTION_TYPES,
+  DEFAULT_BUILDER_QUESTION_TYPE,
+  DEFAULT_QUALITATIVE_MAX_LENGTH,
+  MAX_SECTION_NESTING_LEVEL,
 };

--- a/features/questionnaires/types/index.ts
+++ b/features/questionnaires/types/index.ts
@@ -1,12 +1,11 @@
+import {
+  DEFAULT_QUESTIONNAIRE_TYPE,
+  QUESTIONNAIRE_STATUSES,
+  QUESTIONNAIRE_STATUS_FILTER_LABELS,
+  QUESTIONNAIRE_TYPES,
+  QUESTIONNAIRE_TYPE_LABELS,
+} from "@/features/questionnaires/constants";
 import type { QuestionnaireVersionSchema } from "@/features/questionnaires/types/builder";
-
-export const QUESTIONNAIRE_TYPES = [
-  "FACULTY_FEEDBACK",
-  "FACULTY_IN_CLASSROOM",
-  "FACULTY_OUT_OF_CLASSROOM",
-] as const;
-
-export const QUESTIONNAIRE_STATUSES = ["DRAFT", "ACTIVE", "DEPRECATED"] as const;
 
 export type QuestionnaireType = (typeof QUESTIONNAIRE_TYPES)[number];
 
@@ -88,8 +87,6 @@ export type QuestionnaireVersion = {
   deletedAt?: string | null;
 };
 
-export const DEFAULT_QUESTIONNAIRE_TYPE: QuestionnaireType = "FACULTY_FEEDBACK";
-
 export function resolveQuestionnaireType(value: string | null): QuestionnaireType {
   if (value && QUESTIONNAIRE_TYPES.includes(value as QuestionnaireType)) {
     return value as QuestionnaireType;
@@ -98,17 +95,11 @@ export function resolveQuestionnaireType(value: string | null): QuestionnaireTyp
   return DEFAULT_QUESTIONNAIRE_TYPE;
 }
 
-export const QUESTIONNAIRE_TYPE_LABELS: Record<QuestionnaireType, string> = {
-  FACULTY_IN_CLASSROOM: "Faculty In Classroom",
-  FACULTY_OUT_OF_CLASSROOM: "Faculty Out of Classroom",
-  FACULTY_FEEDBACK: "Faculty Feedback",
-};
-
-export const QUESTIONNAIRE_STATUS_FILTER_LABELS: Record<QuestionnaireStatusFilter, string> = {
-  ALL: "All statuses",
-  DRAFT: "Draft",
-  ACTIVE: "Active",
-  DEPRECATED: "Deprecated",
-};
-
 export * from "@/features/questionnaires/types/builder";
+export {
+  DEFAULT_QUESTIONNAIRE_TYPE,
+  QUESTIONNAIRE_STATUSES,
+  QUESTIONNAIRE_STATUS_FILTER_LABELS,
+  QUESTIONNAIRE_TYPES,
+  QUESTIONNAIRE_TYPE_LABELS,
+};


### PR DESCRIPTION
## Summary
- allow questionnaire titles to be edited from the builder for existing draft versions
- send the optional title field when saving a draft version only if the questionnaire title changed
- keep draft reset and sync behavior aligned with the last saved questionnaire title

## Additional changes in this branch
- move questionnaire constants into the feature constants folder
- update AGENTS.md to match the current frontend architecture

## Verification
- npx tsc --noEmit
- npm run lint 

Closes issue #7 