### PR TITLE
[REFACTORING][FAC-WEB] tighten auth, questionnaires, and dimensions flows

### DIFF
--- a/app/(dashboard)/_guards/auth-guard.tsx
+++ b/app/(dashboard)/_guards/auth-guard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AppLoadingScreen } from "@/components/shared/app-loading-screen";
-import { useActiveRole } from "@/features/auth/hooks/use-active-role";
+import { useAuthSessionState } from "@/features/auth/hooks/use-auth-session-state";
 import { useAuthStore } from "@/stores/auth-store";
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
@@ -13,42 +13,29 @@ type AuthGuardProps = {
 
 export function AuthGuard({ children }: AuthGuardProps) {
   const router = useRouter();
-  const hydrated = useAuthStore((state) => state.hydrated);
-  const token = useAuthStore((state) => state.token);
   const clearSession = useAuthStore((state) => state.clearSession);
-  const { activeRole, roleHome, isPending: isMePending, isError: isMeError } = useActiveRole();
+  const { status } = useAuthSessionState();
 
   useEffect(() => {
-    if (!hydrated) return;
+    if (status === "hydrating" || status === "loading-profile") return;
 
-    if (!token) {
+    if (status === "signed-out") {
       router.replace("/auth");
       return;
     }
 
-    if (isMePending) return;
-
-    if (isMeError) {
+    if (status === "invalid-session" || status === "unsupported-role") {
       clearSession();
       router.replace("/auth");
       return;
     }
+  }, [clearSession, router, status]);
 
-    if (!activeRole || !roleHome) {
-      clearSession();
-      router.replace("/auth");
-    }
-  }, [activeRole, clearSession, hydrated, isMeError, isMePending, roleHome, router, token]);
-
-  if (!hydrated || isMePending) {
+  if (status === "hydrating" || status === "loading-profile") {
     return <AppLoadingScreen message="Restoring your session..." />;
   }
 
-  if (token && !isMeError && (!activeRole || !roleHome)) {
-    return <AppLoadingScreen message="Loading your dashboard..." />;
-  }
-
-  if (!token || isMeError || !activeRole || !roleHome) {
+  if (status !== "authenticated") {
     return null;
   }
 

--- a/app/(dashboard)/_guards/role-guard.tsx
+++ b/app/(dashboard)/_guards/role-guard.tsx
@@ -2,7 +2,7 @@
 
 import { AppLoadingScreen } from "@/components/shared/app-loading-screen";
 import type { AppRole } from "@/constants/roles";
-import { useActiveRole } from "@/features/auth/hooks/use-active-role";
+import { useAuthSessionState } from "@/features/auth/hooks/use-auth-session-state";
 import { useAuthStore } from "@/stores/auth-store";
 import { usePathname, useRouter } from "next/navigation";
 import type { ReactNode } from "react";
@@ -19,20 +19,15 @@ export function RoleGuard({ allowedRoles, children }: RoleGuardProps) {
   const clearSession = useAuthStore((state) => state.clearSession);
   const pendingRedirectPath = useAuthStore((state) => state.pendingRedirectPath);
   const setPendingRedirectPath = useAuthStore((state) => state.setPendingRedirectPath);
-  const {
-    activeRole,
-    roleHome,
-    roles,
-    isPending: isMePending,
-    isError: isMeError,
-  } = useActiveRole();
+  const { activeRole, roleHome, roles, status } = useAuthSessionState();
   const hasAnyAllowedRole = roles.some((role) => allowedRoles.includes(role));
   const isAllowed = Boolean(activeRole && allowedRoles.includes(activeRole));
+  const authenticatedHome = status === "authenticated" ? roleHome : null;
 
   useEffect(() => {
-    if (isMePending) return;
+    if (status === "hydrating" || status === "loading-profile") return;
 
-    if (pendingRedirectPath && roleHome === pendingRedirectPath) {
+    if (pendingRedirectPath && authenticatedHome === pendingRedirectPath) {
       if (pathname === pendingRedirectPath) {
         setPendingRedirectPath(null);
       }
@@ -40,44 +35,41 @@ export function RoleGuard({ allowedRoles, children }: RoleGuardProps) {
       return;
     }
 
-    if (isMeError) {
+    if (status === "signed-out" || status === "invalid-session" || status === "unsupported-role") {
       clearSession();
       router.replace("/auth");
       return;
     }
 
-    if (!roleHome) {
-      clearSession();
-      router.replace("/auth");
+    if (!authenticatedHome) {
       return;
     }
 
     if (!hasAnyAllowedRole) {
-      router.replace(roleHome);
+      router.replace(authenticatedHome);
       return;
     }
 
-    if (!isAllowed && pathname !== roleHome) {
-      router.replace(roleHome);
+    if (!isAllowed && pathname !== authenticatedHome) {
+      router.replace(authenticatedHome);
     }
   }, [
+    authenticatedHome,
     clearSession,
     hasAnyAllowedRole,
     isAllowed,
-    isMeError,
-    isMePending,
     pathname,
     pendingRedirectPath,
-    roleHome,
     router,
     setPendingRedirectPath,
+    status,
   ]);
 
-  if (isMePending || !roleHome) {
+  if (status === "hydrating" || status === "loading-profile") {
     return <AppLoadingScreen message="Checking access..." />;
   }
 
-  if (isMeError || !isAllowed) {
+  if (status !== "authenticated" || !isAllowed) {
     return null;
   }
 

--- a/app/(dashboard)/_guards/role-guard.tsx
+++ b/app/(dashboard)/_guards/role-guard.tsx
@@ -17,8 +17,8 @@ export function RoleGuard({ allowedRoles, children }: RoleGuardProps) {
   const router = useRouter();
   const pathname = usePathname();
   const clearSession = useAuthStore((state) => state.clearSession);
-  const pendingRoleHome = useAuthStore((state) => state.pendingRoleHome);
-  const setPendingRoleHome = useAuthStore((state) => state.setPendingRoleHome);
+  const pendingRedirectPath = useAuthStore((state) => state.pendingRedirectPath);
+  const setPendingRedirectPath = useAuthStore((state) => state.setPendingRedirectPath);
   const {
     activeRole,
     roleHome,
@@ -32,9 +32,9 @@ export function RoleGuard({ allowedRoles, children }: RoleGuardProps) {
   useEffect(() => {
     if (isMePending) return;
 
-    if (pendingRoleHome && roleHome === pendingRoleHome) {
-      if (pathname === pendingRoleHome) {
-        setPendingRoleHome(null);
+    if (pendingRedirectPath && roleHome === pendingRedirectPath) {
+      if (pathname === pendingRedirectPath) {
+        setPendingRedirectPath(null);
       }
 
       return;
@@ -67,10 +67,10 @@ export function RoleGuard({ allowedRoles, children }: RoleGuardProps) {
     isMeError,
     isMePending,
     pathname,
-    pendingRoleHome,
+    pendingRedirectPath,
     roleHome,
     router,
-    setPendingRoleHome,
+    setPendingRedirectPath,
   ]);
 
   if (isMePending || !roleHome) {

--- a/app/(dashboard)/chairperson/dashboard/page.tsx
+++ b/app/(dashboard)/chairperson/dashboard/page.tsx
@@ -1,9 +1,9 @@
 export default function ChairpersonDashboardPage() {
   return (
     <section className="md:p-8">
-      <h1 className="text-2xl font-semibold">Chairperson Dashboard</h1>
+      <h1 className="text-2xl font-semibold">Chairperson dashboard</h1>
       <p className="mt-2 text-sm text-muted-foreground">
-        Separate dashboard layer for the chairperson role.
+        Chairperson analytics and summary views will appear here.
       </p>
     </section>
   );

--- a/app/(dashboard)/error.tsx
+++ b/app/(dashboard)/error.tsx
@@ -19,13 +19,13 @@ export default function DashboardError({ error, reset }: ErrorBoundaryProps) {
     <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
       <AlertCircle className="text-destructive size-10" />
       <div className="space-y-1">
-        <h2 className="text-lg font-semibold">Something went wrong</h2>
+        <h2 className="text-lg font-semibold">This page could not be loaded</h2>
         <p className="text-muted-foreground text-sm">
-          An unexpected error occurred. Please try again.
+          Something interrupted the request. Try loading the page again.
         </p>
       </div>
       <Button variant="outline" onClick={reset}>
-        Try again
+        Reload page
       </Button>
     </div>
   );

--- a/app/(dashboard)/superadmin/dimensions/_components/dimension-list-screen.tsx
+++ b/app/(dashboard)/superadmin/dimensions/_components/dimension-list-screen.tsx
@@ -26,6 +26,7 @@ type DimensionListScreenProps = {
   onTypeFilterChange: (value: TypeFilter) => void;
   onStatusFilterChange: (value: DimensionStatusFilter) => void;
   onSearchChange: (value: string) => void;
+  onClearFilters: () => void;
   onCreateClick: () => void;
   onPageSizeChange: (size: number) => void;
   onEdit: (row: Dimension) => void;
@@ -48,6 +49,7 @@ export function DimensionListScreen({
   onTypeFilterChange,
   onStatusFilterChange,
   onSearchChange,
+  onClearFilters,
   onCreateClick,
   onPageSizeChange,
   onEdit,
@@ -59,14 +61,11 @@ export function DimensionListScreen({
     rows.length === 0 && !isLoading && !isError
       ? hasFilters
         ? {
-            description: "No matching dimensions.",
+            description: "No dimensions match the current filters.",
             actionLabel: "Clear filters",
-            onAction: () => {
-              onSearchChange("");
-              onStatusFilterChange("ALL");
-            },
+            onAction: onClearFilters,
           }
-        : { description: "No dimensions yet. Create one to get started." }
+        : { description: "No dimensions are available for this questionnaire type yet." }
       : null;
 
   return (

--- a/app/(dashboard)/superadmin/dimensions/page.tsx
+++ b/app/(dashboard)/superadmin/dimensions/page.tsx
@@ -15,7 +15,7 @@ export default function SuperAdminDimensionsPage() {
       <div>
         <h1 className="font-playfair text-2xl font-semibold">Dimensions</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Manage dimension codes used across questionnaire types.
+          Manage the dimension codes used in questionnaire sections across each questionnaire type.
         </p>
       </div>
 
@@ -34,6 +34,7 @@ export default function SuperAdminDimensionsPage() {
         onTypeFilterChange={page.onTypeFilterChange}
         onStatusFilterChange={page.onStatusFilterChange}
         onSearchChange={page.onSearchChange}
+        onClearFilters={page.onClearFilters}
         onCreateClick={() => page.setCreateOpen(true)}
         onPageSizeChange={page.onPageSizeChange}
         onEdit={(row) => page.setEditDimension(row)}

--- a/app/(dashboard)/superadmin/questionnaire-types/_components/questionnaire-type-list-screen.tsx
+++ b/app/(dashboard)/superadmin/questionnaire-types/_components/questionnaire-type-list-screen.tsx
@@ -53,13 +53,13 @@ export function QuestionnaireTypeListScreen({
   const emptyState = useMemo(() => {
     if (rows.length === 0) {
       return {
-        description: "No questionnaire types found yet.",
+        description: "No questionnaire types have been added yet.",
       };
     }
 
     if (filteredRows.length === 0) {
       return {
-        description: "No matching questionnaire types.",
+        description: "No questionnaire types match the current search or filter.",
         actionLabel: "Clear filters",
         onAction: () => {
           setSearchValue("");

--- a/app/(dashboard)/superadmin/questionnaire-types/page.tsx
+++ b/app/(dashboard)/superadmin/questionnaire-types/page.tsx
@@ -17,9 +17,9 @@ export default function SuperAdminQuestionnaireTypesPage() {
   return (
     <section className="space-y-6 px-4 py-5 sm:px-6 md:p-8">
       <div>
-        <h1 className="font-playfair text-2xl font-semibold">Questionnaire Types</h1>
+        <h1 className="font-playfair text-2xl font-semibold">Questionnaire types</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Manage the questionnaire type catalog used by Super Admin questionnaire flows.
+          Manage the questionnaire type catalog used across questionnaire creation and versioning.
         </p>
       </div>
 
@@ -54,7 +54,7 @@ export default function SuperAdminQuestionnaireTypesPage() {
             }
           }}
           title={`Delete "${deleteTarget.name}"?`}
-          description="This will soft-delete the questionnaire type. System types cannot be deleted, and the backend may reject deletion if the type is already associated with a questionnaire."
+          description="This will archive the questionnaire type. System types cannot be deleted, and the backend may reject the request if the type is already linked to a questionnaire."
           cancelLabel="Cancel"
           confirmLabel="Delete type"
           confirmVariant="destructive"

--- a/app/(dashboard)/superadmin/questionnaires/_components/questionnaire-list-screen.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/_components/questionnaire-list-screen.tsx
@@ -64,15 +64,16 @@ export function QuestionnaireListScreen({
   const hasFilters = normalizedSearch.length > 0 || statusFilter !== "ALL";
   const emptyState = !hasQuestionnaire
     ? {
-        description: "No questionnaire for this type yet.",
+        description:
+          "No questionnaire has been created for this type yet. Create a draft to start building one.",
       }
     : rows.length === 0
       ? {
-          description: "No versions yet.",
+          description: "No versions have been created for this questionnaire yet.",
         }
       : filteredRows.length === 0 && hasFilters
         ? {
-            description: "No matching versions.",
+            description: "No questionnaire versions match the current filters.",
             actionLabel: "Clear filters",
             onAction: () => {
               setSearchValue("");

--- a/app/(dashboard)/superadmin/questionnaires/_components/questionnaire-preview-shell.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/_components/questionnaire-preview-shell.tsx
@@ -3,8 +3,8 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 type QuestionnairePreviewShellProps = {
-  title: string;
-  description: string;
+  title?: string;
+  description?: string;
   backHref: string;
   backLabel: string;
   children: React.ReactNode;
@@ -22,12 +22,16 @@ export function QuestionnairePreviewShell({
       <div className="mx-auto max-w-6xl space-y-8">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {title}
-            </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
-              {description}
-            </p>
+            {title ? (
+              <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+                {title}
+              </h1>
+            ) : null}
+            {description ? (
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+                {description}
+              </p>
+            ) : null}
           </div>
           <Button asChild variant="outline" className="shrink-0 self-start">
             <Link href={backHref}>{backLabel}</Link>

--- a/app/(dashboard)/superadmin/questionnaires/new/_components/questionnaire-builder-discard-dialog.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/new/_components/questionnaire-builder-discard-dialog.tsx
@@ -16,7 +16,7 @@ export function QuestionnaireBuilderDiscardDialog({
       open={open}
       onOpenChange={onOpenChange}
       title="Discard unsaved changes?"
-      description="Going back to questionnaires will discard the unsaved changes in this builder."
+      description="Returning to the questionnaire list will discard any unsaved changes in this draft."
       cancelLabel="Keep editing"
       confirmLabel="Discard changes"
       confirmVariant="destructive"

--- a/app/(dashboard)/superadmin/questionnaires/new/_components/questionnaire-builder-page-header.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/new/_components/questionnaire-builder-page-header.tsx
@@ -8,10 +8,10 @@ export function QuestionnaireBuilderPageHeader({ onBack }: QuestionnaireBuilderP
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div>
-        <h1 className="font-playfair text-2xl font-semibold">Questionnaire Builder</h1>
+        <h1 className="font-playfair text-2xl font-semibold">Questionnaire builder</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Build a quantitative questionnaire, add an optional final comment section, and save it as
-          a draft version.
+          Build the questionnaire structure, add an optional qualitative section, and save changes
+          as a draft.
         </p>
       </div>
       <Button type="button" variant="outline" className="sm:self-start" onClick={onBack}>

--- a/app/(dashboard)/superadmin/questionnaires/new/page.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/new/page.tsx
@@ -10,19 +10,14 @@ export default function QuestionnaireBuilderPage() {
   const {
     activePageType,
     hydrated,
-    resolvedVersionId,
     showBuilderLoading,
     showBuilderError,
     emptyState,
     discardDialogOpen,
     setDiscardDialogOpen,
-    questionnaireListHref,
-    questionnaireTypesQuery,
-    questionnaireVersionsQuery,
-    questionnaireVersionQuery,
-    resetActiveDraft,
     handleBackToQuestionnaires,
-    router,
+    handleRetry,
+    handleConfirmDiscard,
   } = useQuestionnairePageState();
 
   return (
@@ -35,23 +30,13 @@ export default function QuestionnaireBuilderPage() {
         isLoading={showBuilderLoading}
         isError={showBuilderError}
         emptyState={emptyState}
-        onRetry={() => {
-          void questionnaireTypesQuery.refetch();
-          void questionnaireVersionsQuery.refetch();
-          if (resolvedVersionId) {
-            void questionnaireVersionQuery.refetch();
-          }
-        }}
+        onRetry={handleRetry}
       />
 
       <QuestionnaireBuilderDiscardDialog
         open={discardDialogOpen}
         onOpenChange={setDiscardDialogOpen}
-        onConfirm={() => {
-          resetActiveDraft();
-          setDiscardDialogOpen(false);
-          router.push(questionnaireListHref);
-        }}
+        onConfirm={handleConfirmDiscard}
       />
     </section>
   );

--- a/app/(dashboard)/superadmin/questionnaires/new/preview/page.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/new/preview/page.tsx
@@ -28,7 +28,7 @@ export default function QuestionnaireBuilderPreviewPage() {
         backHref={`/superadmin/questionnaires/new?type=${requestedType}`}
         backLabel="Back to builder"
       >
-        <QuestionnairePreviewLoadingCard message="Loading preview draft..." />
+        <QuestionnairePreviewLoadingCard message="Loading the current draft preview..." />
       </QuestionnairePreviewShell>
     );
   }
@@ -37,13 +37,13 @@ export default function QuestionnaireBuilderPreviewPage() {
     return (
       <QuestionnairePreviewShell
         title="Preview unavailable"
-        description="There is no active builder draft to preview. Return to the questionnaire builder and start a draft first."
+        description="There is no draft available to preview yet. Return to the builder and add questionnaire content first."
         backHref={`/superadmin/questionnaires/new?type=${requestedType}`}
         backLabel="Back to builder"
       >
         <QuestionnairePreviewStateCard
           title="Preview unavailable"
-          description="There is no active builder draft to preview. Return to the questionnaire builder and start a draft first."
+          description="There is no draft available to preview yet. Return to the builder and add questionnaire content first."
         />
       </QuestionnairePreviewShell>
     );
@@ -55,7 +55,7 @@ export default function QuestionnaireBuilderPreviewPage() {
   return (
     <QuestionnairePreviewShell
       title={model.title}
-      description="Builder preview. Review the questionnaire structure and wording before saving or publishing."
+      description="Review the questionnaire structure and wording before saving or publishing."
       backHref={backHref}
       backLabel="Back to builder"
     >

--- a/app/(dashboard)/superadmin/questionnaires/new/preview/page.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/new/preview/page.tsx
@@ -36,8 +36,6 @@ export default function QuestionnaireBuilderPreviewPage() {
   if (!draft || !hasPreviewContent) {
     return (
       <QuestionnairePreviewShell
-        title="Preview unavailable"
-        description="There is no draft available to preview yet. Return to the builder and add questionnaire content first."
         backHref={`/superadmin/questionnaires/new?type=${requestedType}`}
         backLabel="Back to builder"
       >

--- a/app/(dashboard)/superadmin/questionnaires/page.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/page.tsx
@@ -13,7 +13,7 @@ export default function SuperAdminQuestionnairesPage() {
     <section className="space-y-6 px-4 py-5 sm:px-6 md:p-8">
       <QuestionnairePageHeader
         title="Questionnaires"
-        description="Browse questionnaire types, search versions, and filter by lifecycle status."
+        description="Manage questionnaire versions by type, review lifecycle status, and prepare drafts for editing or publishing."
       />
 
       <QuestionnaireListScreen

--- a/app/(dashboard)/superadmin/questionnaires/preview/page.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/preview/page.tsx
@@ -22,8 +22,6 @@ export default function QuestionnaireVersionPreviewPage() {
   if (!versionId) {
     return (
       <QuestionnairePreviewShell
-        title="Preview unavailable"
-        description="No questionnaire version was selected for preview."
         backHref="/superadmin/questionnaires"
         backLabel="Back to questionnaires"
       >
@@ -51,8 +49,6 @@ export default function QuestionnaireVersionPreviewPage() {
   if (versionQuery.isError || !versionQuery.data) {
     return (
       <QuestionnairePreviewShell
-        title="Preview unavailable"
-        description="The selected questionnaire version could not be loaded."
         backHref="/superadmin/questionnaires"
         backLabel="Back to questionnaires"
       >

--- a/app/(dashboard)/superadmin/questionnaires/preview/page.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/preview/page.tsx
@@ -39,11 +39,11 @@ export default function QuestionnaireVersionPreviewPage() {
     return (
       <QuestionnairePreviewShell
         title="Loading preview"
-        description="Preparing the questionnaire preview."
+        description="Preparing the selected questionnaire version for preview."
         backHref="/superadmin/questionnaires"
         backLabel="Back to questionnaires"
       >
-        <QuestionnairePreviewLoadingCard message="Loading questionnaire preview..." />
+        <QuestionnairePreviewLoadingCard message="Loading the questionnaire preview..." />
       </QuestionnairePreviewShell>
     );
   }
@@ -52,13 +52,13 @@ export default function QuestionnaireVersionPreviewPage() {
     return (
       <QuestionnairePreviewShell
         title="Preview unavailable"
-        description="The requested questionnaire version could not be loaded."
+        description="The selected questionnaire version could not be loaded."
         backHref="/superadmin/questionnaires"
         backLabel="Back to questionnaires"
       >
         <QuestionnairePreviewStateCard
           title="Preview unavailable"
-          description="The requested questionnaire version could not be loaded."
+          description="The selected questionnaire version could not be loaded."
         />
       </QuestionnairePreviewShell>
     );
@@ -73,7 +73,7 @@ export default function QuestionnaireVersionPreviewPage() {
   return (
     <QuestionnairePreviewShell
       title={model.title}
-      description="Questionnaire preview. Review the structure, sections, and prompts before publishing."
+      description="Review the questionnaire structure, sections, and prompts before publishing."
       backHref="/superadmin/questionnaires"
       backLabel="Back to questionnaires"
     >

--- a/app/(dashboard)/superadmin/questionnaires/preview/page.tsx
+++ b/app/(dashboard)/superadmin/questionnaires/preview/page.tsx
@@ -7,6 +7,7 @@ import { QuestionnaireRatingScaleInstructions } from "@/features/questionnaires/
 import { deserializeQuestionnaireVersionToDraft } from "@/features/questionnaires/lib/builder-deserializer";
 import { buildQuestionnairePreviewModel } from "@/features/questionnaires/lib/builder-serializer";
 import { useQuestionnaireVersion } from "@/features/questionnaires/hooks/use-questionnaire-versions";
+import { resolveQuestionnaireType } from "@/features/questionnaires/types";
 
 import { QuestionnairePreviewLoadingCard } from "../_components/questionnaire-preview-loading-card";
 import { QuestionnairePreviewShell } from "../_components/questionnaire-preview-shell";
@@ -15,16 +16,16 @@ import { QuestionnairePreviewStateCard } from "../_components/questionnaire-prev
 export default function QuestionnaireVersionPreviewPage() {
   const searchParams = useSearchParams();
   const versionId = searchParams.get("versionId");
+  const requestedType = resolveQuestionnaireType(searchParams.get("type"));
   const versionQuery = useQuestionnaireVersion(versionId, {
     enabled: Boolean(versionId),
   });
+  const resolvedType = versionQuery.data?.questionnaireType.code ?? requestedType;
+  const backHref = `/superadmin/questionnaires?type=${resolvedType}`;
 
   if (!versionId) {
     return (
-      <QuestionnairePreviewShell
-        backHref="/superadmin/questionnaires"
-        backLabel="Back to questionnaires"
-      >
+      <QuestionnairePreviewShell backHref={backHref} backLabel="Back to questionnaires">
         <QuestionnairePreviewStateCard
           title="Preview unavailable"
           description="No questionnaire version was selected for preview."
@@ -38,7 +39,7 @@ export default function QuestionnaireVersionPreviewPage() {
       <QuestionnairePreviewShell
         title="Loading preview"
         description="Preparing the selected questionnaire version for preview."
-        backHref="/superadmin/questionnaires"
+        backHref={backHref}
         backLabel="Back to questionnaires"
       >
         <QuestionnairePreviewLoadingCard message="Loading the questionnaire preview..." />
@@ -48,10 +49,7 @@ export default function QuestionnaireVersionPreviewPage() {
 
   if (versionQuery.isError || !versionQuery.data) {
     return (
-      <QuestionnairePreviewShell
-        backHref="/superadmin/questionnaires"
-        backLabel="Back to questionnaires"
-      >
+      <QuestionnairePreviewShell backHref={backHref} backLabel="Back to questionnaires">
         <QuestionnairePreviewStateCard
           title="Preview unavailable"
           description="The selected questionnaire version could not be loaded."
@@ -70,7 +68,7 @@ export default function QuestionnaireVersionPreviewPage() {
     <QuestionnairePreviewShell
       title={model.title}
       description="Review the questionnaire structure, sections, and prompts before publishing."
-      backHref="/superadmin/questionnaires"
+      backHref={backHref}
       backLabel="Back to questionnaires"
     >
       <div>

--- a/app/auth/_components/auth-login-form.tsx
+++ b/app/auth/_components/auth-login-form.tsx
@@ -11,7 +11,7 @@ import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field
 import { Input } from "@/components/ui/input";
 import { useLogin } from "@/features/auth/hooks/use-login";
 import { loginRequestSchema } from "@/features/auth/schemas";
-import type { AuthErrorResponse, LoginRequest } from "@/features/auth/types";
+import type { AuthErrorPayload, LoginRequest } from "@/features/auth/types";
 
 type AuthLoginFormProps = {
   isAuthenticating: boolean;
@@ -32,7 +32,7 @@ export function AuthLoginForm({ isAuthenticating, statusMessage }: AuthLoginForm
 
   const isBusy = isPending || isAuthenticating;
   const loginErrorMessage =
-    (error as AxiosError<AuthErrorResponse> | null)?.response?.data?.message ?? null;
+    (error as AxiosError<AuthErrorPayload> | null)?.response?.data?.message ?? null;
   const feedbackMessage = loginErrorMessage ?? statusMessage;
 
   const onSubmit = (values: LoginRequest) => {
@@ -43,7 +43,9 @@ export function AuthLoginForm({ isAuthenticating, statusMessage }: AuthLoginForm
     <div className="w-full max-w-md space-y-6">
       <div className="text-center">
         <h2 className="font-playfair text-3xl font-bold">Welcome</h2>
-        <p className="mt-2 text-sm">Sign in using your student portal account</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Use your institutional account to continue.
+        </p>
       </div>
 
       {feedbackMessage ? (
@@ -60,13 +62,7 @@ export function AuthLoginForm({ isAuthenticating, statusMessage }: AuthLoginForm
             render={({ field, fieldState }) => (
               <Field>
                 <FieldLabel htmlFor="username">Username</FieldLabel>
-                <Input
-                  {...field}
-                  id="username"
-                  type="text"
-                  placeholder="john@gmail.com"
-                  disabled={isBusy}
-                />
+                <Input {...field} id="username" type="text" placeholder="" disabled={isBusy} />
                 {fieldState.error ? <FieldError>{fieldState.error.message}</FieldError> : null}
               </Field>
             )}
@@ -119,7 +115,7 @@ export function AuthLoginForm({ isAuthenticating, statusMessage }: AuthLoginForm
               Signing in...
             </>
           ) : (
-            "Login"
+            "Sign in"
           )}
         </Button>
       </form>

--- a/app/auth/_hooks/use-auth-page-redirect.ts
+++ b/app/auth/_hooks/use-auth-page-redirect.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { startTransition, useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+type UseAuthPageRedirectParams = {
+  token: string | null;
+  isMePending: boolean;
+  isMeError: boolean;
+  hasProfile: boolean;
+  roleHome: string | null;
+  clearSession: () => void;
+  setUnsupportedRoleMessage: (message: string | null) => void;
+};
+
+export function useAuthPageRedirect({
+  token,
+  isMePending,
+  isMeError,
+  hasProfile,
+  roleHome,
+  clearSession,
+  setUnsupportedRoleMessage,
+}: UseAuthPageRedirectParams) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!token || isMePending) return;
+
+    if (isMeError) {
+      clearSession();
+      return;
+    }
+
+    if (roleHome) {
+      startTransition(() => {
+        setUnsupportedRoleMessage(null);
+      });
+      router.replace(roleHome);
+      return;
+    }
+
+    if (hasProfile) {
+      startTransition(() => {
+        setUnsupportedRoleMessage(
+          "Your account does not have a supported role for Faculytics yet. Contact your administrator."
+        );
+      });
+      clearSession();
+    }
+  }, [
+    clearSession,
+    hasProfile,
+    isMeError,
+    isMePending,
+    roleHome,
+    router,
+    setUnsupportedRoleMessage,
+    token,
+  ]);
+}

--- a/app/auth/_hooks/use-auth-page-redirect.ts
+++ b/app/auth/_hooks/use-auth-page-redirect.ts
@@ -3,21 +3,17 @@
 import { startTransition, useEffect } from "react";
 import { useRouter } from "next/navigation";
 
+import type { AuthSessionStatus } from "@/features/auth/hooks/use-auth-session-state";
+
 type UseAuthPageRedirectParams = {
-  token: string | null;
-  isMePending: boolean;
-  isMeError: boolean;
-  hasProfile: boolean;
+  status: AuthSessionStatus;
   roleHome: string | null;
   clearSession: () => void;
   setUnsupportedRoleMessage: (message: string | null) => void;
 };
 
 export function useAuthPageRedirect({
-  token,
-  isMePending,
-  isMeError,
-  hasProfile,
+  status,
   roleHome,
   clearSession,
   setUnsupportedRoleMessage,
@@ -25,14 +21,16 @@ export function useAuthPageRedirect({
   const router = useRouter();
 
   useEffect(() => {
-    if (!token || isMePending) return;
+    if (status === "signed-out" || status === "hydrating" || status === "loading-profile") {
+      return;
+    }
 
-    if (isMeError) {
+    if (status === "invalid-session") {
       clearSession();
       return;
     }
 
-    if (roleHome) {
+    if (status === "authenticated" && roleHome) {
       startTransition(() => {
         setUnsupportedRoleMessage(null);
       });
@@ -40,7 +38,7 @@ export function useAuthPageRedirect({
       return;
     }
 
-    if (hasProfile) {
+    if (status === "unsupported-role") {
       startTransition(() => {
         setUnsupportedRoleMessage(
           "Your account does not have a supported role for Faculytics yet. Contact your administrator."
@@ -48,14 +46,5 @@ export function useAuthPageRedirect({
       });
       clearSession();
     }
-  }, [
-    clearSession,
-    hasProfile,
-    isMeError,
-    isMePending,
-    roleHome,
-    router,
-    setUnsupportedRoleMessage,
-    token,
-  ]);
+  }, [clearSession, roleHome, router, setUnsupportedRoleMessage, status]);
 }

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { startTransition, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 import { AppBrand } from "@/components/layout/app-brand";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
@@ -12,42 +11,25 @@ import { branding } from "@/constants/branding";
 import { useAuthStore } from "@/stores/auth-store";
 
 import { AuthLoginForm } from "./_components/auth-login-form";
+import { useAuthPageRedirect } from "./_hooks/use-auth-page-redirect";
 
 export default function AuthPage() {
-  const router = useRouter();
   const { data: me, isPending: isMePending, isError: isMeError } = useMe();
   const { roleHome } = useActiveRole();
   const clearSession = useAuthStore((state) => state.clearSession);
   const token = useAuthStore((state) => state.token);
   const [unsupportedRoleMessage, setUnsupportedRoleMessage] = useState<string | null>(null);
   const isAuthenticating = Boolean(token) && isMePending;
-  const statusMessage = unsupportedRoleMessage;
 
-  useEffect(() => {
-    if (!token || isMePending) return;
-
-    if (isMeError) {
-      clearSession();
-      return;
-    }
-
-    if (roleHome) {
-      startTransition(() => {
-        setUnsupportedRoleMessage(null);
-      });
-      router.replace(roleHome);
-      return;
-    }
-
-    if (me) {
-      startTransition(() => {
-        setUnsupportedRoleMessage(
-          "Your account does not have a supported role for this app yet. Contact your administrator."
-        );
-      });
-      clearSession();
-    }
-  }, [clearSession, isMeError, isMePending, me, roleHome, router, token]);
+  useAuthPageRedirect({
+    token,
+    isMePending,
+    isMeError,
+    hasProfile: Boolean(me),
+    roleHome,
+    clearSession,
+    setUnsupportedRoleMessage,
+  });
 
   return (
     <div className="grid h-screen grid-cols-1 lg:grid-cols-10">
@@ -67,11 +49,10 @@ export default function AuthPage() {
           <div className="pointer-events-none absolute inset-0 z-50 flex flex-col justify-end p-16 text-white">
             <div className="mb-16 space-y-6">
               <h1 className="text-5xl font-playfair font-semibold leading-tight">
-                Data-driven decisions for better education
+                Faculty evaluation insights for academic teams
               </h1>
               <p className="max-w-lg text-xl font-medium opacity-90">
-                Powered by artificial intelligence to deliver real-time insights and smart
-                recommendations.
+                Track feedback, monitor teaching trends, and support better academic decisions.
               </p>
             </div>
             <div className="text-sm opacity-70">{branding.APP_COPYRIGHT}</div>
@@ -91,7 +72,10 @@ export default function AuthPage() {
         </div>
 
         <div className="flex grow items-center justify-center px-6 sm:px-10 lg:px-12">
-          <AuthLoginForm isAuthenticating={isAuthenticating} statusMessage={statusMessage} />
+          <AuthLoginForm
+            isAuthenticating={isAuthenticating}
+            statusMessage={unsupportedRoleMessage}
+          />
         </div>
       </div>
     </div>

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -5,8 +5,7 @@ import { useState } from "react";
 import { AppBrand } from "@/components/layout/app-brand";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
 import { BackgroundGradientAnimation } from "@/components/ui/background-gradient-animation";
-import { useActiveRole } from "@/features/auth/hooks/use-active-role";
-import { useMe } from "@/features/auth/hooks/use-me";
+import { useAuthSessionState } from "@/features/auth/hooks/use-auth-session-state";
 import { branding } from "@/constants/branding";
 import { useAuthStore } from "@/stores/auth-store";
 
@@ -14,18 +13,13 @@ import { AuthLoginForm } from "./_components/auth-login-form";
 import { useAuthPageRedirect } from "./_hooks/use-auth-page-redirect";
 
 export default function AuthPage() {
-  const { data: me, isPending: isMePending, isError: isMeError } = useMe();
-  const { roleHome } = useActiveRole();
+  const { roleHome, status } = useAuthSessionState();
   const clearSession = useAuthStore((state) => state.clearSession);
-  const token = useAuthStore((state) => state.token);
   const [unsupportedRoleMessage, setUnsupportedRoleMessage] = useState<string | null>(null);
-  const isAuthenticating = Boolean(token) && isMePending;
+  const isAuthenticating = status === "loading-profile";
 
   useAuthPageRedirect({
-    token,
-    isMePending,
-    isMeError,
-    hasProfile: Boolean(me),
+    status,
     roleHome,
     clearSession,
     setUnsupportedRoleMessage,

--- a/components/layout/role-switcher.tsx
+++ b/components/layout/role-switcher.tsx
@@ -22,10 +22,10 @@ type RoleSwitcherProps = {
 
 export function RoleSwitcher({ align = "end", className }: RoleSwitcherProps) {
   const router = useRouter();
-  const { activeRole, availableRoles, setActiveRole } = useActiveRole();
-  const setPendingRoleHome = useAuthStore((state) => state.setPendingRoleHome);
+  const { activeRole, roles, setActiveRole } = useActiveRole();
+  const setPendingRedirectPath = useAuthStore((state) => state.setPendingRedirectPath);
 
-  if (!activeRole || !availableRoles.length) {
+  if (!activeRole || !roles.length) {
     return null;
   }
 
@@ -37,7 +37,7 @@ export function RoleSwitcher({ align = "end", className }: RoleSwitcherProps) {
       return;
     }
 
-    setPendingRoleHome(nextHomePath);
+    setPendingRedirectPath(nextHomePath);
     setActiveRole(nextActiveRole);
     router.replace(nextHomePath);
   };
@@ -52,7 +52,7 @@ export function RoleSwitcher({ align = "end", className }: RoleSwitcherProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align={align} className="min-w-40">
         <DropdownMenuRadioGroup value={activeRole} onValueChange={handleRoleChange}>
-          {availableRoles.map((role) => (
+          {roles.map((role) => (
             <DropdownMenuRadioItem key={role} value={role}>
               {getRoleLabel(role)}
             </DropdownMenuRadioItem>

--- a/components/shared/app-loading-screen.tsx
+++ b/components/shared/app-loading-screen.tsx
@@ -8,9 +8,7 @@ type AppLoadingScreenProps = {
   message?: string;
 };
 
-export function AppLoadingScreen({
-  message = "Preparing your workspace...",
-}: AppLoadingScreenProps) {
+export function AppLoadingScreen({ message = "Loading your workspace..." }: AppLoadingScreenProps) {
   return (
     <div className="relative flex min-h-screen items-center justify-center overflow-hidden px-6">
       <div className="absolute inset-0 bg-background/40 backdrop-blur-xl" />

--- a/features/auth/api/auth.requests.ts
+++ b/features/auth/api/auth.requests.ts
@@ -1,42 +1,29 @@
 import { apiClient } from "@/network/axios";
 import { Endpoints } from "@/network/endpoints";
 
-import type { LoginRequest, RefreshTokenRequestBody } from "@/features/auth/types";
-import type { LoginResponse, LogoutResponse, MeResponse } from "@/features/auth/types";
+import type {
+  AuthSession,
+  LoginRequest,
+  LogoutResponse,
+  MeResponse,
+  RefreshTokenPayload,
+} from "@/features/auth/types";
 
-/**
- * Login a user with username and password.
- * @param payload Login credentials
- * @returns Login response containing access and refresh tokens
- */
 export async function login(payload: LoginRequest) {
-  const response = await apiClient.post<LoginResponse>(Endpoints.login, payload);
+  const response = await apiClient.post<AuthSession>(Endpoints.login, payload);
   return response.data;
 }
 
-/**
- * Fetch current user profile from active session token.
- * @returns User profile information
- */
 export async function fetchMe() {
   const response = await apiClient.get<MeResponse>(Endpoints.me);
   return response.data;
 }
 
-/**
- * Refresh authentication tokens using a refresh token.
- * @param payload Refresh token payload
- * @returns Next access and refresh tokens
- */
-export async function refreshToken(payload: RefreshTokenRequestBody) {
-  const response = await apiClient.post<LoginResponse>(Endpoints.refresh, payload);
+export async function refreshToken(payload: RefreshTokenPayload) {
+  const response = await apiClient.post<AuthSession>(Endpoints.refresh, payload);
   return response.data;
 }
 
-/**
- * Logout the current authenticated session.
- * @returns Empty response when logout succeeds
- */
 export async function logout() {
   const response = await apiClient.post<LogoutResponse>(Endpoints.logout);
   return response.data;

--- a/features/auth/hooks/use-active-role.ts
+++ b/features/auth/hooks/use-active-role.ts
@@ -13,35 +13,29 @@ import { useMe } from "@/features/auth/hooks/use-me";
 
 export function useActiveRole() {
   const { data: me, isPending, isError } = useMe();
-  const storedActiveRole = useAuthStore((state) => state.activeRole);
+  const persistedRole = useAuthStore((state) => state.activeRole);
   const setActiveRole = useAuthStore((state) => state.setActiveRole);
-  const rawRoles = useMemo(() => me?.roles ?? [], [me?.roles]);
-
-  const availableRoles = useMemo(() => getAvailableRoles(rawRoles), [rawRoles]);
-  const activeRole = useMemo(
-    () => resolveActiveRole(availableRoles, storedActiveRole),
-    [availableRoles, storedActiveRole]
-  );
+  const roles = useMemo(() => getAvailableRoles(me?.roles), [me?.roles]);
+  const activeRole = useMemo(() => resolveActiveRole(roles, persistedRole), [persistedRole, roles]);
   const roleHome = useMemo(
-    () => resolveHomeFromRoles(availableRoles, storedActiveRole),
-    [availableRoles, storedActiveRole]
+    () => resolveHomeFromRoles(roles, persistedRole),
+    [persistedRole, roles]
   );
 
   useEffect(() => {
     if (isPending || isError) return;
 
-    if (storedActiveRole !== activeRole) {
+    if (persistedRole !== activeRole) {
       setActiveRole(activeRole);
     }
-  }, [activeRole, isError, isPending, setActiveRole, storedActiveRole]);
+  }, [activeRole, isError, isPending, persistedRole, setActiveRole]);
 
   return {
     me,
-    roles: availableRoles,
+    roles,
     isPending,
     isError,
     activeRole,
-    availableRoles,
     roleHome,
     setActiveRole,
   };

--- a/features/auth/hooks/use-auth-session-state.ts
+++ b/features/auth/hooks/use-auth-session-state.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useAuthStore } from "@/stores/auth-store";
+
+import { useActiveRole } from "@/features/auth/hooks/use-active-role";
+
+export type AuthSessionStatus =
+  | "hydrating"
+  | "signed-out"
+  | "loading-profile"
+  | "invalid-session"
+  | "authenticated"
+  | "unsupported-role";
+
+export function useAuthSessionState() {
+  const hydrated = useAuthStore((state) => state.hydrated);
+  const token = useAuthStore((state) => state.token);
+  const activeRoleState = useActiveRole();
+  const { me, activeRole, roleHome, isPending, isError, roles } = activeRoleState;
+
+  let status: AuthSessionStatus;
+
+  if (!hydrated) {
+    status = "hydrating";
+  } else if (!token) {
+    status = "signed-out";
+  } else if (isPending) {
+    status = "loading-profile";
+  } else if (isError) {
+    status = "invalid-session";
+  } else if (activeRole && roleHome) {
+    status = "authenticated";
+  } else if (me) {
+    status = "unsupported-role";
+  } else {
+    status = "loading-profile";
+  }
+
+  return {
+    ...activeRoleState,
+    hydrated,
+    token,
+    roles,
+    status,
+  };
+}

--- a/features/auth/hooks/use-auth-session-state.ts
+++ b/features/auth/hooks/use-auth-session-state.ts
@@ -16,7 +16,7 @@ export function useAuthSessionState() {
   const hydrated = useAuthStore((state) => state.hydrated);
   const token = useAuthStore((state) => state.token);
   const activeRoleState = useActiveRole();
-  const { me, activeRole, roleHome, isPending, isError, roles } = activeRoleState;
+  const { me, activeRole, roleHome, isPending, isError } = activeRoleState;
 
   let status: AuthSessionStatus;
 
@@ -39,8 +39,6 @@ export function useAuthSessionState() {
   return {
     ...activeRoleState,
     hydrated,
-    token,
-    roles,
     status,
   };
 }

--- a/features/auth/hooks/use-login.ts
+++ b/features/auth/hooks/use-login.ts
@@ -6,10 +6,6 @@ import { login } from "@/features/auth/api/auth.requests";
 import { useAuthStore } from "@/stores/auth-store";
 import { useSelectedCourseStore } from "@/stores/selected-course-store";
 
-/**
- * Login mutation hook.
- * Handles API call, validation of token payload, and session persistence to Zustand.
- */
 export function useLogin() {
   const queryClient = useQueryClient();
   const setSession = useAuthStore((state) => state.setSession);

--- a/features/auth/hooks/use-me.ts
+++ b/features/auth/hooks/use-me.ts
@@ -4,10 +4,6 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchMe } from "@/features/auth/api/auth.requests";
 import { useAuthStore } from "@/stores/auth-store";
 
-/**
- * Query hook for current authenticated user.
- * Executes only when there is a token in Zustand.
- */
 export function useMe() {
   const token = useAuthStore((state) => state.token);
 

--- a/features/auth/index.ts
+++ b/features/auth/index.ts
@@ -1,5 +1,6 @@
 export * from "@/features/auth/api/auth.requests";
 export * from "@/features/auth/hooks/use-active-role";
+export * from "@/features/auth/hooks/use-auth-session-state";
 export * from "@/features/auth/hooks/use-login";
 export * from "@/features/auth/hooks/use-logout";
 export * from "@/features/auth/hooks/use-me";

--- a/features/auth/lib/role-route.ts
+++ b/features/auth/lib/role-route.ts
@@ -96,14 +96,14 @@ export function getAvailableRoles(roles?: readonly string[] | null): AppRole[] {
 }
 
 export function resolveActiveRole(roles?: readonly AppRole[] | null, activeRole?: AppRole | null) {
-  const availableRoles = roles ?? [];
-  if (!availableRoles.length) return null;
+  const resolvedRoles = roles ?? [];
+  if (!resolvedRoles.length) return null;
 
-  if (activeRole && availableRoles.includes(activeRole)) {
+  if (activeRole && resolvedRoles.includes(activeRole)) {
     return activeRole;
   }
 
-  return availableRoles[0];
+  return resolvedRoles[0];
 }
 
 export function resolveHomeFromRoles(

--- a/features/auth/types/index.ts
+++ b/features/auth/types/index.ts
@@ -3,19 +3,23 @@ export type LoginRequest = {
   password: string;
 };
 
-export type RefreshTokenRequestBody = {
+export type RefreshTokenPayload = {
   refreshToken: string;
 };
-export type LoginResponse = {
+
+export type AuthSession = {
   token: string;
   refreshToken: string;
 };
+
+export type LoginResponse = AuthSession;
+export type RefreshTokenRequestBody = RefreshTokenPayload;
 
 export type LogoutResponse = {
   message: string;
 };
 
-export type AuthErrorResponse = {
+export type AuthErrorPayload = {
   message: string;
   error: string;
   statusCode: number;

--- a/features/dimensions/components/dimension-async-content.tsx
+++ b/features/dimensions/components/dimension-async-content.tsx
@@ -27,7 +27,9 @@ export function DimensionAsyncContent({
     return (
       <div className="flex min-h-44 flex-col items-center justify-center rounded-lg border border-dashed px-6 text-center">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
-        <p className="mt-3 text-sm text-muted-foreground">Loading dimensions...</p>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Loading the dimensions for this questionnaire type...
+        </p>
       </div>
     );
   }
@@ -35,7 +37,9 @@ export function DimensionAsyncContent({
   if (isError) {
     return (
       <div className="flex min-h-44 flex-col items-center justify-center rounded-lg border border-dashed px-6 text-center">
-        <p className="max-w-xl text-sm text-muted-foreground">Unable to load dimensions.</p>
+        <p className="max-w-xl text-sm text-muted-foreground">
+          The dimensions could not be loaded right now.
+        </p>
         <Button type="button" variant="outline" className="mt-5" onClick={onRetry}>
           Retry
         </Button>

--- a/features/dimensions/components/dimension-create-dialog.tsx
+++ b/features/dimensions/components/dimension-create-dialog.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { AxiosError } from "axios";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ChevronDown, Loader2 } from "lucide-react";
 import { Controller, useForm } from "react-hook-form";
@@ -25,6 +24,7 @@ import {
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { useCreateDimension } from "@/features/dimensions/hooks/use-create-dimension";
+import { resolveCreateDimensionErrorMessage } from "@/features/dimensions/lib/action-errors";
 import {
   createDimensionSchema,
   type CreateDimensionFormValues,
@@ -61,10 +61,7 @@ export function DimensionCreateDialog({ open, onOpenChange }: DimensionCreateDia
       form.reset();
       onOpenChange(false);
     } catch (error) {
-      const message =
-        (error as AxiosError<{ message: string }>)?.response?.data?.message ??
-        "Unable to create dimension.";
-      toast.error(message);
+      toast.error(resolveCreateDimensionErrorMessage(error, "The dimension could not be created."));
     }
   };
 
@@ -80,9 +77,9 @@ export function DimensionCreateDialog({ open, onOpenChange }: DimensionCreateDia
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Create Dimension</DialogTitle>
+          <DialogTitle>Create dimension</DialogTitle>
           <DialogDescription>
-            Add a new dimension code for questionnaire sections.
+            Add a dimension code and assign it to the questionnaire type where it should be used.
           </DialogDescription>
         </DialogHeader>
 
@@ -96,7 +93,7 @@ export function DimensionCreateDialog({ open, onOpenChange }: DimensionCreateDia
                   <FieldLabel>Display Name</FieldLabel>
                   <Input
                     {...field}
-                    placeholder="e.g. Classroom Management"
+                    placeholder="e.g. Classroom management"
                     aria-invalid={fieldState.invalid}
                   />
                   {fieldState.error?.message ? (
@@ -123,7 +120,7 @@ export function DimensionCreateDialog({ open, onOpenChange }: DimensionCreateDia
                         {field.value
                           ? (typeSummaries.find((t) => t.id === field.value)?.name ??
                             "Unknown type")
-                          : "Select a type"}
+                          : "Select a questionnaire type"}
                         <ChevronDown className="size-4 text-muted-foreground" />
                       </Button>
                     </DropdownMenuTrigger>
@@ -187,7 +184,7 @@ export function DimensionCreateDialog({ open, onOpenChange }: DimensionCreateDia
                   Creating...
                 </>
               ) : (
-                "Create"
+                "Create dimension"
               )}
             </Button>
           </DialogFooter>

--- a/features/dimensions/components/dimension-edit-dialog.tsx
+++ b/features/dimensions/components/dimension-edit-dialog.tsx
@@ -78,9 +78,10 @@ export function DimensionEditDialog({ open, onOpenChange, dimension }: Dimension
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Edit Dimension</DialogTitle>
+          <DialogTitle>Edit dimension</DialogTitle>
           <DialogDescription>
-            Update the display name for <strong>{dimension?.code}</strong>.
+            Update the display name for <strong>{dimension?.code}</strong>. The dimension code stays
+            the same.
           </DialogDescription>
         </DialogHeader>
 
@@ -92,7 +93,11 @@ export function DimensionEditDialog({ open, onOpenChange, dimension }: Dimension
               render={({ field, fieldState }) => (
                 <Field>
                   <FieldLabel>Display Name</FieldLabel>
-                  <Input {...field} aria-invalid={fieldState.invalid} />
+                  <Input
+                    {...field}
+                    aria-invalid={fieldState.invalid}
+                    placeholder="e.g. Classroom management"
+                  />
                   {fieldState.error?.message ? (
                     <FieldError>{fieldState.error.message}</FieldError>
                   ) : null}
@@ -120,7 +125,7 @@ export function DimensionEditDialog({ open, onOpenChange, dimension }: Dimension
                   Saving...
                 </>
               ) : (
-                "Save"
+                "Save changes"
               )}
             </Button>
           </DialogFooter>

--- a/features/dimensions/components/dimension-table.tsx
+++ b/features/dimensions/components/dimension-table.tsx
@@ -40,7 +40,7 @@ export function DimensionTable({
             <TableHead className="data-table-head w-[15%]">Code</TableHead>
             <TableHead className="data-table-head w-[15%]">Status</TableHead>
             <TableHead className="data-table-head w-[25%]">Type</TableHead>
-            <TableHead className="data-table-head w-[15%]">Action</TableHead>
+            <TableHead className="data-table-head w-[15%]">Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/features/dimensions/components/dimension-toolbar.tsx
+++ b/features/dimensions/components/dimension-toolbar.tsx
@@ -125,7 +125,7 @@ export function DimensionToolbar({
           </DropdownMenu>
 
           <Button type="button" variant="brand" className="w-full min-w-0" onClick={onCreateClick}>
-            Create Dimension
+            New dimension
           </Button>
         </div>
       </div>
@@ -166,7 +166,7 @@ export function DimensionToolbar({
 
         <div className="flex min-w-0 flex-1 flex-wrap items-center justify-end gap-3">
           <Button type="button" variant="brand" className="shrink-0" onClick={onCreateClick}>
-            Create Dimension
+            New dimension
           </Button>
 
           <div className="relative min-w-[15rem] flex-1 lg:max-w-xs xl:max-w-sm">

--- a/features/dimensions/hooks/use-dimension-list-page.ts
+++ b/features/dimensions/hooks/use-dimension-list-page.ts
@@ -1,108 +1,66 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { toast } from "sonner";
+import { useEffect, useMemo, useState } from "react";
 
 import { useDimensionList } from "@/features/dimensions/hooks/use-dimension-list";
-import { useToggleDimensionStatus } from "@/features/dimensions/hooks/use-toggle-dimension-status";
+import { useDimensionListRouteState } from "@/features/dimensions/hooks/use-dimension-list-route-state";
+import { useDimensionToggleFlow } from "@/features/dimensions/hooks/use-dimension-toggle-flow";
 import type { Dimension, ListDimensionsRequest } from "@/features/dimensions/types";
-import type {
-  DimensionStatusFilter,
-  TypeFilter,
-} from "@/features/dimensions/components/dimension-toolbar";
-import { DEFAULT_QUESTIONNAIRE_TYPE } from "@/features/questionnaires/constants";
-import { useQuestionnaireTypeId } from "@/features/questionnaires/hooks/use-questionnaire-type-id";
 import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
-import { resolvePageSizeOption } from "@/lib/pagination";
 import {
   buildQuestionnaireTypeOptions,
   resolveActiveQuestionnaireType,
 } from "@/features/questionnaires/lib/questionnaire-type-options";
+import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
 import { normalizeTypeSearchParam } from "@/features/questionnaires/lib/questionnaire-type-routing";
 
-type DimensionAction = { type: "toggle"; dimension: Dimension } | null;
-
-function resolveTypeFilter(value: string | null): TypeFilter {
-  if (value && value.trim().length > 0) {
-    return value;
-  }
-
-  return DEFAULT_QUESTIONNAIRE_TYPE;
-}
-
-function resolveStatusFilter(value: string | null): DimensionStatusFilter {
-  if (value === "ACTIVE" || value === "INACTIVE" || value === "ALL") {
-    return value;
-  }
-
-  return "ALL";
-}
-
-function resolvePositiveNumber(value: string | null, fallback: number) {
-  if (!value) return fallback;
-
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
-}
+const EMPTY_TYPE_SUMMARIES: QuestionnaireTypeSummary[] = [];
 
 export function useDimensionListPage() {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   const [createOpen, setCreateOpen] = useState(false);
   const [editDimension, setEditDimension] = useState<Dimension | null>(null);
-  const [dimensionAction, setDimensionAction] = useState<DimensionAction>(null);
-
-  const typeFilter = resolveTypeFilter(searchParams.get("type"));
-  const statusFilter = resolveStatusFilter(searchParams.get("status"));
-  const page = resolvePositiveNumber(searchParams.get("page"), 1);
-  const pageSize = resolvePageSizeOption(searchParams.get("pageSize"));
-
-  // Local search state — only syncs to URL after debounce
-  const urlSearch = searchParams.get("search") ?? "";
-  const [searchValue, setSearchValue] = useState(urlSearch);
-  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Sync local state when URL changes externally (e.g. "Clear filters")
-  useEffect(() => {
-    setSearchValue(urlSearch);
-  }, [urlSearch]);
-
-  // Cleanup timer on unmount
-  useEffect(() => {
-    return () => {
-      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
-    };
-  }, []);
+  const {
+    dimensionAction,
+    toggleDialogConfig,
+    isTogglePending,
+    setDimensionAction,
+    onConfirmToggle,
+  } = useDimensionToggleFlow();
 
   // Fetch questionnaire types to resolve code → UUID
   const questionnaireTypesQuery = useQuestionnaireTypes();
-  const typeSummaries = questionnaireTypesQuery.data ?? [];
-  const availableTypeOptions = buildQuestionnaireTypeOptions(typeSummaries);
+  const typeSummaries = questionnaireTypesQuery.data ?? EMPTY_TYPE_SUMMARIES;
+  const availableTypeOptions = useMemo(
+    () => buildQuestionnaireTypeOptions(typeSummaries),
+    [typeSummaries]
+  );
+  const routeState = useDimensionListRouteState();
+  const { statusFilter, page, pageSize, searchValue } = routeState;
   const activeTypeFilter = resolveActiveQuestionnaireType({
-    requestedType: typeFilter,
+    requestedType: routeState.typeFilter,
     availableTypeOptions,
     isResolved: questionnaireTypesQuery.isSuccess,
   });
-  const typeFilterId = useQuestionnaireTypeId(activeTypeFilter);
+  const typeFilterId = useMemo(
+    () => typeSummaries.find((summary) => summary.code === activeTypeFilter)?.id ?? null,
+    [activeTypeFilter, typeSummaries]
+  );
 
   useEffect(() => {
     normalizeTypeSearchParam({
       isResolved: questionnaireTypesQuery.isSuccess,
-      currentTypeParam: searchParams.get("type"),
+      currentTypeParam: routeState.searchParams.get("type"),
       normalizedType: activeTypeFilter,
-      pathname,
-      searchParams,
-      router,
+      pathname: routeState.pathname,
+      searchParams: routeState.searchParams,
+      router: routeState.router,
     });
   }, [
     activeTypeFilter,
-    pathname,
     questionnaireTypesQuery.isSuccess,
-    router,
-    searchParams,
-    typeFilter,
+    routeState.pathname,
+    routeState.router,
+    routeState.searchParams,
   ]);
 
   // Fetch all dimensions for the questionnaire type so search works across all items
@@ -116,7 +74,6 @@ export function useDimensionListPage() {
   const dimensionListQuery = useDimensionList(queryParams, {
     enabled: questionnaireTypesQuery.isSuccess && typeFilterId !== null,
   });
-  const toggleStatusMutation = useToggleDimensionStatus();
 
   const allRows = dimensionListQuery.data?.data ?? [];
 
@@ -152,102 +109,6 @@ export function useDimensionListPage() {
     itemCount: filteredRows.length,
   };
 
-  const updateSearchParams = (updates: Record<string, string | null>) => {
-    const params = new URLSearchParams(searchParams.toString());
-
-    Object.entries(updates).forEach(([key, value]) => {
-      if (value === null || value === "") {
-        params.delete(key);
-        return;
-      }
-
-      params.set(key, value);
-    });
-
-    const nextQuery = params.toString();
-    router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname);
-  };
-
-  const handleTypeFilterChange = (value: TypeFilter) => {
-    updateSearchParams({
-      type: value,
-      page: "1",
-    });
-  };
-
-  const handleStatusFilterChange = (value: DimensionStatusFilter) => {
-    updateSearchParams({
-      status: value === "ALL" ? null : value,
-      page: "1",
-    });
-  };
-
-  const handleSearchChange = useCallback(
-    (value: string) => {
-      setSearchValue(value);
-
-      if (searchTimerRef.current) {
-        clearTimeout(searchTimerRef.current);
-      }
-
-      searchTimerRef.current = setTimeout(() => {
-        updateSearchParams({
-          search: value.trim().length > 0 ? value : null,
-          page: "1",
-        });
-      }, 300);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [pathname, searchParams]
-  );
-
-  const handlePageChange = (nextPage: number) => {
-    updateSearchParams({
-      page: String(nextPage),
-    });
-  };
-
-  const handlePageSizeChange = (size: number) => {
-    updateSearchParams({
-      pageSize: String(size),
-      page: "1",
-    });
-  };
-
-  const handleConfirmToggle = async () => {
-    if (!dimensionAction) return;
-
-    const { dimension } = dimensionAction;
-    const action = dimension.active ? "deactivated" : "activated";
-
-    try {
-      await toggleStatusMutation.mutateAsync({
-        id: dimension.id,
-        active: dimension.active,
-      });
-      toast.success(`Dimension ${action}.`);
-      setDimensionAction(null);
-    } catch {
-      toast.error(`Unable to ${dimension.active ? "deactivate" : "activate"} dimension.`);
-    }
-  };
-
-  const toggleDialogConfig = dimensionAction
-    ? dimensionAction.dimension.active
-      ? {
-          title: `Deactivate "${dimensionAction.dimension.displayName}"?`,
-          description: "This dimension will no longer be selectable in the questionnaire builder.",
-          confirmLabel: "Deactivate",
-          confirmVariant: "destructive" as const,
-        }
-      : {
-          title: `Activate "${dimensionAction.dimension.displayName}"?`,
-          description: "This dimension will become selectable again in the questionnaire builder.",
-          confirmLabel: "Activate",
-          confirmVariant: "brand" as const,
-        }
-    : null;
-
   return {
     typeFilter: activeTypeFilter,
     statusFilter,
@@ -264,16 +125,16 @@ export function useDimensionListPage() {
     editDimension,
     dimensionAction,
     toggleDialogConfig,
-    isTogglePending: toggleStatusMutation.isPending,
+    isTogglePending,
     setCreateOpen,
     setEditDimension,
     setDimensionAction,
-    onTypeFilterChange: handleTypeFilterChange,
-    onStatusFilterChange: handleStatusFilterChange,
-    onSearchChange: handleSearchChange,
-    onPageChange: handlePageChange,
-    onPageSizeChange: handlePageSizeChange,
-    onConfirmToggle: handleConfirmToggle,
+    onTypeFilterChange: routeState.onTypeFilterChange,
+    onStatusFilterChange: routeState.onStatusFilterChange,
+    onSearchChange: routeState.onSearchChange,
+    onPageSizeChange: routeState.onPageSizeChange,
+    onClearFilters: routeState.onClearFilters,
+    onConfirmToggle,
     onRetry: () => {
       void questionnaireTypesQuery.refetch();
       void dimensionListQuery.refetch();

--- a/features/dimensions/hooks/use-dimension-list-route-state.ts
+++ b/features/dimensions/hooks/use-dimension-list-route-state.ts
@@ -1,0 +1,147 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import type {
+  DimensionStatusFilter,
+  TypeFilter,
+} from "@/features/dimensions/components/dimension-toolbar";
+import { DEFAULT_QUESTIONNAIRE_TYPE } from "@/features/questionnaires/constants";
+import { resolvePageSizeOption } from "@/lib/pagination";
+
+function resolveTypeFilter(value: string | null): TypeFilter {
+  if (value && value.trim().length > 0) {
+    return value;
+  }
+
+  return DEFAULT_QUESTIONNAIRE_TYPE;
+}
+
+function resolveStatusFilter(value: string | null): DimensionStatusFilter {
+  if (value === "ACTIVE" || value === "INACTIVE" || value === "ALL") {
+    return value;
+  }
+
+  return "ALL";
+}
+
+function resolvePositiveNumber(value: string | null, fallback: number) {
+  if (!value) return fallback;
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function useDimensionListRouteState() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const typeFilter = resolveTypeFilter(searchParams.get("type"));
+  const statusFilter = resolveStatusFilter(searchParams.get("status"));
+  const page = resolvePositiveNumber(searchParams.get("page"), 1);
+  const pageSize = resolvePageSizeOption(searchParams.get("pageSize"));
+  const urlSearch = searchParams.get("search") ?? "";
+  const [searchValue, setSearchValue] = useState(urlSearch);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setSearchValue(urlSearch);
+  }, [urlSearch]);
+
+  useEffect(() => {
+    return () => {
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+    };
+  }, []);
+
+  const updateSearchParams = useCallback(
+    (updates: Record<string, string | null>) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value === null || value === "") {
+          params.delete(key);
+          return;
+        }
+
+        params.set(key, value);
+      });
+
+      const nextQuery = params.toString();
+      router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname);
+    },
+    [pathname, router, searchParams]
+  );
+
+  const handleTypeFilterChange = (value: TypeFilter) => {
+    updateSearchParams({
+      type: value,
+      page: "1",
+    });
+  };
+
+  const handleStatusFilterChange = (value: DimensionStatusFilter) => {
+    updateSearchParams({
+      status: value === "ALL" ? null : value,
+      page: "1",
+    });
+  };
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchValue(value);
+
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+
+      searchTimerRef.current = setTimeout(() => {
+        updateSearchParams({
+          search: value.trim().length > 0 ? value : null,
+          page: "1",
+        });
+      }, 300);
+    },
+    [updateSearchParams]
+  );
+
+  const handlePageSizeChange = (size: number) => {
+    updateSearchParams({
+      pageSize: String(size),
+      page: "1",
+    });
+  };
+
+  const handleClearFilters = () => {
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = null;
+    }
+
+    setSearchValue("");
+    updateSearchParams({
+      search: null,
+      status: null,
+      page: "1",
+    });
+  };
+
+  return {
+    pathname,
+    router,
+    searchParams,
+    typeFilter,
+    statusFilter,
+    page,
+    pageSize,
+    searchValue,
+    onTypeFilterChange: handleTypeFilterChange,
+    onStatusFilterChange: handleStatusFilterChange,
+    onSearchChange: handleSearchChange,
+    onPageSizeChange: handlePageSizeChange,
+    onClearFilters: handleClearFilters,
+  };
+}

--- a/features/dimensions/hooks/use-dimension-toggle-flow.ts
+++ b/features/dimensions/hooks/use-dimension-toggle-flow.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { useToggleDimensionStatus } from "@/features/dimensions/hooks/use-toggle-dimension-status";
+import type { Dimension } from "@/features/dimensions/types";
+
+type DimensionAction = { type: "toggle"; dimension: Dimension } | null;
+
+export function useDimensionToggleFlow() {
+  const [dimensionAction, setDimensionAction] = useState<DimensionAction>(null);
+  const toggleStatusMutation = useToggleDimensionStatus();
+
+  const handleConfirmToggle = async () => {
+    if (!dimensionAction) {
+      return;
+    }
+
+    const { dimension } = dimensionAction;
+    const action = dimension.active ? "deactivated" : "activated";
+
+    try {
+      await toggleStatusMutation.mutateAsync({
+        id: dimension.id,
+        active: dimension.active,
+      });
+      toast.success(`Dimension ${action}.`);
+      setDimensionAction(null);
+    } catch {
+      toast.error(`Unable to ${dimension.active ? "deactivate" : "activate"} dimension.`);
+    }
+  };
+
+  const toggleDialogConfig = dimensionAction
+    ? dimensionAction.dimension.active
+      ? {
+          title: `Deactivate "${dimensionAction.dimension.displayName}"?`,
+          description: "This dimension will no longer be selectable in the questionnaire builder.",
+          confirmLabel: "Deactivate",
+          confirmVariant: "destructive" as const,
+        }
+      : {
+          title: `Activate "${dimensionAction.dimension.displayName}"?`,
+          description: "This dimension will become selectable again in the questionnaire builder.",
+          confirmLabel: "Activate",
+          confirmVariant: "brand" as const,
+        }
+    : null;
+
+  return {
+    dimensionAction,
+    toggleDialogConfig,
+    isTogglePending: toggleStatusMutation.isPending,
+    setDimensionAction,
+    onConfirmToggle: handleConfirmToggle,
+  };
+}

--- a/features/questionnaires/components/builder/questionnaire-builder-shell.tsx
+++ b/features/questionnaires/components/builder/questionnaire-builder-shell.tsx
@@ -59,7 +59,7 @@ export function QuestionnaireBuilderShell({
   } = useQuestionnaireBuilderController({ activeType });
 
   if (!isHydrated || !draft || !previewModel) {
-    return <Card className="p-6 text-sm text-muted-foreground">Loading builder draft...</Card>;
+    return <Card className="p-6 text-sm text-muted-foreground">Loading the current draft...</Card>;
   }
 
   const hasExistingQuestionnaire = Boolean(draft.metadata.questionnaireId);
@@ -85,8 +85,8 @@ export function QuestionnaireBuilderShell({
               <div className="flex items-center justify-between gap-3">
                 <p className="text-xs text-muted-foreground">
                   {hasExistingQuestionnaire
-                    ? "Questionnaire Title"
-                    : "Set the questionnaire title before creating the first draft version."}
+                    ? "Questionnaire title"
+                    : "Add a questionnaire title before creating the first saved draft."}
                 </p>
                 {statusBadge ? <div className="shrink-0 xl:hidden">{statusBadge}</div> : null}
               </div>
@@ -214,7 +214,7 @@ export function QuestionnaireBuilderShell({
         open={discardDialogOpen}
         onOpenChange={setDiscardDialogOpen}
         title="Discard unsaved changes?"
-        description="This discards changes that have not been saved to the backend and restores the last synced draft state for this questionnaire type."
+        description="This will discard unsaved changes and restore the last saved draft for this questionnaire type."
         cancelLabel="Keep editing"
         confirmLabel="Discard changes"
         confirmVariant="destructive"
@@ -235,7 +235,7 @@ export function QuestionnaireBuilderShell({
                 pendingConversionState.questionCount === 1 ? "" : "s"
               } will be removed.`
             : ""
-        }${pendingConversionState.hasWeight ? " This section weight will also be cleared." : ""}`}
+        }${pendingConversionState.hasWeight ? " The section weight will also be cleared." : ""}`}
         cancelLabel="Cancel"
         confirmLabel="Convert section"
         onConfirm={handleConfirmParentConversion}
@@ -245,7 +245,7 @@ export function QuestionnaireBuilderShell({
         open={saveDialogOpen}
         onOpenChange={setSaveDialogOpen}
         title="Questionnaire draft saved"
-        description="Your changes were saved successfully. You can keep editing here or go back to the questionnaire list."
+        description="Your changes were saved. You can keep editing here or return to the questionnaire list."
         cancelLabel="Keep editing"
         confirmLabel="Go back to questionnaires"
         onConfirm={() => {

--- a/features/questionnaires/components/questionnaire-error-state.tsx
+++ b/features/questionnaires/components/questionnaire-error-state.tsx
@@ -7,9 +7,11 @@ type QuestionnaireErrorStateProps = {
 export function QuestionnaireErrorState({ onRetry }: QuestionnaireErrorStateProps) {
   return (
     <div className="flex min-h-44 flex-col items-center justify-center px-6 text-center">
-      <p className="max-w-xl text-sm text-muted-foreground">Unable to load questionnaires.</p>
+      <p className="max-w-xl text-sm text-muted-foreground">
+        Questionnaire data could not be loaded right now.
+      </p>
       <Button type="button" variant="outline" className="mt-5" onClick={onRetry}>
-        Retry
+        Reload
       </Button>
     </div>
   );

--- a/features/questionnaires/components/questionnaire-list-toolbar.tsx
+++ b/features/questionnaires/components/questionnaire-list-toolbar.tsx
@@ -98,9 +98,11 @@ export function QuestionnaireListToolbar({
         },
         onError: (error) => {
           if (isAxiosErrorWithStatus(error, 409)) {
-            toast.error("A draft already exists — edit it or deprecate it first.");
+            toast.error(
+              "A draft already exists for this questionnaire type. Open it or deprecate it first."
+            );
           } else {
-            toast.error("Failed to create version from template.");
+            toast.error("The draft could not be created from the selected version.");
           }
         },
       }
@@ -175,9 +177,9 @@ export function QuestionnaireListToolbar({
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Create new draft</DialogTitle>
+            <DialogTitle>Create a draft</DialogTitle>
             <DialogDescription>
-              Start from scratch or use a previous version as a template.
+              Start a new draft from scratch or copy an existing version as a starting point.
             </DialogDescription>
           </DialogHeader>
 
@@ -202,6 +204,7 @@ export function QuestionnaireListToolbar({
             {choice === "template" && (
               <div className="space-y-2">
                 <Label htmlFor="template-version-select">Select version</Label>
+
                 <select
                   id="template-version-select"
                   value={selectedVersionId}

--- a/features/questionnaires/components/questionnaire-loading-state.tsx
+++ b/features/questionnaires/components/questionnaire-loading-state.tsx
@@ -6,7 +6,7 @@ export function QuestionnaireLoadingState() {
   return (
     <div className="flex min-h-44 flex-col items-center justify-center px-6 text-center">
       <Loader2 className="size-6 animate-spin text-muted-foreground" />
-      <p className="mt-3 text-sm text-muted-foreground">Loading questionnaires...</p>
+      <p className="mt-3 text-sm text-muted-foreground">Loading questionnaire versions...</p>
     </div>
   );
 }

--- a/features/questionnaires/components/questionnaire-rating-scale-instructions.tsx
+++ b/features/questionnaires/components/questionnaire-rating-scale-instructions.tsx
@@ -27,9 +27,9 @@ export function QuestionnaireRatingScaleInstructions() {
   return (
     <Card className="border-brand-yellow/90 bg-brand-yellow/30">
       <CardHeader>
-        <CardTitle className="font-playfair text-lg">Rating Scale Instructions</CardTitle>
+        <CardTitle className="font-playfair text-lg">Rating scale</CardTitle>
         <CardDescription className="text-primary">
-          Please rate each statement using the following scale:
+          Use this scale when reviewing each quantitative statement.
         </CardDescription>
       </CardHeader>
       <CardContent className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-5">

--- a/features/questionnaires/components/questionnaire-type-create-dialog.tsx
+++ b/features/questionnaires/components/questionnaire-type-create-dialog.tsx
@@ -57,7 +57,7 @@ export function QuestionnaireTypeCreateDialog({
       toast.error(
         resolveCreateQuestionnaireTypeManagementErrorMessage(
           error,
-          "Unable to create questionnaire type."
+          "The questionnaire type could not be created."
         )
       );
     }
@@ -75,9 +75,9 @@ export function QuestionnaireTypeCreateDialog({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Create Questionnaire Type</DialogTitle>
+          <DialogTitle>Create questionnaire type</DialogTitle>
           <DialogDescription>
-            Add a custom questionnaire type for Super Admin management.
+            Add a custom questionnaire type for questionnaire creation and version management.
           </DialogDescription>
         </DialogHeader>
 
@@ -159,7 +159,7 @@ export function QuestionnaireTypeCreateDialog({
                   Creating...
                 </>
               ) : (
-                "Create"
+                "Create type"
               )}
             </Button>
           </DialogFooter>

--- a/features/questionnaires/components/questionnaire-type-edit-dialog.tsx
+++ b/features/questionnaires/components/questionnaire-type-edit-dialog.tsx
@@ -72,7 +72,7 @@ export function QuestionnaireTypeEditDialog({
       form.reset();
       onOpenChange(false);
     } catch (error) {
-      toast.error(resolveApiErrorMessage(error, "Unable to update questionnaire type."));
+      toast.error(resolveApiErrorMessage(error, "The questionnaire type could not be updated."));
     }
   };
 
@@ -88,10 +88,10 @@ export function QuestionnaireTypeEditDialog({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Edit Questionnaire Type</DialogTitle>
+          <DialogTitle>Edit questionnaire type</DialogTitle>
           <DialogDescription>
-            Update the metadata for <strong>{questionnaireType?.code}</strong>. The type code is
-            immutable after creation.
+            Update the metadata for <strong>{questionnaireType?.code}</strong>. The type code cannot
+            be changed after creation.
           </DialogDescription>
         </DialogHeader>
 
@@ -152,7 +152,7 @@ export function QuestionnaireTypeEditDialog({
                   Saving...
                 </>
               ) : (
-                "Save"
+                "Save changes"
               )}
             </Button>
           </DialogFooter>

--- a/features/questionnaires/components/questionnaire-type-management-error-state.tsx
+++ b/features/questionnaires/components/questionnaire-type-management-error-state.tsx
@@ -9,9 +9,11 @@ export function QuestionnaireTypeManagementErrorState({
 }: QuestionnaireTypeManagementErrorStateProps) {
   return (
     <div className="flex min-h-44 flex-col items-center justify-center px-6 text-center">
-      <p className="max-w-xl text-sm text-muted-foreground">Unable to load questionnaire types.</p>
+      <p className="max-w-xl text-sm text-muted-foreground">
+        Questionnaire types could not be loaded right now.
+      </p>
       <Button type="button" variant="outline" className="mt-5" onClick={onRetry}>
-        Retry
+        Reload
       </Button>
     </div>
   );

--- a/features/questionnaires/components/questionnaire-type-management-toolbar.tsx
+++ b/features/questionnaires/components/questionnaire-type-management-toolbar.tsx
@@ -74,14 +74,14 @@ export function QuestionnaireTypeManagementToolbar({
           </DropdownMenu>
 
           <Button type="button" variant="brand" className="w-full min-w-0" onClick={onCreateClick}>
-            Create Type
+            Create type
           </Button>
         </div>
       </div>
 
       <div className="hidden items-center justify-end gap-3 lg:flex">
         <Button type="button" variant="brand" onClick={onCreateClick}>
-          Create Type
+          Create type
         </Button>
 
         <div className="relative w-full min-w-0 lg:w-2/5 lg:flex-none xl:w-1/5">

--- a/features/questionnaires/hooks/use-questionnaire-builder-controller.ts
+++ b/features/questionnaires/hooks/use-questionnaire-builder-controller.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
 
 import { MAX_SECTION_NESTING_LEVEL } from "@/features/questionnaires/constants/builder";
 import { useBuilderUiState } from "@/features/questionnaires/hooks/use-builder-ui-state";
@@ -22,20 +23,39 @@ type UseQuestionnaireBuilderControllerOptions = {
 export function useQuestionnaireBuilderController({
   activeType,
 }: UseQuestionnaireBuilderControllerOptions) {
-  const draft = useQuestionnaireBuilderStore((state) => state.drafts[activeType] ?? null);
-  const updateTitle = useQuestionnaireBuilderStore((state) => state.updateTitle);
-  const selectSection = useQuestionnaireBuilderStore((state) => state.selectSection);
-  const addRootSection = useQuestionnaireBuilderStore((state) => state.addRootSection);
-  const addChildSection = useQuestionnaireBuilderStore((state) => state.addChildSection);
-  const updateSection = useQuestionnaireBuilderStore((state) => state.updateSection);
-  const removeSection = useQuestionnaireBuilderStore((state) => state.removeSection);
-  const moveSection = useQuestionnaireBuilderStore((state) => state.moveSection);
-  const addQuestion = useQuestionnaireBuilderStore((state) => state.addQuestion);
-  const updateQuestion = useQuestionnaireBuilderStore((state) => state.updateQuestion);
-  const removeQuestion = useQuestionnaireBuilderStore((state) => state.removeQuestion);
-  const updateQualitative = useQuestionnaireBuilderStore((state) => state.updateQualitative);
-  const resetActiveDraft = useQuestionnaireBuilderStore((state) => state.resetActiveDraft);
-  const hasUnsavedChanges = useQuestionnaireBuilderStore((state) => state.hasUnsavedChanges);
+  const {
+    draft,
+    updateTitle,
+    selectSection,
+    addRootSection,
+    addChildSection,
+    updateSection,
+    removeSection,
+    moveSection,
+    addQuestion,
+    updateQuestion,
+    removeQuestion,
+    updateQualitative,
+    resetActiveDraft,
+    hasUnsavedChanges,
+  } = useQuestionnaireBuilderStore(
+    useShallow((state) => ({
+      draft: state.drafts[activeType] ?? null,
+      updateTitle: state.updateTitle,
+      selectSection: state.selectSection,
+      addRootSection: state.addRootSection,
+      addChildSection: state.addChildSection,
+      updateSection: state.updateSection,
+      removeSection: state.removeSection,
+      moveSection: state.moveSection,
+      addQuestion: state.addQuestion,
+      updateQuestion: state.updateQuestion,
+      removeQuestion: state.removeQuestion,
+      updateQualitative: state.updateQualitative,
+      resetActiveDraft: state.resetActiveDraft,
+      hasUnsavedChanges: state.hasUnsavedChanges,
+    }))
+  );
   const { save, isPending } = useSaveQuestionnaireBuilder();
   const ui = useBuilderUiState();
 

--- a/features/questionnaires/hooks/use-questionnaire-builder-controller.ts
+++ b/features/questionnaires/hooks/use-questionnaire-builder-controller.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { MAX_SECTION_NESTING_LEVEL } from "@/features/questionnaires/constants/builder";
 import { useBuilderUiState } from "@/features/questionnaires/hooks/use-builder-ui-state";
@@ -69,10 +69,16 @@ export function useQuestionnaireBuilderController({
   }, [draft?.selectedSectionId, pendingScrollToSection, clearPendingScrollToSection]);
 
   // Always compute live — used for totalLeafWeight, and for error display after first save attempt.
-  const liveValidation = draft ? validateQuestionnaireBuilderDraft(draft) : null;
+  const liveValidation = useMemo(
+    () => (draft ? validateQuestionnaireBuilderDraft(draft) : null),
+    [draft]
+  );
   const validation = hasAttemptedSave ? liveValidation : null;
 
-  const previewModel = draft ? buildQuestionnairePreviewModel(draft) : null;
+  const previewModel = useMemo(
+    () => (draft ? buildQuestionnairePreviewModel(draft) : null),
+    [draft]
+  );
   const isDirty = hasUnsavedChanges();
   const isSaved = !isDirty && Boolean(draft?.metadata.versionId);
   const pendingConversionState = canConvertSectionToParent(
@@ -117,9 +123,9 @@ export function useQuestionnaireBuilderController({
   const handleSave = async () => {
     if (draft) {
       setHasAttemptedSave(true);
-      const result = validateQuestionnaireBuilderDraft(draft);
+      const result = liveValidation;
 
-      if (!result.isValid) return;
+      if (result && !result.isValid) return;
     }
 
     const result = await save();

--- a/features/questionnaires/hooks/use-questionnaire-builder-navigation.ts
+++ b/features/questionnaires/hooks/use-questionnaire-builder-navigation.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+
+import type { QuestionnaireTypeCode } from "@/features/questionnaires/types";
+
+type RefetchableQuery = {
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => Promise<unknown>;
+  data?: unknown;
+};
+
+type UseQuestionnaireBuilderNavigationOptions = {
+  activeType: QuestionnaireTypeCode;
+  availableTypes: QuestionnaireTypeCode[];
+  requestedTypeUnavailable: boolean;
+  hasLocalBuilderDraft: boolean;
+  resolvedVersionId: string | null;
+  questionnaireTypesQuery: RefetchableQuery;
+  questionnaireVersionsQuery: RefetchableQuery;
+  questionnaireVersionQuery: RefetchableQuery;
+  hasUnsavedChanges: () => boolean;
+  resetActiveDraft: () => void;
+  router: {
+    push: (href: string) => void;
+    replace: (href: string) => void;
+  };
+};
+
+export function useQuestionnaireBuilderNavigation({
+  activeType,
+  availableTypes,
+  requestedTypeUnavailable,
+  hasLocalBuilderDraft,
+  resolvedVersionId,
+  questionnaireTypesQuery,
+  questionnaireVersionsQuery,
+  questionnaireVersionQuery,
+  hasUnsavedChanges,
+  resetActiveDraft,
+  router,
+}: UseQuestionnaireBuilderNavigationOptions) {
+  const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
+
+  const isLoading =
+    questionnaireTypesQuery.isLoading ||
+    questionnaireVersionsQuery.isLoading ||
+    questionnaireVersionQuery.isLoading;
+  const isError =
+    questionnaireTypesQuery.isError ||
+    questionnaireVersionsQuery.isError ||
+    questionnaireVersionQuery.isError;
+  const questionnaireListHref = `/superadmin/questionnaires?type=${activeType}`;
+  const emptyState =
+    availableTypes.length === 0
+      ? { description: "No questionnaire types are available right now." }
+      : requestedTypeUnavailable
+        ? {
+            description:
+              "That questionnaire type is no longer available. The stale local draft for it was discarded.",
+            actionLabel: "Open available type",
+            onAction: () => {
+              if (availableTypes[0]) {
+                router.replace(`/superadmin/questionnaires/new?type=${availableTypes[0]}`);
+              }
+            },
+          }
+        : null;
+  const showBuilderLoading =
+    !hasLocalBuilderDraft &&
+    (isLoading ||
+      (!requestedTypeUnavailable && availableTypes.length > 0 && !questionnaireVersionsQuery.data));
+  const showBuilderError = !hasLocalBuilderDraft && isError;
+
+  const handleBackToQuestionnaires = () => {
+    if (!hasUnsavedChanges()) {
+      router.push(questionnaireListHref);
+      return;
+    }
+
+    setDiscardDialogOpen(true);
+  };
+
+  const handleRetry = () => {
+    void questionnaireTypesQuery.refetch();
+    void questionnaireVersionsQuery.refetch();
+
+    if (resolvedVersionId) {
+      void questionnaireVersionQuery.refetch();
+    }
+  };
+
+  const handleConfirmDiscard = () => {
+    resetActiveDraft();
+    setDiscardDialogOpen(false);
+    router.push(questionnaireListHref);
+  };
+
+  return {
+    emptyState,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+    questionnaireListHref,
+    showBuilderLoading,
+    showBuilderError,
+    handleBackToQuestionnaires,
+    handleRetry,
+    handleConfirmDiscard,
+  };
+}

--- a/features/questionnaires/hooks/use-questionnaire-draft-hydration.ts
+++ b/features/questionnaires/hooks/use-questionnaire-draft-hydration.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect } from "react";
+
+import {
+  useQuestionnaireVersion,
+  useQuestionnaireVersions,
+} from "@/features/questionnaires/hooks/use-questionnaire-versions";
+import { useQuestionnaireBuilderStore } from "@/features/questionnaires/store/questionnaire-builder-store";
+import type { UseQuestionnaireTypesResult } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import type { QuestionnaireTypeCode } from "@/features/questionnaires/types";
+
+type UseQuestionnaireDraftHydrationOptions = {
+  questionnaireTypesQuery: UseQuestionnaireTypesResult;
+  activeTypeId: string | null;
+  activeType: QuestionnaireTypeCode;
+  requestedType: QuestionnaireTypeCode;
+  requestedTypeUnavailable: boolean;
+  requestedVersionId: string | null;
+};
+
+export function useQuestionnaireDraftHydration({
+  questionnaireTypesQuery,
+  activeTypeId,
+  activeType,
+  requestedType,
+  requestedTypeUnavailable,
+  requestedVersionId,
+}: UseQuestionnaireDraftHydrationOptions) {
+  const hydrated = useQuestionnaireBuilderStore((state) => state.hydrated);
+  const storeActiveType = useQuestionnaireBuilderStore((state) => state.activeType);
+  const loadDraftFromServer = useQuestionnaireBuilderStore((state) => state.loadDraftFromServer);
+  const clearDraftForType = useQuestionnaireBuilderStore((state) => state.clearDraftForType);
+  const setActiveType = useQuestionnaireBuilderStore((state) => state.setActiveType);
+  const currentDraft = useQuestionnaireBuilderStore((state) => state.drafts[activeType] ?? null);
+
+  const questionnaireVersionsQuery = useQuestionnaireVersions(activeTypeId, {
+    enabled:
+      questionnaireTypesQuery.isSuccess && !requestedTypeUnavailable && activeTypeId !== null,
+  });
+  const defaultDraftVersionId =
+    questionnaireVersionsQuery.data?.versions.find((version) => version.status === "DRAFT")?.id ??
+    null;
+  const resolvedVersionId = requestedVersionId ?? defaultDraftVersionId;
+  const questionnaireVersionQuery = useQuestionnaireVersion(resolvedVersionId, {
+    enabled:
+      questionnaireTypesQuery.isSuccess && !requestedTypeUnavailable && Boolean(resolvedVersionId),
+  });
+  const shouldDelayDraftHydration =
+    Boolean(resolvedVersionId) && questionnaireVersionQuery.isLoading;
+  const draftVersion = questionnaireVersionQuery.data ?? null;
+
+  useEffect(() => {
+    if (!questionnaireVersionsQuery.data || shouldDelayDraftHydration) {
+      return;
+    }
+
+    const { questionnaireId, questionnaireTitle, type, versions } = questionnaireVersionsQuery.data;
+    loadDraftFromServer({
+      type: type.code,
+      versions,
+      draftVersion,
+      ...(questionnaireId !== null
+        ? {
+            questionnaireId,
+            questionnaireTitle: questionnaireTitle ?? questionnaireId,
+          }
+        : { questionnaireId: null, questionnaireTitle: null }),
+    });
+  }, [
+    draftVersion,
+    loadDraftFromServer,
+    questionnaireVersionsQuery.data,
+    shouldDelayDraftHydration,
+  ]);
+
+  useEffect(() => {
+    if (!requestedTypeUnavailable) {
+      return;
+    }
+
+    clearDraftForType(requestedType);
+
+    if (storeActiveType === requestedType) {
+      setActiveType(null);
+    }
+  }, [clearDraftForType, requestedType, requestedTypeUnavailable, setActiveType, storeActiveType]);
+
+  return {
+    hydrated,
+    currentDraft,
+    resolvedVersionId,
+    questionnaireVersionsQuery,
+    questionnaireVersionQuery,
+  };
+}

--- a/features/questionnaires/hooks/use-questionnaire-list-page.ts
+++ b/features/questionnaires/hooks/use-questionnaire-list-page.ts
@@ -73,7 +73,7 @@ export function useQuestionnaireListPage() {
   };
 
   const handleViewVersion = (row: QuestionnaireVersionItem) => {
-    router.push(`/superadmin/questionnaires/preview?versionId=${row.id}`);
+    router.push(`/superadmin/questionnaires/preview?type=${activeType}&versionId=${row.id}`);
   };
 
   const isVersionActionPending =

--- a/features/questionnaires/hooks/use-questionnaire-list-page.ts
+++ b/features/questionnaires/hooks/use-questionnaire-list-page.ts
@@ -1,19 +1,14 @@
 import { useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
 import { resolveQuestionnaireActionErrorMessage } from "@/features/questionnaires/lib/action-errors";
-import {
-  buildQuestionnaireTypeOptions,
-  resolveActiveQuestionnaireType,
-} from "@/features/questionnaires/lib/questionnaire-type-options";
 import { normalizeTypeSearchParam } from "@/features/questionnaires/lib/questionnaire-type-routing";
 import { useDeprecateQuestionnaireVersion } from "@/features/questionnaires/hooks/use-deprecate-questionnaire-version";
 import { usePublishQuestionnaireVersion } from "@/features/questionnaires/hooks/use-publish-questionnaire-version";
-import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import { useQuestionnaireTypeResolution } from "@/features/questionnaires/hooks/use-questionnaire-type-resolution";
 import { useQuestionnaireVersions } from "@/features/questionnaires/hooks/use-questionnaire-versions";
 import {
-  resolveQuestionnaireType,
   type QuestionnaireTypeCode,
   type QuestionnaireVersionItem,
   type VersionLifecycleAction,
@@ -21,25 +16,17 @@ import {
 
 export function useQuestionnaireListPage() {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [versionAction, setVersionAction] = useState<VersionLifecycleAction>(null);
-  const selectedType = resolveQuestionnaireType(searchParams.get("type"));
-
-  const questionnaireTypesQuery = useQuestionnaireTypes();
+  const {
+    searchParams,
+    questionnaireTypesQuery,
+    availableTypeOptions,
+    activeType,
+    activeTypeSummary,
+    activeTypeId,
+  } = useQuestionnaireTypeResolution();
   const publishVersionMutation = usePublishQuestionnaireVersion();
   const deprecateVersionMutation = useDeprecateQuestionnaireVersion();
-  const typeSummaries = questionnaireTypesQuery.data ?? [];
-  const availableTypeOptions = buildQuestionnaireTypeOptions(typeSummaries);
-  const activeType = resolveActiveQuestionnaireType({
-    requestedType: selectedType,
-    availableTypeOptions,
-    isResolved: questionnaireTypesQuery.isSuccess,
-  });
-  const activeTypeSummary =
-    availableTypeOptions.find((summary) => summary.code === activeType) ?? null;
-
-  // Resolve code → UUID for the API call
-  const activeTypeId = typeSummaries.find((s) => s.code === activeType)?.id ?? null;
 
   const questionnaireVersionsQuery = useQuestionnaireVersions(activeTypeId, {
     enabled: questionnaireTypesQuery.isSuccess && activeTypeId !== null,
@@ -54,7 +41,7 @@ export function useQuestionnaireListPage() {
       searchParams,
       router,
     });
-  }, [activeType, questionnaireTypesQuery.isSuccess, router, searchParams, selectedType]);
+  }, [activeType, questionnaireTypesQuery.isSuccess, router, searchParams]);
 
   useEffect(() => {
     const builderStatus = searchParams.get("builder");

--- a/features/questionnaires/hooks/use-questionnaire-page-state.ts
+++ b/features/questionnaires/hooks/use-questionnaire-page-state.ts
@@ -1,28 +1,30 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 
-import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import { useQuestionnaireTypeResolution } from "@/features/questionnaires/hooks/use-questionnaire-type-resolution";
 import {
   useQuestionnaireVersion,
   useQuestionnaireVersions,
 } from "@/features/questionnaires/hooks/use-questionnaire-versions";
-import {
-  buildQuestionnaireTypeOptions,
-  resolveActiveQuestionnaireType,
-} from "@/features/questionnaires/lib/questionnaire-type-options";
 import { normalizeTypeSearchParam } from "@/features/questionnaires/lib/questionnaire-type-routing";
 import { useQuestionnaireBuilderStore } from "@/features/questionnaires/store/questionnaire-builder-store";
-import { resolveQuestionnaireType } from "@/features/questionnaires/types";
 
 export function useQuestionnairePageState() {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
-  const requestedType = resolveQuestionnaireType(searchParams.get("type"));
+  const {
+    searchParams,
+    questionnaireTypesQuery,
+    requestedType,
+    requestedTypeUnavailable,
+    availableTypes,
+    activeType: activePageType,
+    activeTypeSummary,
+    activeTypeId,
+  } = useQuestionnaireTypeResolution();
   const requestedVersionId = searchParams.get("versionId");
-  const questionnaireTypesQuery = useQuestionnaireTypes();
   const hydrated = useQuestionnaireBuilderStore((state) => state.hydrated);
   const activeType = useQuestionnaireBuilderStore((state) => state.activeType);
   const loadDraftFromServer = useQuestionnaireBuilderStore((state) => state.loadDraftFromServer);
@@ -30,28 +32,9 @@ export function useQuestionnairePageState() {
   const setActiveType = useQuestionnaireBuilderStore((state) => state.setActiveType);
   const hasUnsavedChanges = useQuestionnaireBuilderStore((state) => state.hasUnsavedChanges);
   const resetActiveDraft = useQuestionnaireBuilderStore((state) => state.resetActiveDraft);
-
-  const typeSummaries = questionnaireTypesQuery.data ?? [];
-  const availableTypeOptions = buildQuestionnaireTypeOptions(typeSummaries);
-  const availableTypes = availableTypeOptions.map((summary) => summary.code);
-  const fetchedCodes = typeSummaries.map((summary) => summary.code);
-  const requestedTypeUnavailable =
-    questionnaireTypesQuery.isSuccess &&
-    fetchedCodes.length > 0 &&
-    !fetchedCodes.includes(requestedType);
-  const activePageType = resolveActiveQuestionnaireType({
-    requestedType,
-    availableTypeOptions,
-    isResolved: questionnaireTypesQuery.isSuccess,
-  });
-  const activeTypeSummary =
-    availableTypeOptions.find((summary) => summary.code === activePageType) ?? null;
   const currentDraft = useQuestionnaireBuilderStore(
     (state) => state.drafts[activePageType] ?? null
   );
-
-  // Resolve code → UUID for the API call
-  const activeTypeId = typeSummaries.find((summary) => summary.code === activePageType)?.id ?? null;
 
   const questionnaireVersionsQuery = useQuestionnaireVersions(activeTypeId, {
     enabled:

--- a/features/questionnaires/hooks/use-questionnaire-page-state.ts
+++ b/features/questionnaires/hooks/use-questionnaire-page-state.ts
@@ -1,21 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-
-import { useQuestionnaireTypeResolution } from "@/features/questionnaires/hooks/use-questionnaire-type-resolution";
-import {
-  useQuestionnaireVersion,
-  useQuestionnaireVersions,
-} from "@/features/questionnaires/hooks/use-questionnaire-versions";
-import { normalizeTypeSearchParam } from "@/features/questionnaires/lib/questionnaire-type-routing";
+import { useQuestionnaireBuilderNavigation } from "@/features/questionnaires/hooks/use-questionnaire-builder-navigation";
+import { useQuestionnaireDraftHydration } from "@/features/questionnaires/hooks/use-questionnaire-draft-hydration";
+import { useQuestionnaireRouteState } from "@/features/questionnaires/hooks/use-questionnaire-route-state";
 import { useQuestionnaireBuilderStore } from "@/features/questionnaires/store/questionnaire-builder-store";
 
 export function useQuestionnairePageState() {
-  const router = useRouter();
-  const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
   const {
-    searchParams,
+    router,
     questionnaireTypesQuery,
     requestedType,
     requestedTypeUnavailable,
@@ -23,126 +15,48 @@ export function useQuestionnairePageState() {
     activeType: activePageType,
     activeTypeSummary,
     activeTypeId,
-  } = useQuestionnaireTypeResolution();
+    searchParams,
+  } = useQuestionnaireRouteState();
   const requestedVersionId = searchParams.get("versionId");
-  const hydrated = useQuestionnaireBuilderStore((state) => state.hydrated);
-  const activeType = useQuestionnaireBuilderStore((state) => state.activeType);
-  const loadDraftFromServer = useQuestionnaireBuilderStore((state) => state.loadDraftFromServer);
-  const clearDraftForType = useQuestionnaireBuilderStore((state) => state.clearDraftForType);
-  const setActiveType = useQuestionnaireBuilderStore((state) => state.setActiveType);
   const hasUnsavedChanges = useQuestionnaireBuilderStore((state) => state.hasUnsavedChanges);
   const resetActiveDraft = useQuestionnaireBuilderStore((state) => state.resetActiveDraft);
-  const currentDraft = useQuestionnaireBuilderStore(
-    (state) => state.drafts[activePageType] ?? null
-  );
-
-  const questionnaireVersionsQuery = useQuestionnaireVersions(activeTypeId, {
-    enabled:
-      questionnaireTypesQuery.isSuccess && !requestedTypeUnavailable && activeTypeId !== null,
+  const {
+    hydrated,
+    currentDraft,
+    resolvedVersionId,
+    questionnaireVersionsQuery,
+    questionnaireVersionQuery,
+  } = useQuestionnaireDraftHydration({
+    questionnaireTypesQuery,
+    activeTypeId,
+    activeType: activePageType,
+    requestedType,
+    requestedTypeUnavailable,
+    requestedVersionId,
   });
-  const defaultDraftVersionId =
-    questionnaireVersionsQuery.data?.versions.find((version) => version.status === "DRAFT")?.id ??
-    null;
-  const resolvedVersionId = requestedVersionId ?? defaultDraftVersionId;
-  const questionnaireVersionQuery = useQuestionnaireVersion(resolvedVersionId, {
-    enabled:
-      questionnaireTypesQuery.isSuccess && !requestedTypeUnavailable && Boolean(resolvedVersionId),
-  });
-  const shouldDelayDraftHydration =
-    Boolean(resolvedVersionId) && questionnaireVersionQuery.isLoading;
-  const draftVersion = questionnaireVersionQuery.data ?? null;
-
-  useEffect(() => {
-    normalizeTypeSearchParam({
-      isResolved: questionnaireTypesQuery.isSuccess,
-      currentTypeParam: searchParams.get("type"),
-      normalizedType: activePageType,
-      pathname: "/superadmin/questionnaires/new",
-      searchParams,
-      router,
-    });
-  }, [activePageType, questionnaireTypesQuery.isSuccess, router, searchParams]);
-
-  useEffect(() => {
-    if (!questionnaireVersionsQuery.data) {
-      return;
-    }
-
-    if (shouldDelayDraftHydration) {
-      return;
-    }
-
-    const { questionnaireId, questionnaireTitle, type, versions } = questionnaireVersionsQuery.data;
-    const typeCode = type.code;
-    loadDraftFromServer({
-      type: typeCode,
-      versions,
-      draftVersion,
-      ...(questionnaireId !== null
-        ? {
-            questionnaireId,
-            questionnaireTitle: questionnaireTitle ?? questionnaireId,
-          }
-        : { questionnaireId: null, questionnaireTitle: null }),
-    });
-  }, [
-    draftVersion,
-    loadDraftFromServer,
-    questionnaireVersionsQuery.data,
-    shouldDelayDraftHydration,
-  ]);
-
-  useEffect(() => {
-    if (!requestedTypeUnavailable) {
-      return;
-    }
-
-    clearDraftForType(requestedType);
-
-    if (activeType === requestedType) {
-      setActiveType(null);
-    }
-  }, [activeType, clearDraftForType, requestedType, requestedTypeUnavailable, setActiveType]);
-
-  const isLoading =
-    questionnaireTypesQuery.isLoading ||
-    questionnaireVersionsQuery.isLoading ||
-    questionnaireVersionQuery.isLoading;
-  const isError =
-    questionnaireTypesQuery.isError ||
-    questionnaireVersionsQuery.isError ||
-    questionnaireVersionQuery.isError;
-  const questionnaireListHref = `/superadmin/questionnaires?type=${activePageType}`;
-  const emptyState =
-    availableTypes.length === 0
-      ? { description: "No questionnaire types are available right now." }
-      : requestedTypeUnavailable
-        ? {
-            description:
-              "That questionnaire type is no longer available. The stale local draft for it was discarded.",
-            actionLabel: "Open available type",
-            onAction: () => {
-              if (availableTypes[0]) {
-                router.replace(`/superadmin/questionnaires/new?type=${availableTypes[0]}`);
-              }
-            },
-          }
-        : null;
   const hasLocalBuilderDraft = hydrated && Boolean(currentDraft);
-  const showBuilderLoading =
-    !hasLocalBuilderDraft &&
-    (isLoading ||
-      (!requestedTypeUnavailable && availableTypes.length > 0 && !questionnaireVersionsQuery.data));
-  const showBuilderError = !hasLocalBuilderDraft && isError;
-
-  const handleBackToQuestionnaires = () => {
-    if (!hasUnsavedChanges()) {
-      router.push(questionnaireListHref);
-      return;
-    }
-
-    setDiscardDialogOpen(true);
-  };
+  const {
+    emptyState,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+    showBuilderLoading,
+    showBuilderError,
+    handleBackToQuestionnaires,
+    handleRetry,
+    handleConfirmDiscard,
+  } = useQuestionnaireBuilderNavigation({
+    activeType: activePageType,
+    availableTypes,
+    requestedTypeUnavailable,
+    hasLocalBuilderDraft,
+    resolvedVersionId,
+    questionnaireTypesQuery,
+    questionnaireVersionsQuery,
+    questionnaireVersionQuery,
+    hasUnsavedChanges,
+    resetActiveDraft,
+    router,
+  });
 
   return {
     activePageType,
@@ -154,12 +68,12 @@ export function useQuestionnairePageState() {
     emptyState,
     discardDialogOpen,
     setDiscardDialogOpen,
-    questionnaireListHref,
     questionnaireTypesQuery,
     questionnaireVersionsQuery,
     questionnaireVersionQuery,
     resetActiveDraft,
     handleBackToQuestionnaires,
-    router,
+    handleRetry,
+    handleConfirmDiscard,
   };
 }

--- a/features/questionnaires/hooks/use-questionnaire-route-state.ts
+++ b/features/questionnaires/hooks/use-questionnaire-route-state.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+import { useQuestionnaireTypeResolution } from "@/features/questionnaires/hooks/use-questionnaire-type-resolution";
+import { normalizeTypeSearchParam } from "@/features/questionnaires/lib/questionnaire-type-routing";
+
+export function useQuestionnaireRouteState() {
+  const router = useRouter();
+  const routeState = useQuestionnaireTypeResolution();
+  const { searchParams, questionnaireTypesQuery, activeType } = routeState;
+
+  useEffect(() => {
+    normalizeTypeSearchParam({
+      isResolved: questionnaireTypesQuery.isSuccess,
+      currentTypeParam: searchParams.get("type"),
+      normalizedType: activeType,
+      pathname: "/superadmin/questionnaires/new",
+      searchParams,
+      router,
+    });
+  }, [activeType, questionnaireTypesQuery.isSuccess, router, searchParams]);
+
+  return {
+    router,
+    ...routeState,
+  };
+}

--- a/features/questionnaires/hooks/use-questionnaire-type-management-page.ts
+++ b/features/questionnaires/hooks/use-questionnaire-type-management-page.ts
@@ -28,7 +28,7 @@ export function useQuestionnaireTypeManagementPage() {
       toast.error(
         resolveDeleteQuestionnaireTypeManagementErrorMessage(
           error,
-          "Unable to delete questionnaire type."
+          "The questionnaire type could not be deleted."
         )
       );
     }

--- a/features/questionnaires/hooks/use-questionnaire-type-resolution.ts
+++ b/features/questionnaires/hooks/use-questionnaire-type-resolution.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useMemo } from "react";
+import { useSearchParams } from "next/navigation";
+
+import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import {
+  buildQuestionnaireTypeOptions,
+  resolveActiveQuestionnaireType,
+} from "@/features/questionnaires/lib/questionnaire-type-options";
+import {
+  resolveQuestionnaireType,
+  type QuestionnaireTypeSummary,
+} from "@/features/questionnaires/types";
+
+const EMPTY_TYPE_SUMMARIES: QuestionnaireTypeSummary[] = [];
+
+type UseQuestionnaireTypeResolutionOptions = {
+  enabled?: boolean;
+};
+
+export function useQuestionnaireTypeResolution(options?: UseQuestionnaireTypeResolutionOptions) {
+  const searchParams = useSearchParams();
+  const requestedType = resolveQuestionnaireType(searchParams.get("type"));
+  const questionnaireTypesQuery = useQuestionnaireTypes({ enabled: options?.enabled });
+  const typeSummaries = questionnaireTypesQuery.data ?? EMPTY_TYPE_SUMMARIES;
+
+  const availableTypeOptions = useMemo(
+    () => buildQuestionnaireTypeOptions(typeSummaries),
+    [typeSummaries]
+  );
+
+  const fetchedCodes = useMemo(() => typeSummaries.map((summary) => summary.code), [typeSummaries]);
+
+  const requestedTypeUnavailable =
+    questionnaireTypesQuery.isSuccess &&
+    fetchedCodes.length > 0 &&
+    !fetchedCodes.includes(requestedType);
+
+  const activeType = useMemo(
+    () =>
+      resolveActiveQuestionnaireType({
+        requestedType,
+        availableTypeOptions,
+        isResolved: questionnaireTypesQuery.isSuccess,
+      }),
+    [availableTypeOptions, questionnaireTypesQuery.isSuccess, requestedType]
+  );
+
+  const activeTypeSummary = useMemo(
+    () => availableTypeOptions.find((summary) => summary.code === activeType) ?? null,
+    [activeType, availableTypeOptions]
+  );
+
+  const activeTypeId = useMemo(
+    () => typeSummaries.find((summary) => summary.code === activeType)?.id ?? null,
+    [activeType, typeSummaries]
+  );
+
+  const availableTypes = useMemo(
+    () => availableTypeOptions.map((summary) => summary.code),
+    [availableTypeOptions]
+  );
+
+  return {
+    searchParams,
+    questionnaireTypesQuery,
+    requestedType,
+    requestedTypeUnavailable,
+    availableTypeOptions,
+    availableTypes,
+    activeType,
+    activeTypeSummary,
+    activeTypeId,
+  };
+}

--- a/features/questionnaires/hooks/use-questionnaire-types.ts
+++ b/features/questionnaires/hooks/use-questionnaire-types.ts
@@ -19,3 +19,5 @@ export function useQuestionnaireTypes(options?: UseQuestionnaireTypesOptions) {
     queryFn: fetchQuestionnaireTypes,
   });
 }
+
+export type UseQuestionnaireTypesResult = ReturnType<typeof useQuestionnaireTypes>;

--- a/features/questionnaires/index.ts
+++ b/features/questionnaires/index.ts
@@ -15,6 +15,7 @@ export * from "@/features/questionnaires/hooks/use-save-draft";
 export * from "@/features/questionnaires/hooks/use-check-submission";
 export * from "@/features/questionnaires/hooks/use-create-questionnaire-type-management";
 export * from "@/features/questionnaires/hooks/use-questionnaire-list-page";
+export * from "@/features/questionnaires/hooks/use-questionnaire-type-resolution";
 export * from "@/features/questionnaires/hooks/use-questionnaire-type-management";
 export * from "@/features/questionnaires/hooks/use-questionnaire-type-management-page";
 export * from "@/features/questionnaires/types";

--- a/network/axios.ts
+++ b/network/axios.ts
@@ -1,5 +1,5 @@
 import { Endpoints } from "@/network/endpoints";
-import type { LoginResponse } from "@/features/auth/types";
+import type { AuthSession } from "@/features/auth/types";
 import { useAuthStore } from "@/stores/auth-store";
 import axios, { AxiosError, AxiosHeaders, type InternalAxiosRequestConfig } from "axios";
 import { toast } from "sonner";
@@ -40,7 +40,7 @@ const refreshClient = axios.create({
   },
 });
 
-let refreshPromise: Promise<LoginResponse> | null = null;
+let refreshPromise: Promise<AuthSession> | null = null;
 let lastRateLimitToastAt = 0;
 
 function getRateLimitMessage(error: AxiosError) {
@@ -73,8 +73,9 @@ function notifyRateLimit(error: AxiosError) {
 
 function refreshAccessToken(refreshToken: string) {
   if (!refreshPromise) {
+    // Use a separate client here so the refresh request does not trigger the same auth interceptor flow.
     refreshPromise = refreshClient
-      .post<LoginResponse>(Endpoints.refresh, { refreshToken })
+      .post<AuthSession>(Endpoints.refresh, { refreshToken })
       .then((response) => response.data)
       .finally(() => {
         refreshPromise = null;
@@ -112,6 +113,7 @@ apiClient.interceptors.response.use(
       !originalRequest ||
       !isUnauthorized ||
       originalRequest._retry ||
+      // Avoid retry loops when an authentication endpoint itself fails with 401.
       isAuthEndpoint(originalRequest.url)
     ) {
       return Promise.reject(error);

--- a/providers/app-provider.tsx
+++ b/providers/app-provider.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from "@/components/layout/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryProvider } from "@/providers/query-provider";
 import { ReactNode } from "react";
-import { Toaster } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
 
 export function AppProvider({ children }: { children: ReactNode }) {
   return (

--- a/stores/auth-store.ts
+++ b/stores/auth-store.ts
@@ -9,11 +9,11 @@ type AuthStore = {
   isAuthenticated: boolean;
   hydrated: boolean;
   activeRole: AppRole | null;
-  pendingRoleHome: string | null;
+  pendingRedirectPath: string | null;
   setHydrated: (hydrated: boolean) => void;
   setSession: (token: string, refreshToken: string) => void;
   setActiveRole: (activeRole: AppRole | null) => void;
-  setPendingRoleHome: (pendingRoleHome: string | null) => void;
+  setPendingRedirectPath: (pendingRedirectPath: string | null) => void;
   clearSession: () => void;
 };
 
@@ -25,7 +25,7 @@ export const useAuthStore = create<AuthStore>()(
       isAuthenticated: false,
       hydrated: false,
       activeRole: null,
-      pendingRoleHome: null,
+      pendingRedirectPath: null,
       setHydrated: (hydrated) => set({ hydrated }),
 
       setSession: (token, refreshToken) =>
@@ -36,7 +36,7 @@ export const useAuthStore = create<AuthStore>()(
           hydrated: true,
         }),
       setActiveRole: (activeRole) => set({ activeRole }),
-      setPendingRoleHome: (pendingRoleHome) => set({ pendingRoleHome }),
+      setPendingRedirectPath: (pendingRedirectPath) => set({ pendingRedirectPath }),
       clearSession: () =>
         set({
           token: null,
@@ -44,7 +44,7 @@ export const useAuthStore = create<AuthStore>()(
           isAuthenticated: false,
           hydrated: true,
           activeRole: null,
-          pendingRoleHome: null,
+          pendingRedirectPath: null,
         }),
     }),
     {

--- a/stores/auth-store.ts
+++ b/stores/auth-store.ts
@@ -6,7 +6,6 @@ import type { AppRole } from "@/constants/roles";
 type AuthStore = {
   token: string | null;
   refreshToken: string | null;
-  isAuthenticated: boolean;
   hydrated: boolean;
   activeRole: AppRole | null;
   pendingRedirectPath: string | null;
@@ -22,7 +21,6 @@ export const useAuthStore = create<AuthStore>()(
     (set) => ({
       token: null,
       refreshToken: null,
-      isAuthenticated: false,
       hydrated: false,
       activeRole: null,
       pendingRedirectPath: null,
@@ -32,7 +30,6 @@ export const useAuthStore = create<AuthStore>()(
         set({
           token,
           refreshToken,
-          isAuthenticated: Boolean(token),
           hydrated: true,
         }),
       setActiveRole: (activeRole) => set({ activeRole }),
@@ -41,7 +38,6 @@ export const useAuthStore = create<AuthStore>()(
         set({
           token: null,
           refreshToken: null,
-          isAuthenticated: false,
           hydrated: true,
           activeRole: null,
           pendingRedirectPath: null,
@@ -53,7 +49,6 @@ export const useAuthStore = create<AuthStore>()(
       partialize: (state) => ({
         token: state.token,
         refreshToken: state.refreshToken,
-        isAuthenticated: state.isAuthenticated,
         activeRole: state.activeRole,
       }),
       onRehydrateStorage: () => (state) => {


### PR DESCRIPTION
  Summary

  - tighten frontend writing and user-facing copy across auth, questionnaires, dashboard states, and dimensions
  - simplify auth/session handling and questionnaire builder page orchestration
  - reduce questionnaire builder and dimensions page complexity with small hook extractions
  - fix questionnaire preview back navigation so it preserves the active questionnaire type
  - fix dimensions Clear filters so it clears debounced search and status reliably

  What changed

  - Auth
      - standardized sign-in copy and removed misleading auth affordances
      - centralized auth session state for guards and auth-page redirects
      - removed redundant auth store/type noise
  - Shared/dashboard UI
      - improved loading and error copy on shared/dashboard surfaces
  - Questionnaires
      - cleaned list, builder, preview, and questionnaire type management copy
      - extracted shared questionnaire type resolution
      - memoized builder validation and preview-model derivation
      - reduced builder-controller subscription churn
      - split builder page orchestration into route, hydration, and navigation hooks
      - fixed preview back navigation to preserve questionnaire type context
  - Dimensions
      - improved page, empty, loading, error, and dialog copy
      - extracted route/search state and toggle flow from the dimensions page hook
      - fixed Clear filters so it cancels stale debounced search updates

  Validation

  - bun run typecheck
  - targeted bun run lint
  - manual testing completed for:
      - auth flow and guards
      - questionnaire list, builder, preview, save/discard flows
      - dimensions filters, dialogs, toggles, and clear-filters behavior

  Notes

  - changes are intended to be behavior-preserving refactors and copy cleanups