### PR TITLE
[DEVELOP][FAC-WEB-23] handle 429 rate limit responses

### DIFF
--- a/network/axios.ts
+++ b/network/axios.ts
@@ -2,6 +2,7 @@ import { Endpoints } from "@/network/endpoints";
 import type { LoginResponse } from "@/features/auth/types";
 import { useAuthStore } from "@/stores/auth-store";
 import axios, { AxiosError, AxiosHeaders, type InternalAxiosRequestConfig } from "axios";
+import { toast } from "sonner";
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3000";
 
@@ -40,6 +41,35 @@ const refreshClient = axios.create({
 });
 
 let refreshPromise: Promise<LoginResponse> | null = null;
+let lastRateLimitToastAt = 0;
+
+function getRateLimitMessage(error: AxiosError) {
+  const retryAfterValue = error.response?.headers["retry-after"];
+  const retryAfterSeconds = Number.parseInt(String(retryAfterValue ?? ""), 10);
+
+  if (Number.isNaN(retryAfterSeconds) || retryAfterSeconds <= 0) {
+    return "Too many requests. Please wait and try again.";
+  }
+
+  const secondsLabel = retryAfterSeconds === 1 ? "second" : "seconds";
+  return `Too many requests. Please wait ${retryAfterSeconds} ${secondsLabel} and try again.`;
+}
+
+function notifyRateLimit(error: AxiosError) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const now = Date.now();
+
+  // Avoid stacking identical 429 toasts when multiple requests fail together.
+  if (now - lastRateLimitToastAt < 3000) {
+    return;
+  }
+
+  lastRateLimitToastAt = now;
+  toast.error(getRateLimitMessage(error));
+}
 
 function refreshAccessToken(refreshToken: string) {
   if (!refreshPromise) {
@@ -71,6 +101,12 @@ apiClient.interceptors.response.use(
   async (error: AxiosError) => {
     const originalRequest = error.config as RetriableRequestConfig | undefined;
     const isUnauthorized = error.response?.status === 401;
+    const isRateLimited = error.response?.status === 429;
+
+    if (isRateLimited) {
+      notifyRateLimit(error);
+      return Promise.reject(error);
+    }
 
     if (
       !originalRequest ||


### PR DESCRIPTION
## Summary
- add global 429 handling in the shared Axios response interceptor
- surface a user-friendly toast with Retry-After wait time when provided by the API
- suppress duplicate rate-limit toasts during burst failures while keeping 401 refresh behavior unchanged

## Test plan
- [x] `bun run typecheck`
- [x] Manually verify the 429 toast path via temporary local simulation during development
- [x] Verify against a real backend-generated 429 response if available

Closes #43