### PR TITLE
FAC-WEB feat: add template selection modal for questionnaire version creation

### DIFF
--- a/app/(dashboard)/superadmin/questionnaires/_components/questionnaire-list-screen.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/_components/questionnaire-list-screen.tsx
@@ -27,6 +27,7 @@ type QuestionnaireListScreenProps = {
   onPublishVersion: (row: QuestionnaireVersionItem) => void;
   onDeprecateVersion: (row: QuestionnaireVersionItem) => void;
   disableActions?: boolean;
+  questionnaireId: string | null;
 };
 
 export function QuestionnaireListScreen({
@@ -44,6 +45,7 @@ export function QuestionnaireListScreen({
   onPublishVersion,
   onDeprecateVersion,
   disableActions = false,
+  questionnaireId,
 }: QuestionnaireListScreenProps) {
   const [searchValue, setSearchValue] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("ALL");
@@ -79,6 +81,8 @@ export function QuestionnaireListScreen({
           }
         : null;
 
+  const templateVersions = rows.filter((v) => v.status !== "DRAFT");
+
   return (
     <div className="space-y-6">
       <QuestionnaireListToolbar
@@ -94,6 +98,8 @@ export function QuestionnaireListScreen({
         }}
         onStatusFilterChange={setStatusFilter}
         onSearchChange={setSearchValue}
+        questionnaireId={questionnaireId}
+        templateVersions={templateVersions}
       />
 
       <QuestionnaireAsyncContent

--- a/app/(dashboard)/superadmin/questionnaires/page.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/page.tsx
@@ -31,6 +31,7 @@ export default function SuperAdminQuestionnairesPage() {
         onPublishVersion={(row) => page.setVersionAction({ type: "publish", row })}
         onDeprecateVersion={(row) => page.setVersionAction({ type: "deprecate", row })}
         disableActions={page.isVersionActionPending}
+        questionnaireId={page.activeTypeSummary?.questionnaireId ?? null}
       />
 
       {page.actionDialogConfig && (

--- a/features/questionnaires/api/questionnaire.requests.ts
+++ b/features/questionnaires/api/questionnaire.requests.ts
@@ -154,6 +154,23 @@ export async function createQuestionnaireVersion({
 }
 
 /**
+ * Create a new draft version by copying the schema from an existing version.
+ */
+export async function createVersionFromTemplate({
+  questionnaireId,
+  sourceVersionId,
+}: {
+  questionnaireId: string;
+  sourceVersionId: string;
+}) {
+  const response = await apiClient.post<QuestionnaireVersionDetail>(
+    Endpoints.questionnaireVersionFromTemplate.replace(":id", questionnaireId),
+    { sourceVersionId }
+  );
+  return response.data;
+}
+
+/**
  * Update an existing draft questionnaire version.
  */
 export async function updateQuestionnaireVersion({

--- a/features/questionnaires/components/questionnaire-list-toolbar.tsx
+++ b/features/questionnaires/components/questionnaire-list-toolbar.tsx
@@ -1,15 +1,29 @@
 "use client";
 
-import Link from "next/link";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 import { QuestionnaireSearchInput } from "@/features/questionnaires/components/questionnaire-search-input";
 import { QuestionnaireStatusFilter } from "@/features/questionnaires/components/questionnaire-status-filter";
 import { QuestionnaireTypeDropdown } from "@/features/questionnaires/components/questionnaire-type-dropdown";
+import { useCreateVersionFromTemplate } from "@/features/questionnaires/hooks/use-create-version-from-template";
+import { isAxiosErrorWithStatus } from "@/lib/api-errors";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import type {
   QuestionnaireStatusFilter as StatusFilter,
   QuestionnaireTypeCode,
   QuestionnaireTypeSummary,
+  QuestionnaireVersionItem,
 } from "@/features/questionnaires/types";
 
 type QuestionnaireListToolbarProps = {
@@ -21,7 +35,18 @@ type QuestionnaireListToolbarProps = {
   onTypeChange: (nextType: QuestionnaireTypeCode) => void;
   onStatusFilterChange: (value: StatusFilter) => void;
   onSearchChange: (value: string) => void;
+  questionnaireId: string | null;
+  templateVersions: QuestionnaireVersionItem[];
 };
+
+type TemplateChoice = "scratch" | "template";
+
+function formatVersionLabel(v: QuestionnaireVersionItem) {
+  const date = v.publishedAt
+    ? new Date(v.publishedAt).toLocaleDateString()
+    : new Date(v.createdAt).toLocaleDateString();
+  return `v${v.versionNumber} — ${v.status} (${date})`;
+}
 
 export function QuestionnaireListToolbar({
   availableTypes,
@@ -32,8 +57,67 @@ export function QuestionnaireListToolbar({
   onTypeChange,
   onStatusFilterChange,
   onSearchChange,
+  questionnaireId,
+  templateVersions,
 }: QuestionnaireListToolbarProps) {
+  const router = useRouter();
+  const createFromTemplate = useCreateVersionFromTemplate();
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [choice, setChoice] = useState<TemplateChoice>("scratch");
+  const [selectedVersionId, setSelectedVersionId] = useState<string>("");
+
   const createDraftHref = `/superadmin/questionnaires/new?type=${activeType}`;
+  const hasTemplates = templateVersions.length > 0 && questionnaireId !== null;
+
+  function handleCreateDraftClick() {
+    if (hasTemplates) {
+      setChoice("scratch");
+      setSelectedVersionId(templateVersions[0].id);
+      setModalOpen(true);
+    } else {
+      router.push(createDraftHref);
+    }
+  }
+
+  function handleConfirm() {
+    if (choice === "scratch") {
+      setModalOpen(false);
+      router.push(createDraftHref);
+      return;
+    }
+
+    if (!questionnaireId || !selectedVersionId) return;
+
+    createFromTemplate.mutate(
+      { questionnaireId, sourceVersionId: selectedVersionId },
+      {
+        onSuccess: (data) => {
+          setModalOpen(false);
+          router.push(`/superadmin/questionnaires/new?type=${activeType}&versionId=${data.id}`);
+        },
+        onError: (error) => {
+          if (isAxiosErrorWithStatus(error, 409)) {
+            toast.error("A draft already exists — edit it or deprecate it first.");
+          } else {
+            toast.error("Failed to create version from template.");
+          }
+        },
+      }
+    );
+  }
+
+  const createDraftButton = !hasDraftVersion ? (
+    <Button variant="brand" className="shrink-0" onClick={handleCreateDraftClick}>
+      Create Draft
+    </Button>
+  ) : null;
+
+  const createDraftButtonMobile = !hasDraftVersion ? (
+    <Button variant="brand" className="w-full min-w-0" onClick={handleCreateDraftClick}>
+      Create Draft
+    </Button>
+  ) : null;
 
   return (
     <>
@@ -55,11 +139,7 @@ export function QuestionnaireListToolbar({
               onValueChange={onStatusFilterChange}
               className="w-full min-w-0 justify-between gap-3"
             />
-            {!hasDraftVersion ? (
-              <Button asChild variant="brand" className="w-full min-w-0">
-                <Link href={createDraftHref}>Create Draft</Link>
-              </Button>
-            ) : null}
+            {createDraftButtonMobile}
           </div>
         </div>
       </div>
@@ -73,11 +153,7 @@ export function QuestionnaireListToolbar({
         />
 
         <div className="flex min-w-0 flex-1 flex-wrap items-center justify-end gap-3">
-          {!hasDraftVersion ? (
-            <Button asChild variant="brand" className="shrink-0">
-              <Link href={createDraftHref}>Create Draft</Link>
-            </Button>
-          ) : null}
+          {createDraftButton}
           <QuestionnaireSearchInput
             value={searchValue}
             onChange={onSearchChange}
@@ -90,6 +166,78 @@ export function QuestionnaireListToolbar({
           />
         </div>
       </div>
+
+      <Dialog
+        open={modalOpen}
+        onOpenChange={(open) => {
+          if (!createFromTemplate.isPending) setModalOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create new draft</DialogTitle>
+            <DialogDescription>
+              Start from scratch or use a previous version as a template.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <Button
+                variant={choice === "scratch" ? "default" : "outline"}
+                className="h-auto py-3"
+                onClick={() => setChoice("scratch")}
+              >
+                Start from scratch
+              </Button>
+              <Button
+                variant={choice === "template" ? "default" : "outline"}
+                className="h-auto py-3"
+                onClick={() => setChoice("template")}
+              >
+                Use a template
+              </Button>
+            </div>
+
+            {choice === "template" && (
+              <div className="space-y-2">
+                <Label htmlFor="template-version-select">Select version</Label>
+                <select
+                  id="template-version-select"
+                  value={selectedVersionId}
+                  onChange={(e) => setSelectedVersionId(e.target.value)}
+                  className="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-sm transition-colors focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {templateVersions.map((v) => (
+                    <option key={v.id} value={v.id}>
+                      {formatVersionLabel(v)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              disabled={createFromTemplate.isPending}
+              onClick={() => setModalOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="brand"
+              disabled={
+                createFromTemplate.isPending || (choice === "template" && !selectedVersionId)
+              }
+              onClick={handleConfirm}
+            >
+              {createFromTemplate.isPending ? "Creating\u2026" : "Continue"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/features/questionnaires/hooks/use-create-version-from-template.ts
+++ b/features/questionnaires/hooks/use-create-version-from-template.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { createVersionFromTemplate } from "@/features/questionnaires/api/questionnaire.requests";
+
+export function useCreateVersionFromTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createVersionFromTemplate,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["questionnaires"] });
+    },
+  });
+}

--- a/network/endpoints.ts
+++ b/network/endpoints.ts
@@ -17,6 +17,7 @@ export enum Endpoints {
   questionnaireLatestActiveVersion = "/api/v1/questionnaires/:id/latest-active-version",
   questionnaireVersionPublish = "/api/v1/questionnaires/versions/:versionId/publish",
   questionnaireVersionDeprecate = "/api/v1/questionnaires/versions/:versionId/deprecate",
+  questionnaireVersionFromTemplate = "/api/v1/questionnaires/:id/versions/from-template",
 
   // Questionnaire Submissions
   questionnaireSubmissions = "/api/v1/questionnaires/submissions",


### PR DESCRIPTION
## Summary

- Add template selection modal to "Create Draft" button — when previous versions exist, admins can choose to start from scratch or copy a past version's schema
- New endpoint constant, API request function, and TanStack Query mutation hook for the `from-template` API
- Props threaded from page -> screen -> toolbar for `questionnaireId` and `templateVersions`

Closes #58
**Depends on:** CtrlAltElite-Devs/api.faculytics#261

## Test plan

- [ ] `bun run typecheck` and `bun run lint` pass
- [ ] With previous versions: clicking "Create Draft" opens modal with scratch/template options
- [ ] Selecting a template and confirming creates a draft and opens the builder with pre-populated schema
- [ ] With no previous versions: clicking "Create Draft" navigates directly (no modal)
- [ ] Confirm button disabled and shows "Creating…" while mutation is pending
- [ ] On 409, toast shows "A draft already exists — edit it or deprecate it first."
- [ ] On other errors, toast shows generic failure message

🤖 Generated with [Claude Code](https://claude.com/claude-code)