### PR TITLE
feat: handle submission status from enrollments endpoint

### DIFF
--- a/app/(dashboard)/student/courses/_components/course-card.tsx
+++ b/app/(dashboard)/student/courses/_components/course-card.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { Layers3 } from "lucide-react";
+import { CheckCircle2, Layers3 } from "lucide-react";
 
 import { decodeHtmlEntities, resolveCourseImageSrc } from "@/lib/string";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -17,6 +17,7 @@ export type CourseCardProps = {
   feedbackHref: string;
   onGiveFeedback?: () => void;
   imageSrc?: string;
+  submitted?: boolean;
 };
 
 export default function CourseCard({
@@ -28,6 +29,7 @@ export default function CourseCard({
   feedbackHref,
   onGiveFeedback,
   imageSrc,
+  submitted,
 }: CourseCardProps) {
   const decodedShortname = decodeHtmlEntities(shortname);
   const decodedFullname = decodeHtmlEntities(fullname);
@@ -81,11 +83,18 @@ export default function CourseCard({
             </div>
           )}
         </div>
-        <Button asChild variant="brand" className="mt-auto w-full">
-          <Link href={feedbackHref} onClick={onGiveFeedback}>
-            Give Feedback
-          </Link>
-        </Button>
+        {submitted ? (
+          <Button variant="outline" className="mt-auto w-full" disabled>
+            <CheckCircle2 className="size-4" />
+            Submitted
+          </Button>
+        ) : (
+          <Button asChild variant="brand" className="mt-auto w-full">
+            <Link href={feedbackHref} onClick={onGiveFeedback}>
+              Give Feedback
+            </Link>
+          </Button>
+        )}
       </CardContent>
     </Card>
   );

--- a/app/(dashboard)/student/courses/_components/course-grid.tsx
+++ b/app/(dashboard)/student/courses/_components/course-grid.tsx
@@ -21,6 +21,7 @@ export function CourseGrid({ enrollments, onSelectCourse }: CourseGridProps) {
           imageSrc={enrollment.course.courseImage}
           feedbackHref={`/student/courses/${enrollment.course.id}/evaluation`}
           onGiveFeedback={() => onSelectCourse(enrollment)}
+          submitted={enrollment.submission?.submitted}
         />
       ))}
     </>

--- a/features/enrollments/types/index.ts
+++ b/features/enrollments/types/index.ts
@@ -30,6 +30,11 @@ export type SectionShortResponseDto = {
   name: string;
 };
 
+export type SubmissionStatusDto = {
+  submitted: boolean;
+  submittedAt?: string;
+};
+
 export type EnrollmentResponseDto = {
   id: string;
   role: string;
@@ -37,6 +42,7 @@ export type EnrollmentResponseDto = {
   faculty?: FacultyShortResponseDto | null;
   semester?: SemesterShortResponseDto | null;
   section?: SectionShortResponseDto | null;
+  submission: SubmissionStatusDto;
 };
 
 export type PaginationMeta = {

--- a/features/questionnaires/hooks/use-submit-evaluation.ts
+++ b/features/questionnaires/hooks/use-submit-evaluation.ts
@@ -35,6 +35,7 @@ export function useSubmitEvaluation() {
       queryKey: ["questionnaires", "submissions", "check"],
     });
     queryClient.invalidateQueries({ queryKey: ["questionnaires", "drafts"] });
+    queryClient.invalidateQueries({ queryKey: ["enrollments", "me"] });
     router.push("/student/courses");
   }, [queryClient, router]);
 


### PR DESCRIPTION
## Summary
- Add `submission` field to `EnrollmentResponseDto` type to consume the new backend response shape
- Show "Submitted" disabled button on course cards when evaluation is already submitted, replacing "Give Feedback"
- Invalidate enrollments cache after submission so the course list reflects updated status immediately

## Test plan
- [x] Verify course cards show "Give Feedback" for courses without submissions
- [x] Verify course cards show disabled "Submitted" button for already-submitted courses
- [x] Submit an evaluation, confirm the course card updates to "Submitted" after redirect
- [x] Verify the evaluation page safety-net check still works (direct URL to already-submitted course)

Closes #26