### PR TITLE
[REFACTOR][FAC-WEB-19] migrate QuestionnaireType enum to entity

### DIFF
--- a/app/(dashboard)/superadmin/questionnaires/_components/questionnaire-list-screen.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/_components/questionnaire-list-screen.tsx
@@ -7,16 +7,16 @@ import { QuestionnaireAsyncContent } from "@/features/questionnaires/components/
 import { QuestionnaireTable } from "@/features/questionnaires/components/questionnaire-table";
 import type {
   QuestionnaireStatusFilter as StatusFilter,
-  QuestionnaireType,
+  QuestionnaireTypeCode,
   QuestionnaireVersionItem,
 } from "@/features/questionnaires/types";
 
 type QuestionnaireListScreenProps = {
-  availableTypes: QuestionnaireType[];
-  activeType: QuestionnaireType;
+  availableTypes: QuestionnaireTypeCode[];
+  activeType: QuestionnaireTypeCode;
   hasDraftVersion: boolean;
   hasQuestionnaire: boolean;
-  onTypeChange: (nextType: QuestionnaireType) => void;
+  onTypeChange: (nextType: QuestionnaireTypeCode) => void;
   isLoading: boolean;
   isError: boolean;
   rows: QuestionnaireVersionItem[];

--- a/app/(dashboard)/superadmin/questionnaires/new/_components/questionnaire-builder-screen.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/new/_components/questionnaire-builder-screen.tsx
@@ -1,9 +1,9 @@
 import { QuestionnaireAsyncContent } from "@/features/questionnaires/components/questionnaire-async-content";
 import { QuestionnaireBuilderShell } from "@/features/questionnaires/components/builder/questionnaire-builder-shell";
-import type { QuestionnaireType } from "@/features/questionnaires/types";
+import type { QuestionnaireTypeCode } from "@/features/questionnaires/types";
 
 type QuestionnaireBuilderScreenProps = {
-  activeType: QuestionnaireType;
+  activeType: QuestionnaireTypeCode;
   isHydrated: boolean;
   isLoading: boolean;
   isError: boolean;

--- a/features/dimensions/components/dimension-async-content.tsx
+++ b/features/dimensions/components/dimension-async-content.tsx
@@ -25,7 +25,7 @@ export function DimensionAsyncContent({
 }: DimensionAsyncContentProps) {
   if (isLoading) {
     return (
-      <div className="flex min-h-44 flex-col items-center justify-center px-6 text-center">
+      <div className="flex min-h-44 flex-col items-center justify-center rounded-lg border border-dashed px-6 text-center">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
         <p className="mt-3 text-sm text-muted-foreground">Loading dimensions...</p>
       </div>
@@ -34,7 +34,7 @@ export function DimensionAsyncContent({
 
   if (isError) {
     return (
-      <div className="flex min-h-44 flex-col items-center justify-center px-6 text-center">
+      <div className="flex min-h-44 flex-col items-center justify-center rounded-lg border border-dashed px-6 text-center">
         <p className="max-w-xl text-sm text-muted-foreground">Unable to load dimensions.</p>
         <Button type="button" variant="outline" className="mt-5" onClick={onRetry}>
           Retry
@@ -45,7 +45,7 @@ export function DimensionAsyncContent({
 
   if (emptyState) {
     return (
-      <div className="flex min-h-44 flex-col items-center justify-center px-6 text-center">
+      <div className="flex min-h-44 flex-col items-center justify-center rounded-lg border border-dashed px-6 text-center">
         <p className="max-w-xl text-sm text-muted-foreground">{emptyState.description}</p>
         {emptyState.actionLabel && emptyState.onAction ? (
           <Button

--- a/features/dimensions/components/dimension-code-select.tsx
+++ b/features/dimensions/components/dimension-code-select.tsx
@@ -4,8 +4,8 @@ import { useId, useMemo, useState } from "react";
 import { Check, ChevronsUpDown, LoaderCircle } from "lucide-react";
 
 import { useDimensions } from "@/features/dimensions/hooks/use-dimensions";
-import type { Dimension } from "@/features/dimensions/types";
-import type { QuestionnaireType } from "@/features/questionnaires/types";
+import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import type { QuestionnaireTypeCode } from "@/features/questionnaires/types";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -26,11 +26,16 @@ import { cn } from "@/lib/utils";
 import { normalizeDimensionText } from "@/features/dimensions/lib/dimension-utils";
 
 type DimensionCodeSelectProps = {
-  questionnaireType: QuestionnaireType;
+  questionnaireType: QuestionnaireTypeCode;
   value: string | null;
   onChange: (code: string | null) => void;
   ariaInvalid?: boolean;
   errorMessage?: string;
+};
+
+type DimensionDisplayItem = {
+  code: string;
+  displayName: string;
 };
 
 export function DimensionCodeSelect({
@@ -44,38 +49,29 @@ export function DimensionCodeSelect({
   const [isOpen, setIsOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
 
-  const dimensionsQuery = useDimensions(questionnaireType);
+  // Resolve code → UUID via cached questionnaire types
+  const typesQuery = useQuestionnaireTypes();
+  const questionnaireTypeId =
+    typesQuery.data?.find((t) => t.code === questionnaireType)?.id ?? null;
+
+  const dimensionsQuery = useDimensions(questionnaireTypeId);
   const activeDimensions = useMemo(() => dimensionsQuery.data?.data ?? [], [dimensionsQuery.data]);
 
   const selectedDimension = useMemo(
     () => activeDimensions.find((dimension) => dimension.code === value),
     [activeDimensions, value]
   );
-  const unavailableSelectedDimension = useMemo<Dimension | null>(() => {
+  const unavailableSelection = useMemo<DimensionDisplayItem | null>(() => {
     if (!value || selectedDimension || dimensionsQuery.isLoading || dimensionsQuery.isError) {
       return null;
     }
 
-    return {
-      id: `unavailable-${value}`,
-      code: value,
-      displayName: value,
-      questionnaireType,
-      active: false,
-      createdAt: "",
-      updatedAt: "",
-    };
-  }, [
-    dimensionsQuery.isError,
-    dimensionsQuery.isLoading,
-    questionnaireType,
-    selectedDimension,
-    value,
-  ]);
+    return { code: value, displayName: value };
+  }, [dimensionsQuery.isError, dimensionsQuery.isLoading, selectedDimension, value]);
 
   const normalizedSearch = normalizeDimensionText(searchValue);
   const selectedDisplayValue =
-    selectedDimension?.displayName ?? unavailableSelectedDimension?.displayName ?? "";
+    selectedDimension?.displayName ?? unavailableSelection?.displayName ?? "";
   const filteredDimensions = useMemo(() => {
     if (!normalizedSearch) {
       return activeDimensions;
@@ -88,11 +84,13 @@ export function DimensionCodeSelect({
     });
   }, [activeDimensions, normalizedSearch]);
 
-  const selectDimension = (dimension: Dimension) => {
-    onChange(dimension.code);
-    setSearchValue(dimension.displayName);
+  const selectDimension = (item: DimensionDisplayItem) => {
+    onChange(item.code);
+    setSearchValue(item.displayName);
     setIsOpen(false);
   };
+
+  const isLoading = typesQuery.isLoading || dimensionsQuery.isLoading;
 
   return (
     <div className="space-y-2">
@@ -124,7 +122,7 @@ export function DimensionCodeSelect({
               />
               <InputGroupAddon align="inline-end">
                 <InputGroupText className="gap-2 text-xs">
-                  {dimensionsQuery.isLoading ? "Loading..." : `${activeDimensions.length} codes`}
+                  {isLoading ? "Loading..." : `${activeDimensions.length} codes`}
                   <ChevronsUpDown className="size-4 opacity-50" />
                 </InputGroupText>
               </InputGroupAddon>
@@ -140,7 +138,7 @@ export function DimensionCodeSelect({
               onValueChange={setSearchValue}
             />
             <CommandList>
-              {dimensionsQuery.isLoading ? (
+              {isLoading ? (
                 <div className="flex items-center gap-2 px-3 py-3 text-sm text-muted-foreground">
                   <LoaderCircle className="size-4 animate-spin" />
                   Loading dimensions...
@@ -149,24 +147,22 @@ export function DimensionCodeSelect({
                 <>
                   <CommandEmpty>No matching dimensions.</CommandEmpty>
 
-                  {unavailableSelectedDimension ? (
+                  {unavailableSelection ? (
                     <CommandGroup heading="Unavailable Selection">
                       <CommandItem
-                        value={`unavailable-${unavailableSelectedDimension.code}`}
+                        value={`unavailable-${unavailableSelection.code}`}
                         className="text-amber-700"
                         onSelect={() => {
-                          selectDimension(unavailableSelectedDimension);
+                          selectDimension(unavailableSelection);
                         }}
                       >
                         <Check
                           className={cn(
                             "size-4",
-                            value === unavailableSelectedDimension.code
-                              ? "opacity-100"
-                              : "opacity-0"
+                            value === unavailableSelection.code ? "opacity-100" : "opacity-0"
                           )}
                         />
-                        <span className="truncate">{unavailableSelectedDimension.displayName}</span>
+                        <span className="truncate">{unavailableSelection.displayName}</span>
                       </CommandItem>
                     </CommandGroup>
                   ) : null}
@@ -198,10 +194,10 @@ export function DimensionCodeSelect({
       </Popover>
 
       {errorMessage ? <p className="text-sm text-destructive">{errorMessage}</p> : null}
-      {!errorMessage && unavailableSelectedDimension ? (
+      {!errorMessage && unavailableSelection ? (
         <p className="text-sm text-amber-700">
-          The saved code &quot;{unavailableSelectedDimension.code}&quot; is not in the active
-          registry. Re-select it or choose a replacement before publishing.
+          The saved code &quot;{unavailableSelection.code}&quot; is not in the active registry.
+          Re-select it or choose a replacement before publishing.
         </p>
       ) : null}
     </div>

--- a/features/dimensions/components/dimension-code-select.tsx
+++ b/features/dimensions/components/dimension-code-select.tsx
@@ -4,7 +4,7 @@ import { useId, useMemo, useState } from "react";
 import { Check, ChevronsUpDown, LoaderCircle } from "lucide-react";
 
 import { useDimensions } from "@/features/dimensions/hooks/use-dimensions";
-import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import { useQuestionnaireTypeId } from "@/features/questionnaires/hooks/use-questionnaire-type-id";
 import type { QuestionnaireTypeCode } from "@/features/questionnaires/types";
 import { Button } from "@/components/ui/button";
 import {
@@ -50,9 +50,7 @@ export function DimensionCodeSelect({
   const [searchValue, setSearchValue] = useState("");
 
   // Resolve code → UUID via cached questionnaire types
-  const typesQuery = useQuestionnaireTypes();
-  const questionnaireTypeId =
-    typesQuery.data?.find((t) => t.code === questionnaireType)?.id ?? null;
+  const questionnaireTypeId = useQuestionnaireTypeId(questionnaireType);
 
   const dimensionsQuery = useDimensions(questionnaireTypeId);
   const activeDimensions = useMemo(() => dimensionsQuery.data?.data ?? [], [dimensionsQuery.data]);
@@ -90,7 +88,7 @@ export function DimensionCodeSelect({
     setIsOpen(false);
   };
 
-  const isLoading = typesQuery.isLoading || dimensionsQuery.isLoading;
+  const isLoading = !questionnaireTypeId || dimensionsQuery.isLoading;
 
   return (
     <div className="space-y-2">

--- a/features/dimensions/components/dimension-create-dialog.tsx
+++ b/features/dimensions/components/dimension-create-dialog.tsx
@@ -29,11 +29,7 @@ import {
   createDimensionSchema,
   type CreateDimensionFormValues,
 } from "@/features/dimensions/schemas/dimension.schemas";
-import {
-  QUESTIONNAIRE_TYPE_LABELS,
-  QUESTIONNAIRE_TYPES,
-} from "@/features/questionnaires/constants";
-import type { QuestionnaireType } from "@/features/questionnaires/types";
+import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
 
 type DimensionCreateDialogProps = {
   open: boolean;
@@ -42,12 +38,14 @@ type DimensionCreateDialogProps = {
 
 export function DimensionCreateDialog({ open, onOpenChange }: DimensionCreateDialogProps) {
   const createMutation = useCreateDimension();
+  const typesQuery = useQuestionnaireTypes();
+  const typeSummaries = typesQuery.data ?? [];
 
   const form = useForm<CreateDimensionFormValues>({
     resolver: zodResolver(createDimensionSchema),
     defaultValues: {
       displayName: "",
-      questionnaireType: undefined,
+      questionnaireTypeId: "",
       code: "",
     },
   });
@@ -56,7 +54,7 @@ export function DimensionCreateDialog({ open, onOpenChange }: DimensionCreateDia
     try {
       await createMutation.mutateAsync({
         displayName: values.displayName,
-        questionnaireType: values.questionnaireType as QuestionnaireType,
+        questionnaireTypeId: values.questionnaireTypeId,
         code: values.code || undefined,
       });
       toast.success("Dimension created.");
@@ -109,7 +107,7 @@ export function DimensionCreateDialog({ open, onOpenChange }: DimensionCreateDia
             />
 
             <Controller
-              name="questionnaireType"
+              name="questionnaireTypeId"
               control={form.control}
               render={({ field, fieldState }) => (
                 <Field>
@@ -123,7 +121,8 @@ export function DimensionCreateDialog({ open, onOpenChange }: DimensionCreateDia
                         aria-invalid={fieldState.invalid}
                       >
                         {field.value
-                          ? QUESTIONNAIRE_TYPE_LABELS[field.value as QuestionnaireType]
+                          ? (typeSummaries.find((t) => t.id === field.value)?.name ??
+                            "Unknown type")
                           : "Select a type"}
                         <ChevronDown className="size-4 text-muted-foreground" />
                       </Button>
@@ -133,9 +132,9 @@ export function DimensionCreateDialog({ open, onOpenChange }: DimensionCreateDia
                         value={field.value ?? ""}
                         onValueChange={field.onChange}
                       >
-                        {QUESTIONNAIRE_TYPES.map((type) => (
-                          <DropdownMenuRadioItem key={type} value={type}>
-                            {QUESTIONNAIRE_TYPE_LABELS[type]}
+                        {typeSummaries.map((type) => (
+                          <DropdownMenuRadioItem key={type.id} value={type.id}>
+                            {type.name}
                           </DropdownMenuRadioItem>
                         ))}
                       </DropdownMenuRadioGroup>

--- a/features/dimensions/components/dimension-table.tsx
+++ b/features/dimensions/components/dimension-table.tsx
@@ -16,7 +16,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { QUESTIONNAIRE_TYPE_LABELS } from "@/features/questionnaires/constants";
 import type { Dimension } from "@/features/dimensions/types";
 
 type DimensionTableProps = {
@@ -60,7 +59,7 @@ export function DimensionTable({
                 </Badge>
               </TableCell>
               <TableCell className="data-table-cell text-muted-foreground">
-                {QUESTIONNAIRE_TYPE_LABELS[row.questionnaireType]}
+                {row.questionnaireType.name}
               </TableCell>
               <TableCell className="data-table-cell">
                 <DropdownMenu>

--- a/features/dimensions/components/dimension-toolbar.tsx
+++ b/features/dimensions/components/dimension-toolbar.tsx
@@ -17,7 +17,7 @@ import {
   QUESTIONNAIRE_TYPE_LABELS,
   QUESTIONNAIRE_TYPES,
 } from "@/features/questionnaires/constants";
-import type { QuestionnaireType } from "@/features/questionnaires/types";
+import type { QuestionnaireTypeCode } from "@/features/questionnaires/types";
 
 type DimensionStatusFilter = "ALL" | "ACTIVE" | "INACTIVE";
 
@@ -27,7 +27,7 @@ const STATUS_FILTER_LABELS: Record<DimensionStatusFilter, string> = {
   INACTIVE: "Inactive",
 };
 
-type TypeFilter = QuestionnaireType;
+type TypeFilter = QuestionnaireTypeCode;
 
 type DimensionToolbarProps = {
   typeFilter: TypeFilter;

--- a/features/dimensions/hooks/use-create-dimension.ts
+++ b/features/dimensions/hooks/use-create-dimension.ts
@@ -3,59 +3,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { createDimension } from "@/features/dimensions/api/dimension.requests";
-import type { DimensionsListResponse } from "@/features/dimensions/types";
-import { useAuthStore } from "@/stores/auth-store";
 
 export function useCreateDimension() {
   const queryClient = useQueryClient();
-  const token = useAuthStore((state) => state.token);
 
   return useMutation({
     mutationFn: createDimension,
-    onSuccess: (dimension) => {
-      const typeId = dimension.questionnaireType.id;
-
-      queryClient.setQueryData<DimensionsListResponse | undefined>(
-        ["dimensions", typeId, "active", token],
-        (current) => {
-          if (!current) {
-            return {
-              data: [dimension],
-              meta: {
-                page: 1,
-                limit: 100,
-                totalItems: 1,
-                totalPages: 1,
-                itemCount: 1,
-              },
-            };
-          }
-
-          const alreadyPresent = current.data.some((item) => item.code === dimension.code);
-          if (alreadyPresent) {
-            return current;
-          }
-
-          const nextData = [dimension, ...current.data];
-
-          return {
-            ...current,
-            data: nextData,
-            meta: {
-              ...current.meta,
-              totalItems: current.meta.totalItems + 1,
-              itemCount: nextData.length,
-              totalPages: Math.max(
-                1,
-                Math.ceil((current.meta.totalItems + 1) / current.meta.limit)
-              ),
-            },
-          };
-        }
-      );
-
+    onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["dimensions", typeId],
+        queryKey: ["dimensions"],
       });
     },
   });

--- a/features/dimensions/hooks/use-create-dimension.ts
+++ b/features/dimensions/hooks/use-create-dimension.ts
@@ -13,8 +13,10 @@ export function useCreateDimension() {
   return useMutation({
     mutationFn: createDimension,
     onSuccess: (dimension) => {
+      const typeId = dimension.questionnaireType.id;
+
       queryClient.setQueryData<DimensionsListResponse | undefined>(
-        ["dimensions", dimension.questionnaireType, "active", token],
+        ["dimensions", typeId, "active", token],
         (current) => {
           if (!current) {
             return {
@@ -53,7 +55,7 @@ export function useCreateDimension() {
       );
 
       void queryClient.invalidateQueries({
-        queryKey: ["dimensions", dimension.questionnaireType],
+        queryKey: ["dimensions", typeId],
       });
     },
   });

--- a/features/dimensions/hooks/use-dimension-list-page.ts
+++ b/features/dimensions/hooks/use-dimension-list-page.ts
@@ -15,6 +15,7 @@ import {
   QUESTIONNAIRE_TYPES,
   DEFAULT_QUESTIONNAIRE_TYPE,
 } from "@/features/questionnaires/constants";
+import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
 
 type DimensionAction = { type: "toggle"; dimension: Dimension } | null;
 
@@ -64,15 +65,22 @@ export function useDimensionListPage() {
 
   const deferredSearch = useDeferredValue(searchValue);
 
+  // Fetch questionnaire types to resolve code → UUID
+  const questionnaireTypesQuery = useQuestionnaireTypes();
+  const typeSummaries = questionnaireTypesQuery.data ?? [];
+  const typeFilterId = typeSummaries.find((s) => s.code === typeFilter)?.id ?? null;
+
   // Fetch all dimensions for the questionnaire type so search works across all items
   const queryParams: ListDimensionsRequest = {
     limit: 100,
-    questionnaireType: typeFilter,
+    ...(typeFilterId && { questionnaireTypeId: typeFilterId }),
     ...(statusFilter === "ACTIVE" && { active: true }),
     ...(statusFilter === "INACTIVE" && { active: false }),
   };
 
-  const dimensionListQuery = useDimensionList(queryParams);
+  const dimensionListQuery = useDimensionList(queryParams, {
+    enabled: questionnaireTypesQuery.isSuccess && typeFilterId !== null,
+  });
   const toggleStatusMutation = useToggleDimensionStatus();
 
   const allRows = dimensionListQuery.data?.data ?? [];
@@ -201,8 +209,9 @@ export function useDimensionListPage() {
     pageSize,
     rows: filteredRows,
     meta,
-    isLoading: dimensionListQuery.isLoading,
-    isError: dimensionListQuery.isError,
+    typeSummaries,
+    isLoading: questionnaireTypesQuery.isLoading || dimensionListQuery.isLoading,
+    isError: questionnaireTypesQuery.isError || dimensionListQuery.isError,
     createOpen,
     editDimension,
     dimensionAction,
@@ -218,6 +227,7 @@ export function useDimensionListPage() {
     onPageSizeChange: handlePageSizeChange,
     onConfirmToggle: handleConfirmToggle,
     onRetry: () => {
+      void questionnaireTypesQuery.refetch();
       void dimensionListQuery.refetch();
     },
   };

--- a/features/dimensions/hooks/use-dimension-list-page.ts
+++ b/features/dimensions/hooks/use-dimension-list-page.ts
@@ -15,6 +15,7 @@ import {
   QUESTIONNAIRE_TYPES,
   DEFAULT_QUESTIONNAIRE_TYPE,
 } from "@/features/questionnaires/constants";
+import { useQuestionnaireTypeId } from "@/features/questionnaires/hooks/use-questionnaire-type-id";
 import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
 
 type DimensionAction = { type: "toggle"; dimension: Dimension } | null;
@@ -82,7 +83,7 @@ export function useDimensionListPage() {
   // Fetch questionnaire types to resolve code → UUID
   const questionnaireTypesQuery = useQuestionnaireTypes();
   const typeSummaries = questionnaireTypesQuery.data ?? [];
-  const typeFilterId = typeSummaries.find((s) => s.code === typeFilter)?.id ?? null;
+  const typeFilterId = useQuestionnaireTypeId(typeFilter);
 
   // Fetch all dimensions for the questionnaire type so search works across all items
   const queryParams: ListDimensionsRequest = {

--- a/features/dimensions/hooks/use-dimension-list-page.ts
+++ b/features/dimensions/hooks/use-dimension-list-page.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useDeferredValue, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
@@ -59,11 +59,25 @@ export function useDimensionListPage() {
 
   const typeFilter = resolveTypeFilter(searchParams.get("type"));
   const statusFilter = resolveStatusFilter(searchParams.get("status"));
-  const searchValue = searchParams.get("search") ?? "";
   const page = resolvePositiveNumber(searchParams.get("page"), 1);
   const pageSize = resolvePageSize(searchParams.get("pageSize"));
 
-  const deferredSearch = useDeferredValue(searchValue);
+  // Local search state — only syncs to URL after debounce
+  const urlSearch = searchParams.get("search") ?? "";
+  const [searchValue, setSearchValue] = useState(urlSearch);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync local state when URL changes externally (e.g. "Clear filters")
+  useEffect(() => {
+    setSearchValue(urlSearch);
+  }, [urlSearch]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    };
+  }, []);
 
   // Fetch questionnaire types to resolve code → UUID
   const questionnaireTypesQuery = useQuestionnaireTypes();
@@ -92,7 +106,7 @@ export function useDimensionListPage() {
         ? allRows.filter((row) => !row.active)
         : allRows;
 
-  const normalizedSearch = deferredSearch.trim().toLowerCase();
+  const normalizedSearch = searchValue.trim().toLowerCase();
   const searchFilteredRows =
     normalizedSearch.length > 0
       ? statusFilteredRows.filter(
@@ -147,12 +161,24 @@ export function useDimensionListPage() {
     });
   };
 
-  const handleSearchChange = (value: string) => {
-    updateSearchParams({
-      search: value.trim().length > 0 ? value : null,
-      page: "1",
-    });
-  };
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchValue(value);
+
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+
+      searchTimerRef.current = setTimeout(() => {
+        updateSearchParams({
+          search: value.trim().length > 0 ? value : null,
+          page: "1",
+        });
+      }, 300);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [pathname, searchParams]
+  );
 
   const handlePageChange = (nextPage: number) => {
     updateSearchParams({

--- a/features/dimensions/hooks/use-dimension-list.ts
+++ b/features/dimensions/hooks/use-dimension-list.ts
@@ -6,12 +6,20 @@ import { fetchDimensions } from "@/features/dimensions/api/dimension.requests";
 import type { ListDimensionsRequest } from "@/features/dimensions/types";
 import { useAuthStore } from "@/stores/auth-store";
 
-export function useDimensionList(filters: ListDimensionsRequest) {
+type UseDimensionListOptions = {
+  enabled?: boolean;
+};
+
+export function useDimensionList(
+  filters: ListDimensionsRequest,
+  options?: UseDimensionListOptions
+) {
   const token = useAuthStore((state) => state.token);
+  const isEnabled = options?.enabled ?? true;
 
   return useQuery({
     queryKey: ["dimensions", "list", filters, token],
-    enabled: Boolean(token),
+    enabled: Boolean(token) && isEnabled,
     placeholderData: keepPreviousData,
     queryFn: () => fetchDimensions(filters),
   });

--- a/features/dimensions/hooks/use-dimensions.ts
+++ b/features/dimensions/hooks/use-dimensions.ts
@@ -3,30 +3,26 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchDimensions } from "@/features/dimensions/api/dimension.requests";
-import type { QuestionnaireType } from "@/features/questionnaires/types";
 import { useAuthStore } from "@/stores/auth-store";
 
 type UseDimensionsOptions = {
   enabled?: boolean;
 };
 
-export function useDimensions(
-  questionnaireType: QuestionnaireType | null,
-  options?: UseDimensionsOptions
-) {
+export function useDimensions(questionnaireTypeId: string | null, options?: UseDimensionsOptions) {
   const token = useAuthStore((state) => state.token);
   const isEnabled = options?.enabled ?? true;
 
   return useQuery({
-    queryKey: ["dimensions", questionnaireType, "active", token],
-    enabled: Boolean(token) && Boolean(questionnaireType) && isEnabled,
+    queryKey: ["dimensions", questionnaireTypeId, "active", token],
+    enabled: Boolean(token) && Boolean(questionnaireTypeId) && isEnabled,
     queryFn: async () => {
-      if (!questionnaireType) {
-        throw new Error("Questionnaire type is required.");
+      if (!questionnaireTypeId) {
+        throw new Error("Questionnaire type ID is required.");
       }
 
       return fetchDimensions({
-        questionnaireType,
+        questionnaireTypeId,
         active: true,
         limit: 100,
       });

--- a/features/dimensions/schemas/dimension.schemas.ts
+++ b/features/dimensions/schemas/dimension.schemas.ts
@@ -1,15 +1,11 @@
 import { z } from "zod";
 
-import { QUESTIONNAIRE_TYPES } from "@/features/questionnaires/constants";
-
 export const createDimensionSchema = z.object({
   displayName: z
     .string()
     .min(1, "Display name is required.")
     .max(255, "Display name must be at most 255 characters."),
-  questionnaireType: z.enum(QUESTIONNAIRE_TYPES, {
-    message: "Questionnaire type is required.",
-  }),
+  questionnaireTypeId: z.string().min(1, "Questionnaire type is required."),
   code: z
     .string()
     .regex(

--- a/features/dimensions/types/index.ts
+++ b/features/dimensions/types/index.ts
@@ -1,10 +1,10 @@
-import type { QuestionnaireType } from "@/features/questionnaires/types";
+import type { QuestionnaireTypeEntity } from "@/features/questionnaires/types";
 
 export type Dimension = {
   id: string;
   code: string;
   displayName: string;
-  questionnaireType: QuestionnaireType;
+  questionnaireType: QuestionnaireTypeEntity;
   active: boolean;
   createdAt: string;
   updatedAt: string;
@@ -24,7 +24,7 @@ export type DimensionsListResponse = {
 };
 
 export type ListDimensionsRequest = {
-  questionnaireType?: QuestionnaireType;
+  questionnaireTypeId?: string;
   active?: boolean;
   page?: number;
   limit?: number;
@@ -32,7 +32,7 @@ export type ListDimensionsRequest = {
 
 export type CreateDimensionRequest = {
   displayName: string;
-  questionnaireType: QuestionnaireType;
+  questionnaireTypeId: string;
   code?: string;
 };
 

--- a/features/questionnaires/api/questionnaire.requests.ts
+++ b/features/questionnaires/api/questionnaire.requests.ts
@@ -75,7 +75,7 @@ export async function createQuestionnaireVersion({
   questionnaireId: string;
   payload: CreateQuestionnaireVersionRequest;
 }) {
-  const response = await apiClient.post<QuestionnaireVersion>(
+  const response = await apiClient.post<QuestionnaireVersionDetail>(
     Endpoints.questionnaireVersions.replace(":id", questionnaireId),
     payload
   );

--- a/features/questionnaires/api/questionnaire.requests.ts
+++ b/features/questionnaires/api/questionnaire.requests.ts
@@ -9,7 +9,6 @@ import type {
   FetchDraftParams,
   Questionnaire,
   QuestionnaireVersionDetail,
-  QuestionnaireType,
   QuestionnaireTypeSummary,
   QuestionnaireVersion,
   QuestionnaireVersionsResponse,
@@ -28,10 +27,11 @@ export async function fetchQuestionnaireTypes() {
 
 /**
  * Fetch questionnaire versions for a specific questionnaire type.
+ * @param typeId - UUID of the questionnaire type entity
  */
-export async function fetchQuestionnaireVersionsByType(type: QuestionnaireType) {
+export async function fetchQuestionnaireVersionsByType(typeId: string) {
   const response = await apiClient.get<QuestionnaireVersionsResponse>(
-    Endpoints.questionnaireTypeVersions.replace(":type", type)
+    Endpoints.questionnaireTypeVersions.replace(":type", typeId)
   );
   return response.data;
 }

--- a/features/questionnaires/components/builder/questionnaire-builder-shell.tsx
+++ b/features/questionnaires/components/builder/questionnaire-builder-shell.tsx
@@ -15,10 +15,10 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { ConfirmationDialog } from "@/components/shared/confirmation-dialog";
 import { Separator } from "@/components/ui/separator";
 import { useQuestionnaireBuilderController } from "@/features/questionnaires/hooks/use-questionnaire-builder-controller";
-import type { QuestionnaireType } from "@/features/questionnaires/types";
+import type { QuestionnaireTypeCode } from "@/features/questionnaires/types";
 
 type QuestionnaireBuilderShellProps = {
-  activeType: QuestionnaireType;
+  activeType: QuestionnaireTypeCode;
   isHydrated: boolean;
 };
 

--- a/features/questionnaires/components/builder/questionnaire-section-editor.tsx
+++ b/features/questionnaires/components/builder/questionnaire-section-editor.tsx
@@ -25,12 +25,12 @@ import type {
   QuestionnaireBuilderQuestionNode,
   QuestionnaireBuilderSectionNode,
   QuestionnaireBuilderSectionUpdates,
-  QuestionnaireType,
+  QuestionnaireTypeCode,
   QuestionnaireBuilderValidationIssue,
 } from "@/features/questionnaires/types";
 
 type QuestionnaireSectionEditorProps = {
-  questionnaireType: QuestionnaireType;
+  questionnaireType: QuestionnaireTypeCode;
   section: QuestionnaireBuilderSectionNode;
   sectionIssues: QuestionnaireBuilderValidationIssue[];
   questionIssues: Record<string, QuestionnaireBuilderValidationIssue[]>;

--- a/features/questionnaires/components/questionnaire-list-toolbar.tsx
+++ b/features/questionnaires/components/questionnaire-list-toolbar.tsx
@@ -8,16 +8,16 @@ import { QuestionnaireTypeButtonGroup } from "@/features/questionnaires/componen
 import { Button } from "@/components/ui/button";
 import type {
   QuestionnaireStatusFilter as StatusFilter,
-  QuestionnaireType,
+  QuestionnaireTypeCode,
 } from "@/features/questionnaires/types";
 
 type QuestionnaireListToolbarProps = {
-  availableTypes: QuestionnaireType[];
-  activeType: QuestionnaireType;
+  availableTypes: QuestionnaireTypeCode[];
+  activeType: QuestionnaireTypeCode;
   statusFilter: StatusFilter;
   searchValue: string;
   hasDraftVersion: boolean;
-  onTypeChange: (nextType: QuestionnaireType) => void;
+  onTypeChange: (nextType: QuestionnaireTypeCode) => void;
   onStatusFilterChange: (value: StatusFilter) => void;
   onSearchChange: (value: string) => void;
 };

--- a/features/questionnaires/components/questionnaire-type-button-group.tsx
+++ b/features/questionnaires/components/questionnaire-type-button-group.tsx
@@ -13,12 +13,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { QUESTIONNAIRE_TYPE_LABELS } from "@/features/questionnaires/constants";
-import type { QuestionnaireType } from "@/features/questionnaires/types";
+import type { QuestionnaireTypeCode } from "@/features/questionnaires/types";
 
 type QuestionnaireTypeButtonGroupProps = {
-  types: QuestionnaireType[];
-  value: QuestionnaireType;
-  onValueChange: (value: QuestionnaireType) => void;
+  types: QuestionnaireTypeCode[];
+  value: QuestionnaireTypeCode;
+  onValueChange: (value: QuestionnaireTypeCode) => void;
   className?: string;
 };
 
@@ -41,7 +41,7 @@ export function QuestionnaireTypeButtonGroup({
           <DropdownMenuContent align="start" className="min-w-56">
             <DropdownMenuRadioGroup
               value={value}
-              onValueChange={(nextValue) => onValueChange(nextValue as QuestionnaireType)}
+              onValueChange={(nextValue) => onValueChange(nextValue as QuestionnaireTypeCode)}
             >
               {types.map((type) => (
                 <DropdownMenuRadioItem key={type} value={type}>

--- a/features/questionnaires/hooks/use-active-questionnaire-version.ts
+++ b/features/questionnaires/hooks/use-active-questionnaire-version.ts
@@ -7,7 +7,6 @@ import {
   fetchQuestionnaireVersionsByType,
 } from "@/features/questionnaires/api/questionnaire.requests";
 import { useAuthStore } from "@/stores/auth-store";
-import type { QuestionnaireType } from "@/features/questionnaires/types";
 
 /**
  * Fetches the full active version detail (with schema) for a questionnaire type.
@@ -17,21 +16,23 @@ import type { QuestionnaireType } from "@/features/questionnaires/types";
  * 2. GET /:id/latest-active-version → get full version with schemaSnapshot
  *
  * This avoids the role-restricted GET /versions/:versionId endpoint.
+ *
+ * @param typeId - UUID of the questionnaire type entity
  */
 export function useActiveQuestionnaireVersion(
-  type: QuestionnaireType | null,
+  typeId: string | null,
   options?: { enabled?: boolean }
 ) {
   const token = useAuthStore((state) => state.token);
   const isEnabled = options?.enabled ?? true;
 
   return useQuery({
-    queryKey: ["questionnaires", "active-version", type, token],
-    enabled: Boolean(token) && Boolean(type) && isEnabled,
+    queryKey: ["questionnaires", "active-version", typeId, token],
+    enabled: Boolean(token) && Boolean(typeId) && isEnabled,
     queryFn: async () => {
-      if (!type) throw new Error("Questionnaire type is required.");
+      if (!typeId) throw new Error("Questionnaire type ID is required.");
 
-      const typeSummary = await fetchQuestionnaireVersionsByType(type);
+      const typeSummary = await fetchQuestionnaireVersionsByType(typeId);
       const questionnaireId = typeSummary.questionnaireId;
 
       if (!questionnaireId) return null;

--- a/features/questionnaires/hooks/use-create-questionnaire-version.ts
+++ b/features/questionnaires/hooks/use-create-questionnaire-version.ts
@@ -10,7 +10,10 @@ export function useCreateQuestionnaireVersion() {
   return useMutation({
     mutationFn: createQuestionnaireVersion,
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["questionnaires"] });
+      void queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "questionnaires" && query.queryKey.includes("versions"),
+      });
     },
   });
 }

--- a/features/questionnaires/hooks/use-create-questionnaire-version.ts
+++ b/features/questionnaires/hooks/use-create-questionnaire-version.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { createQuestionnaireVersion } from "@/features/questionnaires/api/questionnaire.requests";
+import { isVersionQuery } from "@/features/questionnaires/lib/query-keys";
 
 export function useCreateQuestionnaireVersion() {
   const queryClient = useQueryClient();
@@ -10,10 +11,7 @@ export function useCreateQuestionnaireVersion() {
   return useMutation({
     mutationFn: createQuestionnaireVersion,
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        predicate: (query) =>
-          query.queryKey[0] === "questionnaires" && query.queryKey.includes("versions"),
-      });
+      void queryClient.invalidateQueries({ predicate: isVersionQuery });
     },
   });
 }

--- a/features/questionnaires/hooks/use-deprecate-questionnaire-version.ts
+++ b/features/questionnaires/hooks/use-deprecate-questionnaire-version.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { deprecateQuestionnaireVersion } from "@/features/questionnaires/api/questionnaire.requests";
+import { isVersionQuery } from "@/features/questionnaires/lib/query-keys";
 
 export function useDeprecateQuestionnaireVersion() {
   const queryClient = useQueryClient();
@@ -10,11 +11,7 @@ export function useDeprecateQuestionnaireVersion() {
   return useMutation({
     mutationFn: deprecateQuestionnaireVersion,
     onSuccess: () => {
-      // Invalidate version details + version lists, but not the types query
-      void queryClient.invalidateQueries({
-        predicate: (query) =>
-          query.queryKey[0] === "questionnaires" && query.queryKey.includes("versions"),
-      });
+      void queryClient.invalidateQueries({ predicate: isVersionQuery });
     },
   });
 }

--- a/features/questionnaires/hooks/use-deprecate-questionnaire-version.ts
+++ b/features/questionnaires/hooks/use-deprecate-questionnaire-version.ts
@@ -10,7 +10,11 @@ export function useDeprecateQuestionnaireVersion() {
   return useMutation({
     mutationFn: deprecateQuestionnaireVersion,
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["questionnaires"] });
+      // Invalidate version details + version lists, but not the types query
+      void queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "questionnaires" && query.queryKey.includes("versions"),
+      });
     },
   });
 }

--- a/features/questionnaires/hooks/use-evaluation-data.ts
+++ b/features/questionnaires/hooks/use-evaluation-data.ts
@@ -20,7 +20,7 @@ import { decodeHtmlEntities } from "@/lib/string";
 import { useSelectedCourseStore } from "@/stores/selected-course-store";
 
 import { useActiveQuestionnaireVersion } from "./use-active-questionnaire-version";
-import { useQuestionnaireTypes } from "./use-questionnaire-types";
+import { useQuestionnaireTypeId } from "./use-questionnaire-type-id";
 import { useCheckSubmission } from "./use-check-submission";
 import { useEvaluationDraft } from "./use-evaluation-draft";
 
@@ -89,8 +89,7 @@ export function useEvaluationData(courseId: string): EvaluationDataResult {
   const semester = enrollment?.semester;
 
   // --- Step 2: Fetch active version ---
-  const typesQuery = useQuestionnaireTypes();
-  const feedbackTypeId = typesQuery.data?.find((t) => t.code === "FACULTY_FEEDBACK")?.id ?? null;
+  const feedbackTypeId = useQuestionnaireTypeId("FACULTY_FEEDBACK");
 
   const activeVersionQuery = useActiveQuestionnaireVersion(feedbackTypeId, {
     enabled:

--- a/features/questionnaires/hooks/use-evaluation-data.ts
+++ b/features/questionnaires/hooks/use-evaluation-data.ts
@@ -20,6 +20,7 @@ import { decodeHtmlEntities } from "@/lib/string";
 import { useSelectedCourseStore } from "@/stores/selected-course-store";
 
 import { useActiveQuestionnaireVersion } from "./use-active-questionnaire-version";
+import { useQuestionnaireTypes } from "./use-questionnaire-types";
 import { useCheckSubmission } from "./use-check-submission";
 import { useEvaluationDraft } from "./use-evaluation-draft";
 
@@ -88,8 +89,12 @@ export function useEvaluationData(courseId: string): EvaluationDataResult {
   const semester = enrollment?.semester;
 
   // --- Step 2: Fetch active version ---
-  const activeVersionQuery = useActiveQuestionnaireVersion("FACULTY_FEEDBACK", {
-    enabled: Boolean(enrollment) && Boolean(faculty) && Boolean(semester),
+  const typesQuery = useQuestionnaireTypes();
+  const feedbackTypeId = typesQuery.data?.find((t) => t.code === "FACULTY_FEEDBACK")?.id ?? null;
+
+  const activeVersionQuery = useActiveQuestionnaireVersion(feedbackTypeId, {
+    enabled:
+      Boolean(enrollment) && Boolean(faculty) && Boolean(semester) && feedbackTypeId !== null,
   });
   const activeVersion = activeVersionQuery.data;
 

--- a/features/questionnaires/hooks/use-publish-questionnaire-version.ts
+++ b/features/questionnaires/hooks/use-publish-questionnaire-version.ts
@@ -10,7 +10,10 @@ export function usePublishQuestionnaireVersion() {
   return useMutation({
     mutationFn: publishQuestionnaireVersion,
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["questionnaires"] });
+      void queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "questionnaires" && query.queryKey.includes("versions"),
+      });
     },
   });
 }

--- a/features/questionnaires/hooks/use-publish-questionnaire-version.ts
+++ b/features/questionnaires/hooks/use-publish-questionnaire-version.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { publishQuestionnaireVersion } from "@/features/questionnaires/api/questionnaire.requests";
+import { isVersionQuery } from "@/features/questionnaires/lib/query-keys";
 
 export function usePublishQuestionnaireVersion() {
   const queryClient = useQueryClient();
@@ -10,10 +11,7 @@ export function usePublishQuestionnaireVersion() {
   return useMutation({
     mutationFn: publishQuestionnaireVersion,
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        predicate: (query) =>
-          query.queryKey[0] === "questionnaires" && query.queryKey.includes("versions"),
-      });
+      void queryClient.invalidateQueries({ predicate: isVersionQuery });
     },
   });
 }

--- a/features/questionnaires/hooks/use-questionnaire-builder-controller.ts
+++ b/features/questionnaires/hooks/use-questionnaire-builder-controller.ts
@@ -13,10 +13,10 @@ import {
   validateQuestionnaireBuilderDraft,
 } from "@/features/questionnaires/lib/builder-validator";
 import { useQuestionnaireBuilderStore } from "@/features/questionnaires/store/questionnaire-builder-store";
-import type { QuestionnaireType } from "@/features/questionnaires/types";
+import type { QuestionnaireTypeCode } from "@/features/questionnaires/types";
 
 type UseQuestionnaireBuilderControllerOptions = {
-  activeType: QuestionnaireType;
+  activeType: QuestionnaireTypeCode;
 };
 
 export function useQuestionnaireBuilderController({

--- a/features/questionnaires/hooks/use-questionnaire-list-page.ts
+++ b/features/questionnaires/hooks/use-questionnaire-list-page.ts
@@ -13,8 +13,8 @@ import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-quest
 import { useQuestionnaireVersions } from "@/features/questionnaires/hooks/use-questionnaire-versions";
 import {
   resolveQuestionnaireType,
+  type QuestionnaireTypeCode,
   type QuestionnaireVersionItem,
-  type QuestionnaireType,
   type VersionLifecycleAction,
 } from "@/features/questionnaires/types";
 
@@ -28,16 +28,20 @@ export function useQuestionnaireListPage() {
   const publishVersionMutation = usePublishQuestionnaireVersion();
   const deprecateVersionMutation = useDeprecateQuestionnaireVersion();
   const typeSummaries = questionnaireTypesQuery.data ?? [];
-  const fetchedTypes = typeSummaries.map((summary) => summary.type);
+  const fetchedCodes = typeSummaries.map((summary) => summary.code);
   const availableTypes =
-    fetchedTypes.length > 0
-      ? QUESTIONNAIRE_TYPES.filter((type) => fetchedTypes.includes(type))
+    fetchedCodes.length > 0
+      ? QUESTIONNAIRE_TYPES.filter((type) => fetchedCodes.includes(type))
       : [...QUESTIONNAIRE_TYPES];
   const activeType = availableTypes.includes(selectedType)
     ? selectedType
     : (availableTypes[0] ?? DEFAULT_QUESTIONNAIRE_TYPE);
-  const questionnaireVersionsQuery = useQuestionnaireVersions(activeType, {
-    enabled: questionnaireTypesQuery.isSuccess,
+
+  // Resolve code → UUID for the API call
+  const activeTypeId = typeSummaries.find((s) => s.code === activeType)?.id ?? null;
+
+  const questionnaireVersionsQuery = useQuestionnaireVersions(activeTypeId, {
+    enabled: questionnaireTypesQuery.isSuccess && activeTypeId !== null,
   });
 
   useEffect(() => {
@@ -61,7 +65,7 @@ export function useQuestionnaireListPage() {
     );
   }, [router, searchParams]);
 
-  const handleTypeChange = (nextType: QuestionnaireType) => {
+  const handleTypeChange = (nextType: QuestionnaireTypeCode) => {
     router.replace(`/superadmin/questionnaires?type=${nextType}`);
   };
 
@@ -103,7 +107,7 @@ export function useQuestionnaireListPage() {
     }
   };
 
-  const selectedSummary = typeSummaries.find((summary) => summary.type === activeType);
+  const selectedSummary = typeSummaries.find((summary) => summary.code === activeType);
   const versionRows = questionnaireVersionsQuery.data?.versions ?? [];
   const actionDialogConfig =
     versionAction?.type === "publish"

--- a/features/questionnaires/hooks/use-questionnaire-page-state.ts
+++ b/features/questionnaires/hooks/use-questionnaire-page-state.ts
@@ -31,23 +31,28 @@ export function useQuestionnairePageState() {
   const resetActiveDraft = useQuestionnaireBuilderStore((state) => state.resetActiveDraft);
 
   const typeSummaries = questionnaireTypesQuery.data ?? [];
-  const fetchedTypes = typeSummaries.map((summary) => summary.type);
+  const fetchedCodes = typeSummaries.map((summary) => summary.code);
   const availableTypes =
-    fetchedTypes.length > 0
-      ? QUESTIONNAIRE_TYPES.filter((type) => fetchedTypes.includes(type))
+    fetchedCodes.length > 0
+      ? QUESTIONNAIRE_TYPES.filter((type) => fetchedCodes.includes(type))
       : [...QUESTIONNAIRE_TYPES];
   const requestedTypeUnavailable =
     questionnaireTypesQuery.isSuccess &&
-    fetchedTypes.length > 0 &&
-    !fetchedTypes.includes(requestedType);
+    fetchedCodes.length > 0 &&
+    !fetchedCodes.includes(requestedType);
   const activePageType = availableTypes.includes(requestedType)
     ? requestedType
     : (availableTypes[0] ?? DEFAULT_QUESTIONNAIRE_TYPE);
   const currentDraft = useQuestionnaireBuilderStore(
     (state) => state.drafts[activePageType] ?? null
   );
-  const questionnaireVersionsQuery = useQuestionnaireVersions(requestedType, {
-    enabled: questionnaireTypesQuery.isSuccess && !requestedTypeUnavailable,
+
+  // Resolve code → UUID for the API call
+  const requestedTypeId = typeSummaries.find((s) => s.code === requestedType)?.id ?? null;
+
+  const questionnaireVersionsQuery = useQuestionnaireVersions(requestedTypeId, {
+    enabled:
+      questionnaireTypesQuery.isSuccess && !requestedTypeUnavailable && requestedTypeId !== null,
   });
   const defaultDraftVersionId =
     questionnaireVersionsQuery.data?.versions.find((version) => version.status === "DRAFT")?.id ??
@@ -81,8 +86,9 @@ export function useQuestionnairePageState() {
     }
 
     const { questionnaireId, questionnaireTitle, type, versions } = questionnaireVersionsQuery.data;
+    const typeCode = type.code;
     loadDraftFromServer({
-      type,
+      type: typeCode,
       versions,
       draftVersion,
       ...(questionnaireId !== null

--- a/features/questionnaires/hooks/use-questionnaire-type-id.ts
+++ b/features/questionnaires/hooks/use-questionnaire-type-id.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import type { QuestionnaireTypeCode } from "@/features/questionnaires/types";
+
+/**
+ * Resolve a questionnaire type code to its UUID via the cached types query.
+ * Returns `null` while types are loading or if the code is not found.
+ */
+export function useQuestionnaireTypeId(code: QuestionnaireTypeCode | null) {
+  const typesQuery = useQuestionnaireTypes();
+  if (!code) return null;
+  return typesQuery.data?.find((t) => t.code === code)?.id ?? null;
+}

--- a/features/questionnaires/hooks/use-questionnaire-versions.ts
+++ b/features/questionnaires/hooks/use-questionnaire-versions.ts
@@ -7,28 +7,27 @@ import {
   fetchQuestionnaireVersionsByType,
 } from "@/features/questionnaires/api/questionnaire.requests";
 import { useAuthStore } from "@/stores/auth-store";
-import type { QuestionnaireType } from "@/features/questionnaires/types";
 
 type UseQuestionnaireVersionsOptions = {
   enabled?: boolean;
 };
 
 export function useQuestionnaireVersions(
-  type: QuestionnaireType | null,
+  typeId: string | null,
   options?: UseQuestionnaireVersionsOptions
 ) {
   const token = useAuthStore((state) => state.token);
   const isEnabled = options?.enabled ?? true;
 
   return useQuery({
-    queryKey: ["questionnaires", "types", type, "versions", token],
-    enabled: Boolean(token) && Boolean(type) && isEnabled,
+    queryKey: ["questionnaires", "types", typeId, "versions", token],
+    enabled: Boolean(token) && Boolean(typeId) && isEnabled,
     queryFn: async () => {
-      if (!type) {
-        throw new Error("Questionnaire type is required.");
+      if (!typeId) {
+        throw new Error("Questionnaire type ID is required.");
       }
 
-      return fetchQuestionnaireVersionsByType(type);
+      return fetchQuestionnaireVersionsByType(typeId);
     },
   });
 }

--- a/features/questionnaires/hooks/use-save-questionnaire-builder.ts
+++ b/features/questionnaires/hooks/use-save-questionnaire-builder.ts
@@ -1,17 +1,20 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 import { toast } from "sonner";
 
-import { fetchQuestionnaireVersionById } from "@/features/questionnaires/api/questionnaire.requests";
 import { useCreateQuestionnaire } from "@/features/questionnaires/hooks/use-create-questionnaire";
 import { useCreateQuestionnaireVersion } from "@/features/questionnaires/hooks/use-create-questionnaire-version";
 import { serializeQuestionnaireBuilderDraft } from "@/features/questionnaires/lib/builder-serializer";
 import { useUpdateQuestionnaireVersion } from "@/features/questionnaires/hooks/use-update-questionnaire-version";
 import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
 import { useQuestionnaireBuilderStore } from "@/features/questionnaires/store/questionnaire-builder-store";
+import { useAuthStore } from "@/stores/auth-store";
 
 export function useSaveQuestionnaireBuilder() {
+  const queryClient = useQueryClient();
+  const token = useAuthStore((state) => state.token);
   const createQuestionnaireMutation = useCreateQuestionnaire();
   const typesQuery = useQuestionnaireTypes();
   const createQuestionnaireVersionMutation = useCreateQuestionnaireVersion();
@@ -41,7 +44,6 @@ export function useSaveQuestionnaireBuilder() {
 
     try {
       let questionnaireId = draft.metadata.questionnaireId;
-      let savedVersionId = draft.metadata.versionId;
 
       if (!questionnaireId) {
         const typeId = typesQuery.data?.find((t) => t.code === draft.metadata.type)?.id;
@@ -58,32 +60,35 @@ export function useSaveQuestionnaireBuilder() {
         setQuestionnaireRootMetadata(createdQuestionnaire.id, createdQuestionnaire.title);
       }
 
+      let savedVersion: import("@/features/questionnaires/types").QuestionnaireVersionDetail;
+
       if (draft.metadata.versionId) {
         const shouldSendTitle =
           draft.metadata.questionnaireTitle === null ||
           trimmedTitle !== draft.metadata.questionnaireTitle.trim();
-        const updatedVersion = await updateQuestionnaireVersionMutation.mutateAsync({
+        savedVersion = await updateQuestionnaireVersionMutation.mutateAsync({
           versionId: draft.metadata.versionId,
           payload: {
             schema: payload,
             ...(shouldSendTitle ? { title: trimmedTitle } : {}),
           },
         });
-        savedVersionId = updatedVersion.id;
       } else {
-        const createdVersion = await createQuestionnaireVersionMutation.mutateAsync({
+        savedVersion = await createQuestionnaireVersionMutation.mutateAsync({
           questionnaireId,
           payload: {
             schema: payload,
           },
         });
-        savedVersionId = createdVersion.id;
       }
 
-      if (savedVersionId) {
-        const savedVersion = await fetchQuestionnaireVersionById(savedVersionId);
-        syncDraftVersion(savedVersion);
-      }
+      // Sync the builder store and seed the query cache with the response
+      // so the page-state hook doesn't re-fetch the same version.
+      syncDraftVersion(savedVersion);
+      queryClient.setQueryData(
+        ["questionnaires", "versions", savedVersion.id, token],
+        savedVersion
+      );
 
       toast.success("Questionnaire draft saved.");
       return { status: "saved" as const, type: draft.metadata.type };

--- a/features/questionnaires/hooks/use-save-questionnaire-builder.ts
+++ b/features/questionnaires/hooks/use-save-questionnaire-builder.ts
@@ -9,6 +9,7 @@ import { useCreateQuestionnaireVersion } from "@/features/questionnaires/hooks/u
 import { serializeQuestionnaireBuilderDraft } from "@/features/questionnaires/lib/builder-serializer";
 import { useUpdateQuestionnaireVersion } from "@/features/questionnaires/hooks/use-update-questionnaire-version";
 import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import type { QuestionnaireVersionDetail } from "@/features/questionnaires/types";
 import { useQuestionnaireBuilderStore } from "@/features/questionnaires/store/questionnaire-builder-store";
 import { useAuthStore } from "@/stores/auth-store";
 
@@ -60,7 +61,7 @@ export function useSaveQuestionnaireBuilder() {
         setQuestionnaireRootMetadata(createdQuestionnaire.id, createdQuestionnaire.title);
       }
 
-      let savedVersion: import("@/features/questionnaires/types").QuestionnaireVersionDetail;
+      let savedVersion: QuestionnaireVersionDetail;
 
       if (draft.metadata.versionId) {
         const shouldSendTitle =

--- a/features/questionnaires/hooks/use-save-questionnaire-builder.ts
+++ b/features/questionnaires/hooks/use-save-questionnaire-builder.ts
@@ -8,10 +8,12 @@ import { useCreateQuestionnaire } from "@/features/questionnaires/hooks/use-crea
 import { useCreateQuestionnaireVersion } from "@/features/questionnaires/hooks/use-create-questionnaire-version";
 import { serializeQuestionnaireBuilderDraft } from "@/features/questionnaires/lib/builder-serializer";
 import { useUpdateQuestionnaireVersion } from "@/features/questionnaires/hooks/use-update-questionnaire-version";
+import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
 import { useQuestionnaireBuilderStore } from "@/features/questionnaires/store/questionnaire-builder-store";
 
 export function useSaveQuestionnaireBuilder() {
   const createQuestionnaireMutation = useCreateQuestionnaire();
+  const typesQuery = useQuestionnaireTypes();
   const createQuestionnaireVersionMutation = useCreateQuestionnaireVersion();
   const updateQuestionnaireVersionMutation = useUpdateQuestionnaireVersion();
   const setQuestionnaireRootMetadata = useQuestionnaireBuilderStore(
@@ -42,9 +44,15 @@ export function useSaveQuestionnaireBuilder() {
       let savedVersionId = draft.metadata.versionId;
 
       if (!questionnaireId) {
+        const typeId = typesQuery.data?.find((t) => t.code === draft.metadata.type)?.id;
+        if (!typeId) {
+          toast.error("Unable to resolve questionnaire type. Please reload and try again.");
+          return;
+        }
+
         const createdQuestionnaire = await createQuestionnaireMutation.mutateAsync({
           title: trimmedTitle,
-          type: draft.metadata.type,
+          typeId,
         });
         questionnaireId = createdQuestionnaire.id;
         setQuestionnaireRootMetadata(createdQuestionnaire.id, createdQuestionnaire.title);

--- a/features/questionnaires/hooks/use-update-questionnaire-version.ts
+++ b/features/questionnaires/hooks/use-update-questionnaire-version.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { updateQuestionnaireVersion } from "@/features/questionnaires/api/questionnaire.requests";
+import { isVersionQuery } from "@/features/questionnaires/lib/query-keys";
 
 export function useUpdateQuestionnaireVersion() {
   const queryClient = useQueryClient();
@@ -10,10 +11,7 @@ export function useUpdateQuestionnaireVersion() {
   return useMutation({
     mutationFn: updateQuestionnaireVersion,
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        predicate: (query) =>
-          query.queryKey[0] === "questionnaires" && query.queryKey.includes("versions"),
-      });
+      void queryClient.invalidateQueries({ predicate: isVersionQuery });
     },
   });
 }

--- a/features/questionnaires/hooks/use-update-questionnaire-version.ts
+++ b/features/questionnaires/hooks/use-update-questionnaire-version.ts
@@ -10,7 +10,10 @@ export function useUpdateQuestionnaireVersion() {
   return useMutation({
     mutationFn: updateQuestionnaireVersion,
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["questionnaires"] });
+      void queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "questionnaires" && query.queryKey.includes("versions"),
+      });
     },
   });
 }

--- a/features/questionnaires/lib/builder-deserializer.ts
+++ b/features/questionnaires/lib/builder-deserializer.ts
@@ -157,7 +157,7 @@ export function deserializeQuestionnaireVersionToDraft(
 
   return {
     metadata: {
-      type: version.questionnaireType,
+      type: version.questionnaireType.code,
       title: version.questionnaireTitle,
       questionnaireId: version.questionnaireId,
       versionId: version.id,

--- a/features/questionnaires/lib/builder-factory.ts
+++ b/features/questionnaires/lib/builder-factory.ts
@@ -8,7 +8,7 @@ import type {
   QuestionnaireBuilderQualitativeConfig,
   QuestionnaireBuilderQuestionNode,
   QuestionnaireBuilderSectionNode,
-  QuestionnaireType,
+  QuestionnaireTypeCode,
 } from "@/features/questionnaires/types";
 
 export function createId(prefix: string) {
@@ -98,7 +98,7 @@ export function normalizeSections(
 }
 
 export function createDraft(
-  type: QuestionnaireType,
+  type: QuestionnaireTypeCode,
   overrides?: Partial<QuestionnaireBuilderDraft>
 ): QuestionnaireBuilderDraft {
   return {
@@ -120,7 +120,7 @@ export function createDraft(
 
 export function createSyncedDraftSnapshot(
   draft: QuestionnaireBuilderDraft,
-  type: QuestionnaireType = draft.metadata.type
+  type: QuestionnaireTypeCode = draft.metadata.type
 ): QuestionnaireBuilderDraft {
   return createDraft(type, {
     metadata: {

--- a/features/questionnaires/lib/builder-serializer.ts
+++ b/features/questionnaires/lib/builder-serializer.ts
@@ -6,13 +6,13 @@ import type {
   QuestionnaireBuilderPreviewSection,
   QuestionnaireBuilderQuestionNode,
   QuestionnaireBuilderSectionNode,
-  QuestionnaireType,
+  QuestionnaireTypeCode,
   QuestionnaireSchemaQuestion,
   QuestionnaireSchemaSectionTreeNode,
   QuestionnaireVersionSchema,
 } from "@/features/questionnaires/types";
 
-function getQuestionnaireTypeCode(type: QuestionnaireType): string {
+function getQuestionnaireTypeCode(type: QuestionnaireTypeCode): string {
   switch (type) {
     case "FACULTY_IN_CLASSROOM":
       return "ic";

--- a/features/questionnaires/lib/query-keys.ts
+++ b/features/questionnaires/lib/query-keys.ts
@@ -1,0 +1,10 @@
+import type { Query } from "@tanstack/react-query";
+
+/**
+ * Predicate that matches all questionnaire version-related queries
+ * (version details + type-specific version lists) without matching
+ * the questionnaire types query.
+ */
+export function isVersionQuery(query: Query): boolean {
+  return query.queryKey[0] === "questionnaires" && query.queryKey.includes("versions");
+}

--- a/features/questionnaires/store/questionnaire-builder-store.ts
+++ b/features/questionnaires/store/questionnaire-builder-store.ts
@@ -29,19 +29,19 @@ import type {
   QuestionnaireBuilderSectionNode,
   QuestionnaireBuilderSectionUpdates,
   QuestionnaireBuilderServerContext,
-  QuestionnaireType,
+  QuestionnaireTypeCode,
   QuestionnaireVersionDetail,
 } from "@/features/questionnaires/types";
 
 type QuestionnaireBuilderStore = {
   hydrated: boolean;
-  activeType: QuestionnaireType | null;
-  drafts: Partial<Record<QuestionnaireType, QuestionnaireBuilderDraft>>;
-  syncedDrafts: Partial<Record<QuestionnaireType, QuestionnaireBuilderDraft>>;
+  activeType: QuestionnaireTypeCode | null;
+  drafts: Partial<Record<QuestionnaireTypeCode, QuestionnaireBuilderDraft>>;
+  syncedDrafts: Partial<Record<QuestionnaireTypeCode, QuestionnaireBuilderDraft>>;
   setHydrated: (hydrated: boolean) => void;
   loadDraftFromServer: (context: QuestionnaireBuilderServerContext) => void;
   syncDraftVersion: (version: QuestionnaireVersionDetail) => void;
-  setActiveType: (type: QuestionnaireType | null) => void;
+  setActiveType: (type: QuestionnaireTypeCode | null) => void;
   setQuestionnaireRootMetadata: (questionnaireId: string, title: string) => void;
   updateTitle: (title: string) => void;
   selectSection: (sectionId: string | null) => void;
@@ -59,7 +59,7 @@ type QuestionnaireBuilderStore = {
   removeQuestion: (sectionId: string, questionId: string) => void;
   updateQualitative: (updates: Partial<QuestionnaireBuilderQualitativeConfig>) => void;
   resetActiveDraft: () => void;
-  clearDraftForType: (type: QuestionnaireType) => void;
+  clearDraftForType: (type: QuestionnaireTypeCode) => void;
   hasUnsavedChanges: () => boolean;
 };
 
@@ -198,19 +198,20 @@ export const useQuestionnaireBuilderStore = create<QuestionnaireBuilderStore>()(
         ),
       syncDraftVersion: (version) =>
         set((state) => {
+          const typeCode = version.questionnaireType.code;
           const syncedDraft = createSyncedDraftSnapshot(
-            createDraft(version.questionnaireType, deserializeQuestionnaireVersionToDraft(version))
+            createDraft(typeCode, deserializeQuestionnaireVersionToDraft(version))
           );
 
           return {
-            activeType: version.questionnaireType,
+            activeType: typeCode,
             drafts: {
               ...state.drafts,
-              [version.questionnaireType]: syncedDraft,
+              [typeCode]: syncedDraft,
             },
             syncedDrafts: {
               ...state.syncedDrafts,
-              [version.questionnaireType]: syncedDraft,
+              [typeCode]: syncedDraft,
             },
           };
         }),

--- a/features/questionnaires/store/questionnaire-builder-store.ts
+++ b/features/questionnaires/store/questionnaire-builder-store.ts
@@ -249,11 +249,24 @@ export const useQuestionnaireBuilderStore = create<QuestionnaireBuilderStore>()(
             hasPersistedUnsavedChanges &&
             (!context.draftVersion || draftsMatch(nextDraft, persistedSyncedDraft ?? null));
 
+          // Always update server-owned metadata so stale localStorage IDs
+          // (e.g. after a backend migration:fresh) don't cause 404s.
+          const resolvedDraft = shouldKeepPersistedDraft
+            ? {
+                ...persistedDraft,
+                metadata: {
+                  ...persistedDraft.metadata,
+                  questionnaireId: context.questionnaireId,
+                  questionnaireTitle: context.questionnaireTitle,
+                },
+              }
+            : nextDraft;
+
           return {
             activeType: context.type,
             drafts: {
               ...state.drafts,
-              [context.type]: shouldKeepPersistedDraft ? persistedDraft : nextDraft,
+              [context.type]: resolvedDraft,
             },
             syncedDrafts: nextSyncedDrafts,
           };

--- a/features/questionnaires/types/builder.ts
+++ b/features/questionnaires/types/builder.ts
@@ -5,7 +5,7 @@ import {
   MAX_SECTION_NESTING_LEVEL,
 } from "@/features/questionnaires/constants/builder";
 import type {
-  QuestionnaireType,
+  QuestionnaireTypeCode,
   QuestionnaireVersionDetail,
   QuestionnaireVersionItem,
 } from "@/features/questionnaires/types";
@@ -43,7 +43,7 @@ export type QuestionnaireBuilderQualitativeConfig = {
 };
 
 export type QuestionnaireBuilderMetadata = {
-  type: QuestionnaireType;
+  type: QuestionnaireTypeCode;
   title: string;
   questionnaireId: string | null;
   versionId: string | null;
@@ -60,7 +60,7 @@ export type QuestionnaireBuilderDraft = {
 };
 
 export type QuestionnaireBuilderServerContext = {
-  type: QuestionnaireType;
+  type: QuestionnaireTypeCode;
   versions: QuestionnaireVersionItem[];
   draftVersion: QuestionnaireVersionDetail | null;
 } & (
@@ -89,7 +89,7 @@ export type QuestionnaireBuilderPreviewSection = {
 
 export type QuestionnaireBuilderPreviewModel = {
   title: string;
-  type: QuestionnaireType;
+  type: QuestionnaireTypeCode;
   sections: QuestionnaireBuilderPreviewSection[];
   qualitative: QuestionnaireBuilderQualitativeConfig;
 };
@@ -131,7 +131,7 @@ export type QuestionnaireVersionSchema = {
     version: 1;
     maxScore: 5;
     scoringModel: "SECTION_WEIGHTED";
-    questionnaireType: QuestionnaireType;
+    questionnaireType: QuestionnaireTypeCode;
   };
   sectionTree?: QuestionnaireSchemaSectionTreeNode[];
   sections: QuestionnaireSchemaLeafSection[];

--- a/features/questionnaires/types/index.ts
+++ b/features/questionnaires/types/index.ts
@@ -9,9 +9,6 @@ import type { QuestionnaireVersionSchema } from "@/features/questionnaires/types
 
 export type QuestionnaireTypeCode = (typeof QUESTIONNAIRE_TYPES)[number];
 
-/** @deprecated Use QuestionnaireTypeCode instead — kept as alias during migration */
-export type QuestionnaireType = QuestionnaireTypeCode;
-
 export type QuestionnaireStatus = (typeof QUESTIONNAIRE_STATUSES)[number];
 
 export type QuestionnaireStatusFilter = QuestionnaireStatus | "ALL";

--- a/features/questionnaires/types/index.ts
+++ b/features/questionnaires/types/index.ts
@@ -7,17 +7,32 @@ import {
 } from "@/features/questionnaires/constants";
 import type { QuestionnaireVersionSchema } from "@/features/questionnaires/types/builder";
 
-export type QuestionnaireType = (typeof QUESTIONNAIRE_TYPES)[number];
+export type QuestionnaireTypeCode = (typeof QUESTIONNAIRE_TYPES)[number];
+
+/** @deprecated Use QuestionnaireTypeCode instead — kept as alias during migration */
+export type QuestionnaireType = QuestionnaireTypeCode;
 
 export type QuestionnaireStatus = (typeof QUESTIONNAIRE_STATUSES)[number];
 
 export type QuestionnaireStatusFilter = QuestionnaireStatus | "ALL";
 
+export type QuestionnaireTypeEntity = {
+  id: string;
+  name: string;
+  code: QuestionnaireTypeCode;
+  description: string | null;
+  isSystem: boolean;
+};
+
 export type QuestionnaireTypeSummary = {
-  type: QuestionnaireType;
+  id: string;
+  name: string;
+  code: QuestionnaireTypeCode;
+  description: string | null;
+  isSystem: boolean;
   questionnaireId: string | null;
-  title: string | null;
-  status: QuestionnaireStatus | null;
+  questionnaireTitle: string | null;
+  questionnaireStatus: QuestionnaireStatus | null;
 };
 
 export type QuestionnaireVersionItem = {
@@ -37,7 +52,7 @@ export type VersionLifecycleAction =
 export type QuestionnaireVersionsResponse = {
   questionnaireId: string | null;
   questionnaireTitle: string | null;
-  type: QuestionnaireType;
+  type: QuestionnaireTypeEntity;
   versions: QuestionnaireVersionItem[];
 };
 
@@ -45,7 +60,7 @@ export type QuestionnaireVersionDetail = {
   id: string;
   questionnaireId: string;
   questionnaireTitle: string;
-  questionnaireType: QuestionnaireType;
+  questionnaireType: QuestionnaireTypeEntity;
   versionNumber: number;
   status: QuestionnaireStatus;
   isActive: boolean;
@@ -57,14 +72,14 @@ export type QuestionnaireVersionDetail = {
 
 export type CreateQuestionnaireRequest = {
   title: string;
-  type: QuestionnaireType;
+  typeId: string;
 };
 
 export type Questionnaire = {
   id: string;
   title: string;
   status: QuestionnaireStatus;
-  type: QuestionnaireType;
+  type: QuestionnaireTypeEntity;
   createdAt: string;
   updatedAt: string;
   deletedAt?: string | null;
@@ -156,9 +171,9 @@ export type CheckSubmissionResponse = {
 
 // --- Utility functions ---
 
-export function resolveQuestionnaireType(value: string | null): QuestionnaireType {
-  if (value && QUESTIONNAIRE_TYPES.includes(value as QuestionnaireType)) {
-    return value as QuestionnaireType;
+export function resolveQuestionnaireType(value: string | null): QuestionnaireTypeCode {
+  if (value && QUESTIONNAIRE_TYPES.includes(value as QuestionnaireTypeCode)) {
+    return value as QuestionnaireTypeCode;
   }
 
   return DEFAULT_QUESTIONNAIRE_TYPE;

--- a/network/endpoints.ts
+++ b/network/endpoints.ts
@@ -26,6 +26,10 @@ export enum Endpoints {
   questionnaireDrafts = "/api/v1/questionnaires/drafts",
   questionnaireDraftsList = "/api/v1/questionnaires/drafts/list",
 
+  // Questionnaire Types (entity CRUD)
+  questionnaireTypeEntities = "/api/v1/questionnaire-types",
+  questionnaireTypeEntityById = "/api/v1/questionnaire-types/:id",
+
   // Dimensions
   dimensions = "/api/v1/dimensions",
   dimensionById = "/api/v1/dimensions/:id",


### PR DESCRIPTION
## Summary
- Replaced all `QuestionnaireType` enum string usage with `QuestionnaireTypeCode` (internal) and `QuestionnaireTypeEntity` (API responses)
- Updated all API calls to send UUIDs instead of enum strings — types are resolved via cached `useQuestionnaireTypes()` hook
- Updated 31 files across questionnaire and dimension feature slices (types, hooks, components, store, serializers)

## Test plan
- [x] Questionnaire list page loads and type tabs work
- [x] Questionnaire builder creates/saves drafts correctly
- [x] Dimension management page loads with type filter
- [x] Dimension create dialog submits with UUID
- [x] Dimension code select resolves types correctly
- [x] Student evaluation flow resolves FACULTY_FEEDBACK type

Closes #30