### PR TITLE
[FEAT][FAC-WEB-26] dean and chairperson faculty evaluation flow

### DIFF
--- a/app/(dashboard)/chairperson/evaluation/[facultyId]/page.tsx
+++ b/app/(dashboard)/chairperson/evaluation/[facultyId]/page.tsx
@@ -1,0 +1,20 @@
+import { FacultyEvaluationDetailScreen } from "@/features/faculty-evaluation";
+
+type ChairpersonEvaluationDetailPageProps = {
+  params: Promise<{
+    facultyId: string;
+  }>;
+};
+
+export default async function ChairpersonEvaluationDetailPage({
+  params,
+}: ChairpersonEvaluationDetailPageProps) {
+  const { facultyId } = await params;
+
+  return (
+    <FacultyEvaluationDetailScreen
+      role={{ roleLabel: "Chairperson", rolePath: "/chairperson" }}
+      facultyId={facultyId}
+    />
+  );
+}

--- a/app/(dashboard)/chairperson/evaluation/page.tsx
+++ b/app/(dashboard)/chairperson/evaluation/page.tsx
@@ -1,0 +1,7 @@
+import { FacultyEvaluationListScreen } from "@/features/faculty-evaluation";
+
+export default function ChairpersonEvaluationPage() {
+  return (
+    <FacultyEvaluationListScreen role={{ roleLabel: "Chairperson", rolePath: "/chairperson" }} />
+  );
+}

--- a/app/(dashboard)/dean/evaluation/[facultyId]/page.tsx
+++ b/app/(dashboard)/dean/evaluation/[facultyId]/page.tsx
@@ -1,0 +1,18 @@
+import { FacultyEvaluationDetailScreen } from "@/features/faculty-evaluation";
+
+type DeanEvaluationDetailPageProps = {
+  params: Promise<{
+    facultyId: string;
+  }>;
+};
+
+export default async function DeanEvaluationDetailPage({ params }: DeanEvaluationDetailPageProps) {
+  const { facultyId } = await params;
+
+  return (
+    <FacultyEvaluationDetailScreen
+      role={{ roleLabel: "Dean", rolePath: "/dean" }}
+      facultyId={facultyId}
+    />
+  );
+}

--- a/app/(dashboard)/dean/evaluation/page.tsx
+++ b/app/(dashboard)/dean/evaluation/page.tsx
@@ -1,0 +1,5 @@
+import { FacultyEvaluationListScreen } from "@/features/faculty-evaluation";
+
+export default function DeanEvaluationPage() {
+  return <FacultyEvaluationListScreen role={{ roleLabel: "Dean", rolePath: "/dean" }} />;
+}

--- a/app/(dashboard)/dean/faculties/[facultySlug]/analysis/_components/faculty-analysis-qualitative-metrics.tsx
+++ b/app/(dashboard)/dean/faculties/[facultySlug]/analysis/_components/faculty-analysis-qualitative-metrics.tsx
@@ -2,10 +2,7 @@
 
 import { Cell, Pie, PieChart } from "recharts";
 
-import type {
-  DeanFacultyAnalysisRecord,
-  FacultyAnalysisSemesterKey,
-} from "@/features/faculty-analytics";
+import type { DeanFacultyAnalysisRecord, SemesterKey } from "@/features/faculty-analytics";
 import {
   ChartContainer,
   ChartLegend,
@@ -38,7 +35,7 @@ const qualitativeSentimentChartConfig = {
 
 function useQualitativeMetricsData(
   faculty: DeanFacultyAnalysisRecord,
-  selectedSemester: FacultyAnalysisSemesterKey
+  selectedSemester: SemesterKey
 ) {
   const isMobile = useIsMobile();
   const qualitativeMetrics = faculty.qualitativeMetrics[selectedSemester];
@@ -71,7 +68,7 @@ export function FacultyAnalysisQualitativeOverview({
   selectedSemester,
 }: {
   faculty: DeanFacultyAnalysisRecord;
-  selectedSemester: FacultyAnalysisSemesterKey;
+  selectedSemester: SemesterKey;
 }) {
   const { isMobile, qualitativeMetrics, sentimentData, maxMentions } = useQualitativeMetricsData(
     faculty,
@@ -155,7 +152,7 @@ export function FacultyAnalysisActionableInsights({
   selectedSemester,
 }: {
   faculty: DeanFacultyAnalysisRecord;
-  selectedSemester: FacultyAnalysisSemesterKey;
+  selectedSemester: SemesterKey;
 }) {
   const { qualitativeMetrics, strengthsRecommendation, improvementRecommendation } =
     useQualitativeMetricsData(faculty, selectedSemester);

--- a/app/(dashboard)/dean/faculties/[facultySlug]/analysis/_components/faculty-analysis-screen.tsx
+++ b/app/(dashboard)/dean/faculties/[facultySlug]/analysis/_components/faculty-analysis-screen.tsx
@@ -4,10 +4,7 @@ import { useState } from "react";
 import { ChevronUp } from "lucide-react";
 import Link from "next/link";
 
-import type {
-  DeanFacultyAnalysisRecord,
-  FacultyAnalysisSemesterKey,
-} from "@/features/faculty-analytics";
+import type { DeanFacultyAnalysisRecord, SemesterKey } from "@/features/faculty-analytics";
 import { Button } from "@/components/ui/button";
 
 import {
@@ -19,8 +16,7 @@ import { FacultyAnalysisRemarksList, FacultyAnalysisSummary } from "./faculty-an
 import { FacultyAnalysisToolbar } from "./faculty-analysis-toolbar";
 
 export function FacultyAnalysisScreen({ faculty }: { faculty: DeanFacultyAnalysisRecord }) {
-  const [selectedSemester, setSelectedSemester] =
-    useState<FacultyAnalysisSemesterKey>("firstSemester");
+  const [selectedSemester, setSelectedSemester] = useState<SemesterKey>("firstSemester");
 
   return (
     <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">

--- a/app/(dashboard)/dean/faculties/[facultySlug]/analysis/_components/faculty-analysis-toolbar.tsx
+++ b/app/(dashboard)/dean/faculties/[facultySlug]/analysis/_components/faculty-analysis-toolbar.tsx
@@ -3,7 +3,7 @@
 import { ChevronDown, Upload } from "lucide-react";
 import { useId, useState } from "react";
 
-import type { FacultyAnalysisSemesterKey } from "@/features/faculty-analytics";
+import type { SemesterKey } from "@/features/faculty-analytics";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -22,7 +22,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-const semesterLabels: Record<FacultyAnalysisSemesterKey, string> = {
+const semesterLabels: Record<SemesterKey, string> = {
   firstSemester: "First Semester",
   secondSemester: "Second Semester",
   summerSemester: "Summer",
@@ -32,8 +32,8 @@ export function FacultyAnalysisToolbar({
   selectedSemester,
   onSemesterChange,
 }: {
-  selectedSemester: FacultyAnalysisSemesterKey;
-  onSemesterChange: (semester: FacultyAnalysisSemesterKey) => void;
+  selectedSemester: SemesterKey;
+  onSemesterChange: (semester: SemesterKey) => void;
 }) {
   const fileInputId = useId();
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
@@ -55,9 +55,9 @@ export function FacultyAnalysisToolbar({
         <DropdownMenuContent align="end" className="min-w-44">
           <DropdownMenuRadioGroup
             value={selectedSemester}
-            onValueChange={(value) => onSemesterChange(value as FacultyAnalysisSemesterKey)}
+            onValueChange={(value) => onSemesterChange(value as SemesterKey)}
           >
-            {(Object.entries(semesterLabels) as Array<[FacultyAnalysisSemesterKey, string]>).map(
+            {(Object.entries(semesterLabels) as Array<[SemesterKey, string]>).map(
               ([value, label]) => (
                 <DropdownMenuRadioItem key={value} value={value} className="font-sans text-sm">
                   {label}

--- a/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-already-submitted.tsx
+++ b/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-already-submitted.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
-import { CheckCircle2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
-import { formatDate } from "@/lib/date";
+import { formatDateTime } from "@/lib/date";
 
 type EvaluationAlreadySubmittedProps = {
   submittedAt?: string;
@@ -13,16 +13,10 @@ export function EvaluationAlreadySubmitted({ submittedAt }: EvaluationAlreadySub
   return (
     <Card className="mt-8">
       <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
-        <CheckCircle2 className="size-12 text-primary" />
-        <div>
-          <h2 className="font-playfair text-xl font-semibold">Evaluation Already Submitted</h2>
-          <p className="mt-2 text-sm text-muted-foreground">
-            You have already submitted your evaluation for this course.
-          </p>
+        <div className="space-y-3">
+          <h2 className="font-playfair text-xl font-semibold">Evaluation already submitted.</h2>
           {submittedAt && (
-            <p className="mt-2 text-sm text-muted-foreground">
-              Submitted on {formatDate(submittedAt)}.
-            </p>
+            <Badge variant="secondary">Submitted {formatDateTime(submittedAt)}</Badge>
           )}
         </div>
         <Button asChild variant="outline">

--- a/app/(dashboard)/superadmin/dimensions/_components/dimension-list-screen.tsx
+++ b/app/(dashboard)/superadmin/dimensions/_components/dimension-list-screen.tsx
@@ -6,14 +6,16 @@ import { DimensionTable } from "@/features/dimensions/components/dimension-table
 import {
   DimensionToolbar,
   type DimensionStatusFilter,
-  type TypeFilter,
 } from "@/features/dimensions/components/dimension-toolbar";
 import type { Dimension, DimensionsListMeta } from "@/features/dimensions/types";
-import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
+import type {
+  QuestionnaireTypeCode,
+  QuestionnaireTypeSummary,
+} from "@/features/questionnaires/types";
 
 type DimensionListScreenProps = {
   typeOptions: QuestionnaireTypeSummary[];
-  typeFilter: TypeFilter;
+  typeFilter: QuestionnaireTypeCode;
   statusFilter: DimensionStatusFilter;
   searchValue: string;
   currentPage: number;
@@ -23,7 +25,7 @@ type DimensionListScreenProps = {
   isLoading: boolean;
   isError: boolean;
   disableActions: boolean;
-  onTypeFilterChange: (value: TypeFilter) => void;
+  onTypeFilterChange: (value: QuestionnaireTypeCode) => void;
   onStatusFilterChange: (value: DimensionStatusFilter) => void;
   onSearchChange: (value: string) => void;
   onClearFilters: () => void;

--- a/features/auth/lib/role-route.ts
+++ b/features/auth/lib/role-route.ts
@@ -5,6 +5,7 @@ import {
   ChartNoAxesColumn,
   LayoutDashboard,
   ListChecks,
+  NotebookPen,
   Shield,
   Tags,
   type LucideIcon,
@@ -48,6 +49,7 @@ const ROLE_CONFIG: Record<AppRole, RoleConfig> = {
     navItems: [
       { title: "Dashboard", url: "/dean/dashboard", icon: LayoutDashboard },
       { title: "Faculties", url: "/dean/faculties", icon: ChartNoAxesColumn },
+      { title: "Evaluation", url: "/dean/evaluation", icon: NotebookPen },
     ],
   },
   [APP_ROLES.CHAIRPERSON]: {
@@ -57,6 +59,7 @@ const ROLE_CONFIG: Record<AppRole, RoleConfig> = {
     navItems: [
       { title: "Dashboard", url: "/chairperson/dashboard", icon: LayoutDashboard },
       { title: "Faculties", url: "/chairperson/faculties", icon: Building2 },
+      { title: "Evaluation", url: "/chairperson/evaluation", icon: NotebookPen },
     ],
   },
   [APP_ROLES.ADMIN]: {

--- a/features/dimensions/components/dimension-toolbar.tsx
+++ b/features/dimensions/components/dimension-toolbar.tsx
@@ -27,22 +27,20 @@ const STATUS_FILTER_LABELS: Record<DimensionStatusFilter, string> = {
   INACTIVE: "Inactive",
 };
 
-type TypeFilter = QuestionnaireTypeCode;
-
 type DimensionTypeOption = Pick<QuestionnaireTypeSummary, "code" | "name">;
 
 type DimensionToolbarProps = {
   typeOptions: DimensionTypeOption[];
-  typeFilter: TypeFilter;
+  typeFilter: QuestionnaireTypeCode;
   statusFilter: DimensionStatusFilter;
   searchValue: string;
-  onTypeFilterChange: (value: TypeFilter) => void;
+  onTypeFilterChange: (value: QuestionnaireTypeCode) => void;
   onStatusFilterChange: (value: DimensionStatusFilter) => void;
   onSearchChange: (value: string) => void;
   onCreateClick: () => void;
 };
 
-export type { DimensionStatusFilter, TypeFilter };
+export type { DimensionStatusFilter };
 
 export function DimensionToolbar({
   typeOptions,
@@ -76,7 +74,7 @@ export function DimensionToolbar({
           <DropdownMenuContent align="start" className="min-w-56">
             <DropdownMenuRadioGroup
               value={typeFilter}
-              onValueChange={(v) => onTypeFilterChange(v as TypeFilter)}
+              onValueChange={(v) => onTypeFilterChange(v as QuestionnaireTypeCode)}
             >
               {typeOptions.map((type) => (
                 <DropdownMenuRadioItem key={type.code} value={type.code}>
@@ -151,7 +149,7 @@ export function DimensionToolbar({
           <DropdownMenuContent align="start" className="min-w-[18rem] max-w-[24rem]">
             <DropdownMenuRadioGroup
               value={typeFilter}
-              onValueChange={(v) => onTypeFilterChange(v as TypeFilter)}
+              onValueChange={(v) => onTypeFilterChange(v as QuestionnaireTypeCode)}
             >
               {typeOptions.map((type) => (
                 <DropdownMenuRadioItem key={type.code} value={type.code}>

--- a/features/dimensions/hooks/use-dimension-list-route-state.ts
+++ b/features/dimensions/hooks/use-dimension-list-route-state.ts
@@ -3,16 +3,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import type {
-  DimensionStatusFilter,
-  TypeFilter,
-} from "@/features/dimensions/components/dimension-toolbar";
+import type { DimensionStatusFilter } from "@/features/dimensions/components/dimension-toolbar";
 import { DEFAULT_QUESTIONNAIRE_TYPE } from "@/features/questionnaires/constants";
+import type { QuestionnaireTypeCode } from "@/features/questionnaires/types";
 import { resolvePageSizeOption } from "@/lib/pagination";
 
-function resolveTypeFilter(value: string | null): TypeFilter {
+function resolveTypeFilter(value: string | null): QuestionnaireTypeCode {
   if (value && value.trim().length > 0) {
-    return value;
+    return value as QuestionnaireTypeCode;
   }
 
   return DEFAULT_QUESTIONNAIRE_TYPE;
@@ -76,7 +74,7 @@ export function useDimensionListRouteState() {
     [pathname, router, searchParams]
   );
 
-  const handleTypeFilterChange = (value: TypeFilter) => {
+  const handleTypeFilterChange = (value: QuestionnaireTypeCode) => {
     updateSearchParams({
       type: value,
       page: "1",

--- a/features/faculty-analytics/types/index.ts
+++ b/features/faculty-analytics/types/index.ts
@@ -8,8 +8,6 @@ export type QuantitativeMetricScore = {
 
 export type SemesterKey = "firstSemester" | "secondSemester" | "summerSemester";
 
-export type FacultyAnalysisSemesterKey = SemesterKey;
-
 export type QualitativeTheme = {
   label: string;
   mentions: number;

--- a/features/faculty-evaluation/api/faculty-evaluation.requests.ts
+++ b/features/faculty-evaluation/api/faculty-evaluation.requests.ts
@@ -1,0 +1,13 @@
+import { apiClient } from "@/network/axios";
+import { Endpoints } from "@/network/endpoints";
+import type {
+  FacultyEvaluationListQuery,
+  FacultyEvaluationListResponse,
+} from "@/features/faculty-evaluation/types";
+
+export async function fetchScopedFacultyList(params: FacultyEvaluationListQuery) {
+  const response = await apiClient.get<FacultyEvaluationListResponse>(Endpoints.faculty, {
+    params,
+  });
+  return response.data;
+}

--- a/features/faculty-evaluation/components/evaluate-action-menu.tsx
+++ b/features/faculty-evaluation/components/evaluate-action-menu.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { FacultyEvaluationRoleContext } from "@/features/faculty-evaluation/types";
+import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
+
+type EvaluateActionMenuProps = {
+  facultyId: string;
+  facultyName: string;
+  semesterId: string;
+  semesterLabel: string;
+  role: FacultyEvaluationRoleContext;
+  questionnaireTypes: QuestionnaireTypeSummary[];
+  disabled?: boolean;
+  className?: string;
+};
+
+export function EvaluateActionMenu({
+  facultyId,
+  facultyName,
+  semesterId,
+  semesterLabel,
+  role,
+  questionnaireTypes,
+  disabled = false,
+  className,
+}: EvaluateActionMenuProps) {
+  const router = useRouter();
+
+  const handleSelect = (typeId: string) => {
+    const params = new URLSearchParams({
+      facultyName,
+      semesterId,
+      semesterLabel,
+      typeId,
+    });
+
+    router.push(`${role.rolePath}/evaluation/${facultyId}?${params.toString()}`);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          className={className}
+          disabled={disabled || questionnaireTypes.length === 0}
+        >
+          Evaluate
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-56">
+        {questionnaireTypes.map((type) => (
+          <DropdownMenuItem
+            key={type.id}
+            className="font-sans text-sm"
+            onSelect={() => handleSelect(type.id)}
+          >
+            {type.name}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/features/faculty-evaluation/components/evaluate-action-menu.tsx
+++ b/features/faculty-evaluation/components/evaluate-action-menu.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { buildFacultyEvaluationHref } from "@/features/faculty-evaluation/lib/faculty-evaluation-routes";
 import type { FacultyEvaluationRoleContext } from "@/features/faculty-evaluation/types";
 import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
 
@@ -36,14 +37,16 @@ export function EvaluateActionMenu({
   const router = useRouter();
 
   const handleSelect = (typeId: string) => {
-    const params = new URLSearchParams({
+    const href = buildFacultyEvaluationHref({
+      role,
+      facultyId,
       facultyName,
       semesterId,
       semesterLabel,
       typeId,
     });
 
-    router.push(`${role.rolePath}/evaluation/${facultyId}?${params.toString()}`);
+    router.push(href);
   };
 
   return (

--- a/features/faculty-evaluation/components/evaluation-view-toggle.tsx
+++ b/features/faculty-evaluation/components/evaluation-view-toggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { LayoutGrid, Rows3 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import type { FacultyEvaluationViewMode } from "@/features/faculty-evaluation/types";
+
+type EvaluationViewToggleProps = {
+  value: FacultyEvaluationViewMode;
+  onValueChange: (value: FacultyEvaluationViewMode) => void;
+};
+
+export function EvaluationViewToggle({ value, onValueChange }: EvaluationViewToggleProps) {
+  return (
+    <ButtonGroup>
+      <Button
+        type="button"
+        variant={value === "card" ? "brand" : "outline"}
+        size="default"
+        className="px-4 py-2.5"
+        onClick={() => onValueChange("card")}
+      >
+        <LayoutGrid className="size-4" />
+        Card
+      </Button>
+      <Button
+        type="button"
+        variant={value === "list" ? "brand" : "outline"}
+        size="default"
+        className="px-4 py-2.5"
+        onClick={() => onValueChange("list")}
+      >
+        <Rows3 className="size-4" />
+        List
+      </Button>
+    </ButtonGroup>
+  );
+}

--- a/features/faculty-evaluation/components/faculty-card.tsx
+++ b/features/faculty-evaluation/components/faculty-card.tsx
@@ -4,13 +4,13 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardContent } from "@/components/ui/card";
 import { EvaluateActionMenu } from "@/features/faculty-evaluation/components/evaluate-action-menu";
 import type {
+  FacultyEvaluationListItem,
   FacultyEvaluationRoleContext,
-  FacultyEvaluationRow,
 } from "@/features/faculty-evaluation/types";
 import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
 
 type FacultyCardProps = {
-  faculty: FacultyEvaluationRow;
+  faculty: FacultyEvaluationListItem;
   role: FacultyEvaluationRoleContext;
   semesterId: string;
   semesterLabel: string;

--- a/features/faculty-evaluation/components/faculty-card.tsx
+++ b/features/faculty-evaluation/components/faculty-card.tsx
@@ -40,7 +40,7 @@ export function FacultyCard({
   return (
     <Card className="h-full gap-0 overflow-hidden py-0">
       <CardContent className="flex h-full flex-col gap-4 p-4 sm:p-5">
-        <div className="flex items-start gap-3">
+        <div className="flex items-center gap-3">
           <Avatar className="size-11 border border-border/70">
             {faculty.profilePicture ? (
               <AvatarImage src={faculty.profilePicture} alt={faculty.fullName} />

--- a/features/faculty-evaluation/components/faculty-card.tsx
+++ b/features/faculty-evaluation/components/faculty-card.tsx
@@ -1,0 +1,83 @@
+import { BookOpenText } from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card, CardContent } from "@/components/ui/card";
+import { EvaluateActionMenu } from "@/features/faculty-evaluation/components/evaluate-action-menu";
+import type {
+  FacultyEvaluationRoleContext,
+  FacultyEvaluationRow,
+} from "@/features/faculty-evaluation/types";
+import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
+
+type FacultyCardProps = {
+  faculty: FacultyEvaluationRow;
+  role: FacultyEvaluationRoleContext;
+  semesterId: string;
+  semesterLabel: string;
+  questionnaireTypes: QuestionnaireTypeSummary[];
+  typesLoading?: boolean;
+};
+
+function getInitials(fullName: string) {
+  return (
+    fullName
+      .split(" ")
+      .map((part) => part[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase() || "F"
+  );
+}
+
+export function FacultyCard({
+  faculty,
+  role,
+  semesterId,
+  semesterLabel,
+  questionnaireTypes,
+  typesLoading = false,
+}: FacultyCardProps) {
+  return (
+    <Card className="h-full gap-0 overflow-hidden py-0">
+      <CardContent className="flex h-full flex-col gap-4 p-4 sm:p-5">
+        <div className="flex items-start gap-3">
+          <Avatar className="size-11 border border-border/70">
+            {faculty.profilePicture ? (
+              <AvatarImage src={faculty.profilePicture} alt={faculty.fullName} />
+            ) : null}
+            <AvatarFallback className="bg-slate-100 text-xs font-semibold text-slate-700">
+              {getInitials(faculty.fullName)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0 space-y-1">
+            <h2 className="font-playfair text-xl font-semibold leading-tight text-foreground">
+              {faculty.fullName}
+            </h2>
+          </div>
+        </div>
+
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <div className="flex items-start gap-2.5">
+            <BookOpenText className="mt-0.5 size-4 shrink-0" />
+            <p className="line-clamp-2">
+              {faculty.subjects.length
+                ? faculty.subjects.join(", ")
+                : "Faculty subjects will appear once scoped teaching assignments are available."}
+            </p>
+          </div>
+        </div>
+
+        <EvaluateActionMenu
+          facultyId={faculty.id}
+          facultyName={faculty.fullName}
+          semesterId={semesterId}
+          semesterLabel={semesterLabel}
+          role={role}
+          questionnaireTypes={questionnaireTypes}
+          disabled={typesLoading}
+          className="mt-auto w-full"
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/faculty-evaluation/components/faculty-evaluation-detail-screen.tsx
+++ b/features/faculty-evaluation/components/faculty-evaluation-detail-screen.tsx
@@ -14,6 +14,21 @@ type FacultyEvaluationDetailScreenProps = {
   facultyId: string;
 };
 
+function getSelectedQuestionnaireTypeName(
+  detailResult: ReturnType<typeof useFacultyEvaluationDetail>,
+  selectedTypeId: string | null
+) {
+  if (detailResult.status === "ready") {
+    return detailResult.data.selectedType.name;
+  }
+
+  if (!selectedTypeId) {
+    return undefined;
+  }
+
+  return detailResult.availableTypes.find((type) => type.id === selectedTypeId)?.name;
+}
+
 export function FacultyEvaluationDetailScreen({
   role,
   facultyId,
@@ -33,20 +48,7 @@ export function FacultyEvaluationDetailScreen({
   const returnHref = semesterId
     ? `${role.rolePath}/evaluation?semesterId=${semesterId}`
     : `${role.rolePath}/evaluation`;
-
-  const typeOptions =
-    detailResult.status === "ready"
-      ? detailResult.data.availableTypes
-      : detailResult.availableTypes;
-  const selectedTypeName =
-    typeOptions.find(
-      (type) =>
-        type.id ===
-        (selectedTypeId ??
-          (detailResult.status === "ready"
-            ? detailResult.data.selectedTypeId
-            : detailResult.selectedTypeId))
-    )?.name ?? undefined;
+  const selectedTypeName = getSelectedQuestionnaireTypeName(detailResult, selectedTypeId);
 
   if (detailResult.status === "ready") {
     return (

--- a/features/faculty-evaluation/components/faculty-evaluation-detail-screen.tsx
+++ b/features/faculty-evaluation/components/faculty-evaluation-detail-screen.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { FacultyEvaluationForm } from "@/features/faculty-evaluation/components/faculty-evaluation-form";
+import { FacultyEvaluationPageShell } from "@/features/faculty-evaluation/components/faculty-evaluation-page-shell";
+import { useFacultyEvaluationDetail } from "@/features/faculty-evaluation/hooks/use-faculty-evaluation-detail";
+import type { FacultyEvaluationRoleContext } from "@/features/faculty-evaluation/types";
+import { formatDateTime } from "@/lib/date";
+
+type FacultyEvaluationDetailScreenProps = {
+  role: FacultyEvaluationRoleContext;
+  facultyId: string;
+};
+
+export function FacultyEvaluationDetailScreen({
+  role,
+  facultyId,
+}: FacultyEvaluationDetailScreenProps) {
+  const searchParams = useSearchParams();
+  const facultyName = searchParams.get("facultyName") ?? "";
+  const semesterId = searchParams.get("semesterId") ?? "";
+  const semesterLabel = searchParams.get("semesterLabel") ?? "Selected semester";
+  const selectedTypeId = searchParams.get("typeId");
+
+  const detailResult = useFacultyEvaluationDetail({
+    facultyId,
+    facultyName,
+    semesterId,
+    selectedTypeId,
+  });
+  const returnHref = semesterId
+    ? `${role.rolePath}/evaluation?semesterId=${semesterId}`
+    : `${role.rolePath}/evaluation`;
+
+  const typeOptions =
+    detailResult.status === "ready"
+      ? detailResult.data.availableTypes
+      : detailResult.availableTypes;
+  const selectedTypeName =
+    typeOptions.find(
+      (type) =>
+        type.id ===
+        (selectedTypeId ??
+          (detailResult.status === "ready"
+            ? detailResult.data.selectedTypeId
+            : detailResult.selectedTypeId))
+    )?.name ?? undefined;
+
+  if (detailResult.status === "ready") {
+    return (
+      <FacultyEvaluationForm
+        role={role}
+        semesterLabel={semesterLabel}
+        returnHref={returnHref}
+        data={detailResult.data}
+      />
+    );
+  }
+
+  return (
+    <FacultyEvaluationPageShell
+      role={role}
+      facultyName={facultyName || undefined}
+      semesterLabel={semesterLabel}
+      questionnaireTypeName={selectedTypeName}
+      backHref={returnHref}
+    >
+      <div className="mt-8 rounded-lg border border-dashed p-6 text-sm">
+        {detailResult.status === "already-submitted" ? (
+          <div className="flex flex-col items-center justify-center space-y-3 text-center">
+            <p className="font-medium text-foreground">Evaluation already submitted.</p>
+            {detailResult.submittedAt ? (
+              <Badge variant="secondary">
+                Submitted {formatDateTime(detailResult.submittedAt)}
+              </Badge>
+            ) : null}
+          </div>
+        ) : (
+          <p
+            className={
+              detailResult.status === "error" ? "text-destructive" : "text-muted-foreground"
+            }
+          >
+            {detailResult.message}
+          </p>
+        )}
+      </div>
+    </FacultyEvaluationPageShell>
+  );
+}

--- a/features/faculty-evaluation/components/faculty-evaluation-form.tsx
+++ b/features/faculty-evaluation/components/faculty-evaluation-form.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { CheckCircle2, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { QuestionnaireFormRenderer } from "@/features/questionnaires/components/form/questionnaire-form-renderer";
+import { QuestionnaireRatingScaleInstructions } from "@/features/questionnaires/components/questionnaire-rating-scale-instructions";
+import { useMe } from "@/features/auth/hooks/use-me";
+import { FacultyEvaluationPageShell } from "@/features/faculty-evaluation/components/faculty-evaluation-page-shell";
+import { useRoleSubmitFacultyEvaluation } from "@/features/faculty-evaluation/hooks/use-role-submit-faculty-evaluation";
+import { useAutoSaveDraft } from "@/features/questionnaires/hooks/use-save-draft";
+import { collectRequiredIds } from "@/features/questionnaires/lib/evaluation-validation";
+import type {
+  FacultyEvaluationReadyData,
+  FacultyEvaluationRoleContext,
+} from "@/features/faculty-evaluation/types";
+import type { QuestionnaireFormValues } from "@/features/questionnaires/types";
+
+type FacultyEvaluationFormProps = {
+  role: FacultyEvaluationRoleContext;
+  semesterLabel: string;
+  returnHref: string;
+  data: FacultyEvaluationReadyData;
+};
+
+export function FacultyEvaluationForm({
+  role,
+  semesterLabel,
+  returnHref,
+  data,
+}: FacultyEvaluationFormProps) {
+  const formValuesRef = useRef<QuestionnaireFormValues | null>(null);
+  const [draftStatus, setDraftStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [showSuccessDialog, setShowSuccessDialog] = useState(false);
+
+  const meQuery = useMe();
+  const { mutate, isPending, invalidateAndNavigate } = useRoleSubmitFacultyEvaluation(returnHref);
+
+  const { debouncedSave, cancel: cancelAutoSave } = useAutoSaveDraft({
+    versionId: data.activeVersion.id,
+    facultyId: data.facultyId,
+    semesterId: data.semesterId,
+    onStatusChange: setDraftStatus,
+  });
+
+  const handleChange = useCallback(
+    (values: QuestionnaireFormValues) => {
+      formValuesRef.current = values;
+      debouncedSave(values);
+    },
+    [debouncedSave]
+  );
+
+  const handleSubmit = useCallback(() => {
+    const values = formValuesRef.current;
+    if (!values) return;
+
+    const respondentId = meQuery.data?.id;
+    if (!respondentId) {
+      toast.error("Unable to identify your account. Please try again.");
+      return;
+    }
+
+    const requiredIds = data.model.sections.flatMap(collectRequiredIds);
+    const unanswered = requiredIds.filter((id) => !(id in values.answers));
+
+    if (unanswered.length > 0) {
+      toast.error(`Please answer all required questions. ${unanswered.length} remaining.`);
+      return;
+    }
+
+    if (
+      data.model.qualitative.enabled &&
+      data.model.qualitative.required &&
+      !values.qualitativeComment.trim()
+    ) {
+      toast.error("Please provide your comments before submitting.");
+      return;
+    }
+
+    cancelAutoSave();
+
+    // TODO: Remove `respondentId` once the backend derives final submission identity from JWT.
+    mutate(
+      {
+        versionId: data.activeVersion.id,
+        respondentId,
+        facultyId: data.facultyId,
+        semesterId: data.semesterId,
+        answers: values.answers,
+        qualitativeComment: values.qualitativeComment || undefined,
+      },
+      {
+        onSuccess: () => setShowSuccessDialog(true),
+      }
+    );
+  }, [cancelAutoSave, data, meQuery.data?.id, mutate]);
+
+  return (
+    <FacultyEvaluationPageShell
+      role={role}
+      facultyName={data.facultyName}
+      semesterLabel={semesterLabel}
+      questionnaireTypeName={data.selectedType.name}
+      backHref={returnHref}
+    >
+      <div className="mt-8">
+        <QuestionnaireRatingScaleInstructions />
+      </div>
+
+      <div className="mt-8">
+        <QuestionnaireFormRenderer
+          key={`${data.selectedTypeId}:${data.draftHydrationKey}`}
+          model={data.model}
+          mode="interactive"
+          defaultValues={data.defaultValues}
+          onChange={handleChange}
+          progressTrailing={
+            draftStatus !== "idle" ? (
+              <Badge
+                variant="ghost"
+                className={
+                  draftStatus === "error"
+                    ? "badge-status-deprecated"
+                    : draftStatus === "saved"
+                      ? "badge-status-active"
+                      : "badge-status-draft"
+                }
+              >
+                {draftStatus === "saving" && "Saving draft..."}
+                {draftStatus === "saved" && "Draft saved"}
+                {draftStatus === "error" && "Draft save failed"}
+              </Badge>
+            ) : null
+          }
+        />
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-center justify-end gap-3">
+        <Button variant="brand" onClick={handleSubmit} disabled={isPending}>
+          {isPending ? (
+            <>
+              <Loader2 className="mr-2 size-4 animate-spin" />
+              Submitting...
+            </>
+          ) : (
+            "Submit Evaluation"
+          )}
+        </Button>
+      </div>
+
+      <Dialog open={showSuccessDialog} onOpenChange={setShowSuccessDialog}>
+        <DialogContent
+          className="text-center sm:max-w-md"
+          onInteractOutside={(event) => event.preventDefault()}
+        >
+          <DialogHeader className="items-center">
+            <CheckCircle2 className="size-12 text-green-500" />
+            <DialogTitle className="font-playfair text-xl">Evaluation Submitted</DialogTitle>
+            <DialogDescription className="text-center">
+              Your evaluation has been submitted successfully.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="sm:justify-center">
+            <Button variant="brand" onClick={invalidateAndNavigate}>
+              Back to Evaluation
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </FacultyEvaluationPageShell>
+  );
+}

--- a/features/faculty-evaluation/components/faculty-evaluation-list-screen.tsx
+++ b/features/faculty-evaluation/components/faculty-evaluation-list-screen.tsx
@@ -1,23 +1,13 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { ChevronDown, Search } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { ALL_PROGRAMS_VALUE } from "@/features/faculty-analytics/constants/filters";
-import { EvaluationViewToggle } from "@/features/faculty-evaluation/components/evaluation-view-toggle";
 import { FacultyGrid } from "@/features/faculty-evaluation/components/faculty-grid";
 import { FacultyList } from "@/features/faculty-evaluation/components/faculty-list";
 import { FacultyListState } from "@/features/faculty-evaluation/components/faculty-list-state";
+import { FacultyEvaluationToolbar } from "@/features/faculty-evaluation/components/faculty-evaluation-toolbar";
 import { useFacultyEvaluationListViewModel } from "@/features/faculty-evaluation/hooks/use-faculty-evaluation-list-view-model";
+import { getEvaluatorQuestionnaireTypes } from "@/features/faculty-evaluation/lib/questionnaire-types";
 import type {
   FacultyEvaluationRoleContext,
   FacultyEvaluationViewMode,
@@ -25,7 +15,6 @@ import type {
 import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
 
 const VIEW_STORAGE_KEY = "faculytics-faculty-evaluation-view";
-const STUDENT_ONLY_QUESTIONNAIRE_TYPE_CODE = "FACULTY_FEEDBACK";
 
 function getInitialViewMode(): FacultyEvaluationViewMode {
   if (typeof window === "undefined") {
@@ -40,10 +29,7 @@ export function FacultyEvaluationListScreen({ role }: { role: FacultyEvaluationR
   const [viewMode, setViewMode] = useState<FacultyEvaluationViewMode>(getInitialViewMode);
   const questionnaireTypesQuery = useQuestionnaireTypes();
   const evaluatorQuestionnaireTypes = useMemo(
-    () =>
-      (questionnaireTypesQuery.data ?? []).filter(
-        (type) => type.code !== STUDENT_ONLY_QUESTIONNAIRE_TYPE_CODE
-      ),
+    () => getEvaluatorQuestionnaireTypes(questionnaireTypesQuery.data),
     [questionnaireTypesQuery.data]
   );
   const {
@@ -109,85 +95,21 @@ export function FacultyEvaluationListScreen({ role }: { role: FacultyEvaluationR
         </div>
       </div>
 
-      <div className="mt-8 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-        <div className="relative w-full lg:max-w-sm">
-          <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            value={searchValue}
-            onChange={(event) => setSearchValue(event.target.value)}
-            placeholder="Search faculty name..."
-            className="pl-9"
-            aria-label="Search faculty name"
-          />
-        </div>
-        <div className="flex w-full flex-col gap-3 sm:flex-row lg:w-auto">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm sm:w-56"
-                disabled={!selectedSemesterId || programs.length === 0}
-              >
-                <span className="truncate">{selectedProgramLabel}</span>
-                <ChevronDown className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
-            >
-              <DropdownMenuRadioGroup
-                value={selectedProgramId ?? ALL_PROGRAMS_VALUE}
-                onValueChange={setSelectedProgramId}
-              >
-                {programs.map((program) => (
-                  <DropdownMenuRadioItem
-                    key={program.id ?? ALL_PROGRAMS_VALUE}
-                    value={program.id ?? ALL_PROGRAMS_VALUE}
-                    className="font-sans text-sm"
-                  >
-                    {program.label}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm sm:w-56"
-                disabled={semesters.length === 0}
-              >
-                <span className="truncate">{selectedSemesterLabel}</span>
-                <ChevronDown className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
-            >
-              <DropdownMenuRadioGroup
-                value={selectedSemesterId ?? ""}
-                onValueChange={setSelectedSemesterId}
-              >
-                {semesters.map((semester) => (
-                  <DropdownMenuRadioItem
-                    key={semester.id}
-                    value={semester.id}
-                    className="font-sans text-sm"
-                  >
-                    {semester.label}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          {facultyRows.length > 0 && selectedSemesterId ? (
-            <EvaluationViewToggle value={viewMode} onValueChange={setViewMode} />
-          ) : null}
-        </div>
-      </div>
+      <FacultyEvaluationToolbar
+        searchValue={searchValue}
+        onSearchChange={setSearchValue}
+        programs={programs}
+        selectedProgramId={selectedProgramId}
+        selectedProgramLabel={selectedProgramLabel}
+        onProgramChange={setSelectedProgramId}
+        semesters={semesters}
+        selectedSemesterId={selectedSemesterId}
+        selectedSemesterLabel={selectedSemesterLabel}
+        onSemesterChange={setSelectedSemesterId}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        showViewToggle={facultyRows.length > 0 && Boolean(selectedSemesterId)}
+      />
 
       <div
         className={

--- a/features/faculty-evaluation/components/faculty-evaluation-list-screen.tsx
+++ b/features/faculty-evaluation/components/faculty-evaluation-list-screen.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ChevronDown, Search } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { ALL_PROGRAMS_VALUE } from "@/features/faculty-analytics/constants/filters";
+import { EvaluationViewToggle } from "@/features/faculty-evaluation/components/evaluation-view-toggle";
+import { FacultyGrid } from "@/features/faculty-evaluation/components/faculty-grid";
+import { FacultyList } from "@/features/faculty-evaluation/components/faculty-list";
+import { FacultyListState } from "@/features/faculty-evaluation/components/faculty-list-state";
+import { useFacultyEvaluationListViewModel } from "@/features/faculty-evaluation/hooks/use-faculty-evaluation-list-view-model";
+import type {
+  FacultyEvaluationRoleContext,
+  FacultyEvaluationViewMode,
+} from "@/features/faculty-evaluation/types";
+import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+
+const VIEW_STORAGE_KEY = "faculytics-faculty-evaluation-view";
+const STUDENT_ONLY_QUESTIONNAIRE_TYPE_CODE = "FACULTY_FEEDBACK";
+
+function getInitialViewMode(): FacultyEvaluationViewMode {
+  if (typeof window === "undefined") {
+    return "card";
+  }
+
+  const storedView = window.localStorage.getItem(VIEW_STORAGE_KEY);
+  return storedView === "list" || storedView === "card" ? storedView : "card";
+}
+
+export function FacultyEvaluationListScreen({ role }: { role: FacultyEvaluationRoleContext }) {
+  const [viewMode, setViewMode] = useState<FacultyEvaluationViewMode>(getInitialViewMode);
+  const questionnaireTypesQuery = useQuestionnaireTypes();
+  const evaluatorQuestionnaireTypes = useMemo(
+    () =>
+      (questionnaireTypesQuery.data ?? []).filter(
+        (type) => type.code !== STUDENT_ONLY_QUESTIONNAIRE_TYPE_CODE
+      ),
+    [questionnaireTypesQuery.data]
+  );
+  const {
+    semesters,
+    programs,
+    selectedSemesterId,
+    selectedSemesterLabel,
+    selectedProgramId,
+    selectedProgramLabel,
+    facultyRows,
+    totalItems,
+    searchValue,
+    isLoading,
+    isError,
+    setSelectedSemesterId,
+    setSelectedProgramId,
+    setSearchValue,
+  } = useFacultyEvaluationListViewModel();
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(VIEW_STORAGE_KEY, viewMode);
+    }
+  }, [viewMode]);
+
+  const helperCopy = selectedSemesterId
+    ? `Showing ${totalItems} faculty member${totalItems === 1 ? "" : "s"} for the selected semester.`
+    : "Select a semester to load faculty members for evaluation.";
+
+  const content =
+    isLoading && selectedSemesterId ? (
+      <FacultyListState state="loading" message="Fetching faculty members for evaluation..." />
+    ) : isError ? (
+      <FacultyListState state="error" message="Unable to load scoped faculty data." />
+    ) : facultyRows.length === 0 ? (
+      <FacultyListState state="empty" />
+    ) : viewMode === "card" ? (
+      <FacultyGrid
+        facultyRows={facultyRows}
+        role={role}
+        semesterId={selectedSemesterId ?? ""}
+        semesterLabel={selectedSemesterLabel}
+        questionnaireTypes={evaluatorQuestionnaireTypes}
+        typesLoading={questionnaireTypesQuery.isLoading}
+      />
+    ) : (
+      <FacultyList
+        facultyRows={facultyRows}
+        role={role}
+        semesterId={selectedSemesterId ?? ""}
+        semesterLabel={selectedSemesterLabel}
+        questionnaireTypes={evaluatorQuestionnaireTypes}
+        typesLoading={questionnaireTypesQuery.isLoading}
+      />
+    );
+
+  return (
+    <section className="md:px-16 md:py-12">
+      <div>
+        <div>
+          <h1 className="font-playfair text-3xl font-bold">Evaluation</h1>
+          <p className="mt-2 text-sm text-muted-foreground">{helperCopy}</p>
+        </div>
+      </div>
+
+      <div className="mt-8 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="relative w-full lg:max-w-sm">
+          <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={searchValue}
+            onChange={(event) => setSearchValue(event.target.value)}
+            placeholder="Search faculty name..."
+            className="pl-9"
+            aria-label="Search faculty name"
+          />
+        </div>
+        <div className="flex w-full flex-col gap-3 sm:flex-row lg:w-auto">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm sm:w-56"
+                disabled={!selectedSemesterId || programs.length === 0}
+              >
+                <span className="truncate">{selectedProgramLabel}</span>
+                <ChevronDown className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
+            >
+              <DropdownMenuRadioGroup
+                value={selectedProgramId ?? ALL_PROGRAMS_VALUE}
+                onValueChange={setSelectedProgramId}
+              >
+                {programs.map((program) => (
+                  <DropdownMenuRadioItem
+                    key={program.id ?? ALL_PROGRAMS_VALUE}
+                    value={program.id ?? ALL_PROGRAMS_VALUE}
+                    className="font-sans text-sm"
+                  >
+                    {program.label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm sm:w-56"
+                disabled={semesters.length === 0}
+              >
+                <span className="truncate">{selectedSemesterLabel}</span>
+                <ChevronDown className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
+            >
+              <DropdownMenuRadioGroup
+                value={selectedSemesterId ?? ""}
+                onValueChange={setSelectedSemesterId}
+              >
+                {semesters.map((semester) => (
+                  <DropdownMenuRadioItem
+                    key={semester.id}
+                    value={semester.id}
+                    className="font-sans text-sm"
+                  >
+                    {semester.label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          {facultyRows.length > 0 && selectedSemesterId ? (
+            <EvaluationViewToggle value={viewMode} onValueChange={setViewMode} />
+          ) : null}
+        </div>
+      </div>
+
+      <div
+        className={
+          viewMode === "card"
+            ? "mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+            : "mt-8 space-y-4"
+        }
+      >
+        {content}
+      </div>
+    </section>
+  );
+}

--- a/features/faculty-evaluation/components/faculty-evaluation-list-screen.tsx
+++ b/features/faculty-evaluation/components/faculty-evaluation-list-screen.tsx
@@ -192,7 +192,7 @@ export function FacultyEvaluationListScreen({ role }: { role: FacultyEvaluationR
       <div
         className={
           viewMode === "card"
-            ? "mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+            ? "mt-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6"
             : "mt-8 space-y-4"
         }
       >

--- a/features/faculty-evaluation/components/faculty-evaluation-page-shell.tsx
+++ b/features/faculty-evaluation/components/faculty-evaluation-page-shell.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import type { FacultyEvaluationRoleContext } from "@/features/faculty-evaluation/types";
+
+type FacultyEvaluationPageShellProps = {
+  role: FacultyEvaluationRoleContext;
+  children: React.ReactNode;
+  facultyName?: string;
+  semesterLabel?: string;
+  questionnaireTypeName?: string;
+  backHref?: string;
+};
+
+export function FacultyEvaluationPageShell({
+  role,
+  children,
+  facultyName,
+  semesterLabel,
+  questionnaireTypeName,
+  backHref,
+}: FacultyEvaluationPageShellProps) {
+  return (
+    <section className="px-4 py-5 sm:px-6 md:px-10 md:py-10">
+      <div className="mx-auto max-w-6xl">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+              Faculty Evaluation
+            </h1>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+              {role.roleLabel} respondents can evaluate faculty members within their authorized
+              scope using the currently active questionnaire.
+            </p>
+          </div>
+          <Button asChild variant="outline" className="shrink-0 self-start">
+            <Link href={backHref ?? `${role.rolePath}/evaluation`}>Back to Evaluation</Link>
+          </Button>
+        </div>
+
+        {(facultyName || semesterLabel || questionnaireTypeName) && (
+          <Card className="mt-8 overflow-hidden border-border/70 bg-card shadow-sm">
+            <CardContent className="grid gap-0 p-0 md:grid-cols-3">
+              {facultyName ? (
+                <div className="flex flex-col items-center px-5 py-5 text-center sm:px-6">
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                    Faculty
+                  </p>
+                  <p className="mt-2 font-playfair text-xl font-semibold leading-tight text-foreground">
+                    {facultyName}
+                  </p>
+                </div>
+              ) : null}
+              {semesterLabel ? (
+                <div className="flex flex-col items-center border-t border-border/60 px-5 py-5 text-center sm:px-6 md:border-t-0 md:border-l">
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                    Semester
+                  </p>
+                  <p className="mt-2 text-base font-semibold leading-6 text-foreground sm:text-lg">
+                    {semesterLabel}
+                  </p>
+                </div>
+              ) : null}
+              {questionnaireTypeName ? (
+                <div className="flex flex-col items-center border-t border-border/60 px-5 py-5 text-center sm:px-6 md:border-t-0 md:border-l">
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                    Questionnaire Type
+                  </p>
+                  <p className="mt-2 text-base font-semibold leading-6 text-foreground sm:text-lg">
+                    {questionnaireTypeName}
+                  </p>
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+        )}
+
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/features/faculty-evaluation/components/faculty-evaluation-toolbar.tsx
+++ b/features/faculty-evaluation/components/faculty-evaluation-toolbar.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { ChevronDown, Search } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { ALL_PROGRAMS_VALUE } from "@/features/faculty-analytics/constants/filters";
+import { EvaluationViewToggle } from "@/features/faculty-evaluation/components/evaluation-view-toggle";
+import type { FacultyEvaluationViewMode } from "@/features/faculty-evaluation/types";
+
+type Option = {
+  id: string | null;
+  label: string;
+};
+
+type FacultyEvaluationToolbarProps = {
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  programs: Option[];
+  selectedProgramId: string | null;
+  selectedProgramLabel: string;
+  onProgramChange: (value: string) => void;
+  semesters: Option[];
+  selectedSemesterId: string | null;
+  selectedSemesterLabel: string;
+  onSemesterChange: (value: string) => void;
+  viewMode: FacultyEvaluationViewMode;
+  onViewModeChange: (value: FacultyEvaluationViewMode) => void;
+  showViewToggle: boolean;
+};
+
+export function FacultyEvaluationToolbar({
+  searchValue,
+  onSearchChange,
+  programs,
+  selectedProgramId,
+  selectedProgramLabel,
+  onProgramChange,
+  semesters,
+  selectedSemesterId,
+  selectedSemesterLabel,
+  onSemesterChange,
+  viewMode,
+  onViewModeChange,
+  showViewToggle,
+}: FacultyEvaluationToolbarProps) {
+  return (
+    <div className="mt-8 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <div className="relative w-full lg:max-w-sm">
+        <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={searchValue}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder="Search faculty name..."
+          className="pl-9"
+          aria-label="Search faculty name"
+        />
+      </div>
+      <div className="flex w-full flex-col gap-3 sm:flex-row lg:w-auto">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm sm:w-56"
+              disabled={!selectedSemesterId || programs.length === 0}
+            >
+              <span className="truncate">{selectedProgramLabel}</span>
+              <ChevronDown className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
+          >
+            <DropdownMenuRadioGroup
+              value={selectedProgramId ?? ALL_PROGRAMS_VALUE}
+              onValueChange={onProgramChange}
+            >
+              {programs.map((program) => (
+                <DropdownMenuRadioItem
+                  key={program.id ?? ALL_PROGRAMS_VALUE}
+                  value={program.id ?? ALL_PROGRAMS_VALUE}
+                  className="font-sans text-sm"
+                >
+                  {program.label}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm sm:w-56"
+              disabled={semesters.length === 0}
+            >
+              <span className="truncate">{selectedSemesterLabel}</span>
+              <ChevronDown className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
+          >
+            <DropdownMenuRadioGroup
+              value={selectedSemesterId ?? ""}
+              onValueChange={onSemesterChange}
+            >
+              {semesters.map((semester) => (
+                <DropdownMenuRadioItem
+                  key={semester.id ?? ""}
+                  value={semester.id ?? ""}
+                  className="font-sans text-sm"
+                >
+                  {semester.label}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {showViewToggle ? (
+          <EvaluationViewToggle value={viewMode} onValueChange={onViewModeChange} />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/features/faculty-evaluation/components/faculty-grid.tsx
+++ b/features/faculty-evaluation/components/faculty-grid.tsx
@@ -1,12 +1,12 @@
 import { FacultyCard } from "@/features/faculty-evaluation/components/faculty-card";
 import type {
+  FacultyEvaluationListItem,
   FacultyEvaluationRoleContext,
-  FacultyEvaluationRow,
 } from "@/features/faculty-evaluation/types";
 import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
 
 type FacultyGridProps = {
-  facultyRows: FacultyEvaluationRow[];
+  facultyRows: FacultyEvaluationListItem[];
   role: FacultyEvaluationRoleContext;
   semesterId: string;
   semesterLabel: string;

--- a/features/faculty-evaluation/components/faculty-grid.tsx
+++ b/features/faculty-evaluation/components/faculty-grid.tsx
@@ -1,0 +1,40 @@
+import { FacultyCard } from "@/features/faculty-evaluation/components/faculty-card";
+import type {
+  FacultyEvaluationRoleContext,
+  FacultyEvaluationRow,
+} from "@/features/faculty-evaluation/types";
+import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
+
+type FacultyGridProps = {
+  facultyRows: FacultyEvaluationRow[];
+  role: FacultyEvaluationRoleContext;
+  semesterId: string;
+  semesterLabel: string;
+  questionnaireTypes: QuestionnaireTypeSummary[];
+  typesLoading?: boolean;
+};
+
+export function FacultyGrid({
+  facultyRows,
+  role,
+  semesterId,
+  semesterLabel,
+  questionnaireTypes,
+  typesLoading = false,
+}: FacultyGridProps) {
+  return (
+    <>
+      {facultyRows.map((faculty) => (
+        <FacultyCard
+          key={faculty.id}
+          faculty={faculty}
+          role={role}
+          semesterId={semesterId}
+          semesterLabel={semesterLabel}
+          questionnaireTypes={questionnaireTypes}
+          typesLoading={typesLoading}
+        />
+      ))}
+    </>
+  );
+}

--- a/features/faculty-evaluation/components/faculty-list-state.tsx
+++ b/features/faculty-evaluation/components/faculty-list-state.tsx
@@ -1,0 +1,31 @@
+import { Loader2 } from "lucide-react";
+
+type FacultyListStateProps = {
+  state: "loading" | "error" | "empty";
+  message?: string;
+};
+
+export function FacultyListState({ state, message }: FacultyListStateProps) {
+  if (state === "loading") {
+    return (
+      <div className="col-span-full flex min-h-48 flex-col items-center justify-center gap-3 rounded-lg border border-dashed text-muted-foreground">
+        <Loader2 className="size-5 animate-spin" />
+        <p className="text-sm">{message ?? "Fetching faculty members..."}</p>
+      </div>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <div className="col-span-full rounded-lg border border-dashed p-6 text-sm text-destructive">
+        {message ?? "Unable to load faculty members right now."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="col-span-full rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+      No faculty members are available for evaluation for the selected semester.
+    </div>
+  );
+}

--- a/features/faculty-evaluation/components/faculty-list.tsx
+++ b/features/faculty-evaluation/components/faculty-list.tsx
@@ -9,13 +9,13 @@ import {
 } from "@/components/ui/table";
 import { EvaluateActionMenu } from "@/features/faculty-evaluation/components/evaluate-action-menu";
 import type {
+  FacultyEvaluationListItem,
   FacultyEvaluationRoleContext,
-  FacultyEvaluationRow,
 } from "@/features/faculty-evaluation/types";
 import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
 
 type FacultyListProps = {
-  facultyRows: FacultyEvaluationRow[];
+  facultyRows: FacultyEvaluationListItem[];
   role: FacultyEvaluationRoleContext;
   semesterId: string;
   semesterLabel: string;

--- a/features/faculty-evaluation/components/faculty-list.tsx
+++ b/features/faculty-evaluation/components/faculty-list.tsx
@@ -1,0 +1,95 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { EvaluateActionMenu } from "@/features/faculty-evaluation/components/evaluate-action-menu";
+import type {
+  FacultyEvaluationRoleContext,
+  FacultyEvaluationRow,
+} from "@/features/faculty-evaluation/types";
+import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
+
+type FacultyListProps = {
+  facultyRows: FacultyEvaluationRow[];
+  role: FacultyEvaluationRoleContext;
+  semesterId: string;
+  semesterLabel: string;
+  questionnaireTypes: QuestionnaireTypeSummary[];
+  typesLoading?: boolean;
+};
+
+function getInitials(fullName: string) {
+  return (
+    fullName
+      .split(" ")
+      .map((part) => part[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase() || "F"
+  );
+}
+
+export function FacultyList({
+  facultyRows,
+  role,
+  semesterId,
+  semesterLabel,
+  questionnaireTypes,
+  typesLoading = false,
+}: FacultyListProps) {
+  return (
+    <div className="data-table-wrapper">
+      <Table>
+        <TableHeader className="data-table-header">
+          <TableRow>
+            <TableHead className="data-table-head w-[30%]">Faculty</TableHead>
+            <TableHead className="data-table-head w-[50%]">Subjects</TableHead>
+            <TableHead className="data-table-head w-[20%] text-right">Action</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {facultyRows.map((faculty) => {
+            return (
+              <TableRow key={faculty.id} className="data-table-row">
+                <TableCell className="data-table-cell">
+                  <div className="flex items-center gap-2.5">
+                    <Avatar size="sm">
+                      {faculty.profilePicture ? (
+                        <AvatarImage src={faculty.profilePicture} alt={faculty.fullName} />
+                      ) : null}
+                      <AvatarFallback>{getInitials(faculty.fullName)}</AvatarFallback>
+                    </Avatar>
+                    <div className="min-w-0">
+                      <span className="block truncate font-medium">{faculty.fullName}</span>
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell className="data-table-cell text-muted-foreground whitespace-normal">
+                  {faculty.subjects.length
+                    ? faculty.subjects.join(", ")
+                    : "Faculty subjects will appear once scoped teaching assignments are available."}
+                </TableCell>
+                <TableCell className="data-table-cell text-right">
+                  <EvaluateActionMenu
+                    facultyId={faculty.id}
+                    facultyName={faculty.fullName}
+                    semesterId={semesterId}
+                    semesterLabel={semesterLabel}
+                    role={role}
+                    questionnaireTypes={questionnaireTypes}
+                    disabled={typesLoading}
+                  />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/features/faculty-evaluation/hooks/use-faculty-evaluation-detail-context.ts
+++ b/features/faculty-evaluation/hooks/use-faculty-evaluation-detail-context.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { getEvaluatorQuestionnaireTypes } from "@/features/faculty-evaluation/lib/questionnaire-types";
+import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import type {
+  FacultyEvaluationDetailContext,
+  FacultyEvaluationDetailResult,
+} from "@/features/faculty-evaluation/types";
+
+type UseFacultyEvaluationDetailContextOptions = {
+  facultyId: string;
+  facultyName?: string;
+  semesterId: string;
+  selectedTypeId?: string | null;
+};
+
+type FacultyEvaluationResolvedContext = {
+  status: "resolved";
+  detail: FacultyEvaluationDetailContext;
+  availableTypes: ReturnType<typeof getEvaluatorQuestionnaireTypes>;
+  selectedTypeId: string;
+  selectedType: ReturnType<typeof getEvaluatorQuestionnaireTypes>[number];
+};
+
+type FacultyEvaluationUnresolvedContext = Exclude<
+  FacultyEvaluationDetailResult,
+  | { status: "ready"; data: unknown }
+  | { status: "already-submitted"; detail: unknown }
+  | { status: "no-version"; detail: unknown }
+> & {
+  status: "loading" | "error" | "missing-context" | "no-types";
+};
+
+export function useFacultyEvaluationDetailContext({
+  facultyId,
+  facultyName,
+  semesterId,
+  selectedTypeId: selectedTypeIdProp,
+}: UseFacultyEvaluationDetailContextOptions):
+  | FacultyEvaluationResolvedContext
+  | FacultyEvaluationUnresolvedContext {
+  const typesQuery = useQuestionnaireTypes();
+  const availableTypes = getEvaluatorQuestionnaireTypes(typesQuery.data);
+  const detail: FacultyEvaluationDetailContext = {
+    facultyId,
+    facultyName,
+    semesterId,
+  };
+
+  if (!facultyId || !semesterId) {
+    return {
+      status: "missing-context",
+      message: "Missing faculty evaluation context. Start from the evaluation list page.",
+      availableTypes,
+      selectedTypeId: null,
+    };
+  }
+
+  if (!selectedTypeIdProp) {
+    return {
+      status: "missing-context",
+      message: "Missing questionnaire type. Start from the evaluation list page.",
+      availableTypes,
+      selectedTypeId: null,
+    };
+  }
+
+  if (typesQuery.isLoading) {
+    return {
+      status: "loading",
+      message: "Loading questionnaire types...",
+      availableTypes,
+      selectedTypeId: selectedTypeIdProp,
+    };
+  }
+
+  if (typesQuery.isError) {
+    return {
+      status: "error",
+      message: "Unable to load questionnaire types.",
+      availableTypes,
+      selectedTypeId: selectedTypeIdProp,
+    };
+  }
+
+  const selectedType = availableTypes.find((type) => type.id === selectedTypeIdProp) ?? null;
+
+  if (!selectedType) {
+    return {
+      status: "no-types",
+      message: "No questionnaire types are currently available for evaluation.",
+      availableTypes,
+      selectedTypeId: selectedTypeIdProp,
+    };
+  }
+
+  return {
+    status: "resolved",
+    detail,
+    availableTypes,
+    selectedTypeId: selectedType.id,
+    selectedType,
+  };
+}

--- a/features/faculty-evaluation/hooks/use-faculty-evaluation-detail.ts
+++ b/features/faculty-evaluation/hooks/use-faculty-evaluation-detail.ts
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+
+import { deleteDraft } from "@/features/questionnaires/api/questionnaire.requests";
+import { deserializeQuestionnaireVersionToDraft } from "@/features/questionnaires/lib/builder-deserializer";
+import { buildQuestionnairePreviewModel } from "@/features/questionnaires/lib/builder-serializer";
+import { useActiveQuestionnaireVersion } from "@/features/questionnaires/hooks/use-active-questionnaire-version";
+import { useCheckSubmission } from "@/features/questionnaires/hooks/use-check-submission";
+import { useEvaluationDraft } from "@/features/questionnaires/hooks/use-evaluation-draft";
+import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import type {
+  FacultyEvaluationDetailContext,
+  FacultyEvaluationDetailResult,
+} from "@/features/faculty-evaluation/types";
+
+const STUDENT_ONLY_QUESTIONNAIRE_TYPE_CODE = "FACULTY_FEEDBACK";
+
+type UseFacultyEvaluationDetailOptions = {
+  facultyId: string;
+  facultyName?: string;
+  semesterId: string;
+  selectedTypeId?: string | null;
+};
+
+export function useFacultyEvaluationDetail({
+  facultyId,
+  facultyName,
+  semesterId,
+  selectedTypeId: selectedTypeIdProp,
+}: UseFacultyEvaluationDetailOptions): FacultyEvaluationDetailResult {
+  const typesQuery = useQuestionnaireTypes();
+
+  const availableTypes =
+    typesQuery.data?.filter((type) => type.code !== STUDENT_ONLY_QUESTIONNAIRE_TYPE_CODE) ?? [];
+  const effectiveSelectedTypeId = selectedTypeIdProp ?? null;
+  const selectedType =
+    availableTypes.find((type) => type.id === effectiveSelectedTypeId) ?? availableTypes[0] ?? null;
+  const selectedTypeId = selectedType?.id ?? null;
+
+  const activeVersionQuery = useActiveQuestionnaireVersion(selectedTypeId, {
+    enabled: Boolean(selectedTypeId),
+  });
+
+  const detail: FacultyEvaluationDetailContext = {
+    facultyId,
+    facultyName,
+    semesterId,
+  };
+
+  const evaluationParams = useMemo(
+    () =>
+      activeVersionQuery.data
+        ? {
+            versionId: activeVersionQuery.data.id,
+            facultyId,
+            semesterId,
+          }
+        : null,
+    [activeVersionQuery.data, facultyId, semesterId]
+  );
+
+  const submissionCheck = useCheckSubmission(evaluationParams);
+  const draftQuery = useEvaluationDraft(evaluationParams, {
+    enabled:
+      Boolean(evaluationParams) && submissionCheck.isSuccess && !submissionCheck.data?.submitted,
+  });
+
+  const model = useMemo(
+    () =>
+      activeVersionQuery.data
+        ? buildQuestionnairePreviewModel({
+            ...deserializeQuestionnaireVersionToDraft(activeVersionQuery.data),
+            hydratedFromServer: true,
+          })
+        : null,
+    [activeVersionQuery.data]
+  );
+
+  const draft = draftQuery.data;
+  const isDraftStale = Boolean(
+    draft && activeVersionQuery.data && draft.versionId !== activeVersionQuery.data.id
+  );
+  const staleDeletedRef = useRef(false);
+
+  useEffect(() => {
+    if (isDraftStale && draft && !staleDeletedRef.current) {
+      staleDeletedRef.current = true;
+      void deleteDraft(draft.id);
+    }
+  }, [draft, isDraftStale]);
+
+  const defaultValues =
+    draft && !isDraftStale
+      ? {
+          answers: draft.answers,
+          qualitativeComment: draft.qualitativeComment ?? "",
+        }
+      : undefined;
+  const draftHydrationKey = draft && !isDraftStale ? draft.updatedAt : "fresh";
+
+  if (!facultyId || !semesterId) {
+    return {
+      status: "missing-context",
+      message: "Missing faculty evaluation context. Start from the evaluation list page.",
+      availableTypes,
+      selectedTypeId,
+    };
+  }
+
+  if (!selectedTypeIdProp) {
+    return {
+      status: "missing-context",
+      message: "Missing questionnaire type. Start from the evaluation list page.",
+      availableTypes,
+      selectedTypeId,
+    };
+  }
+
+  if (typesQuery.isLoading) {
+    return {
+      status: "loading",
+      message: "Loading questionnaire types...",
+      availableTypes,
+      selectedTypeId,
+    };
+  }
+
+  if (typesQuery.isError) {
+    return {
+      status: "error",
+      message: "Unable to load questionnaire types.",
+      availableTypes,
+      selectedTypeId,
+    };
+  }
+
+  if (availableTypes.length === 0 || !selectedType || !selectedTypeId) {
+    return {
+      status: "no-types",
+      message: "No questionnaire types are currently available for evaluation.",
+      availableTypes,
+      selectedTypeId,
+    };
+  }
+
+  if (activeVersionQuery.isLoading) {
+    return {
+      status: "loading",
+      message: "Loading questionnaire...",
+      availableTypes,
+      selectedTypeId,
+    };
+  }
+
+  if (activeVersionQuery.isError) {
+    return {
+      status: "error",
+      message: "Unable to load the selected questionnaire.",
+      availableTypes,
+      selectedTypeId,
+    };
+  }
+
+  if (!activeVersionQuery.data || !model) {
+    return {
+      status: "no-version",
+      message: "No active questionnaire is available for the selected type.",
+      availableTypes,
+      selectedTypeId,
+      detail,
+    };
+  }
+
+  if (submissionCheck.isLoading || draftQuery.isLoading) {
+    return {
+      status: "loading",
+      message: "Preparing your evaluation form...",
+      availableTypes,
+      selectedTypeId,
+    };
+  }
+
+  if (submissionCheck.isError || draftQuery.isError) {
+    return {
+      status: "error",
+      message: "Unable to prepare the evaluation form.",
+      availableTypes,
+      selectedTypeId,
+    };
+  }
+
+  if (submissionCheck.data?.submitted) {
+    return {
+      status: "already-submitted",
+      submittedAt: submissionCheck.data.submittedAt,
+      availableTypes,
+      selectedTypeId,
+      detail,
+    };
+  }
+
+  return {
+    status: "ready",
+    data: {
+      ...detail,
+      selectedTypeId,
+      selectedType,
+      availableTypes,
+      activeVersion: { id: activeVersionQuery.data.id },
+      model,
+      defaultValues,
+      draftHydrationKey,
+    },
+  };
+}

--- a/features/faculty-evaluation/hooks/use-faculty-evaluation-detail.ts
+++ b/features/faculty-evaluation/hooks/use-faculty-evaluation-detail.ts
@@ -1,20 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
-
-import { deleteDraft } from "@/features/questionnaires/api/questionnaire.requests";
-import { deserializeQuestionnaireVersionToDraft } from "@/features/questionnaires/lib/builder-deserializer";
-import { buildQuestionnairePreviewModel } from "@/features/questionnaires/lib/builder-serializer";
-import { useActiveQuestionnaireVersion } from "@/features/questionnaires/hooks/use-active-questionnaire-version";
-import { useCheckSubmission } from "@/features/questionnaires/hooks/use-check-submission";
-import { useEvaluationDraft } from "@/features/questionnaires/hooks/use-evaluation-draft";
-import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
-import type {
-  FacultyEvaluationDetailContext,
-  FacultyEvaluationDetailResult,
-} from "@/features/faculty-evaluation/types";
-
-const STUDENT_ONLY_QUESTIONNAIRE_TYPE_CODE = "FACULTY_FEEDBACK";
+import { useFacultyEvaluationDetailContext } from "@/features/faculty-evaluation/hooks/use-faculty-evaluation-detail-context";
+import { useFacultyEvaluationFormPreparation } from "@/features/faculty-evaluation/hooks/use-faculty-evaluation-form-preparation";
+import type { FacultyEvaluationDetailResult } from "@/features/faculty-evaluation/types";
 
 type UseFacultyEvaluationDetailOptions = {
   facultyId: string;
@@ -29,188 +17,27 @@ export function useFacultyEvaluationDetail({
   semesterId,
   selectedTypeId: selectedTypeIdProp,
 }: UseFacultyEvaluationDetailOptions): FacultyEvaluationDetailResult {
-  const typesQuery = useQuestionnaireTypes();
-
-  const availableTypes =
-    typesQuery.data?.filter((type) => type.code !== STUDENT_ONLY_QUESTIONNAIRE_TYPE_CODE) ?? [];
-  const effectiveSelectedTypeId = selectedTypeIdProp ?? null;
-  const selectedType =
-    availableTypes.find((type) => type.id === effectiveSelectedTypeId) ?? availableTypes[0] ?? null;
-  const selectedTypeId = selectedType?.id ?? null;
-
-  const activeVersionQuery = useActiveQuestionnaireVersion(selectedTypeId, {
-    enabled: Boolean(selectedTypeId),
-  });
-
-  const detail: FacultyEvaluationDetailContext = {
+  const detailContext = useFacultyEvaluationDetailContext({
     facultyId,
     facultyName,
     semesterId,
-  };
-
-  const evaluationParams = useMemo(
-    () =>
-      activeVersionQuery.data
-        ? {
-            versionId: activeVersionQuery.data.id,
-            facultyId,
-            semesterId,
-          }
-        : null,
-    [activeVersionQuery.data, facultyId, semesterId]
-  );
-
-  const submissionCheck = useCheckSubmission(evaluationParams);
-  const draftQuery = useEvaluationDraft(evaluationParams, {
-    enabled:
-      Boolean(evaluationParams) && submissionCheck.isSuccess && !submissionCheck.data?.submitted,
+    selectedTypeId: selectedTypeIdProp,
   });
 
-  const model = useMemo(
-    () =>
-      activeVersionQuery.data
-        ? buildQuestionnairePreviewModel({
-            ...deserializeQuestionnaireVersionToDraft(activeVersionQuery.data),
-            hydratedFromServer: true,
-          })
-        : null,
-    [activeVersionQuery.data]
-  );
-
-  const draft = draftQuery.data;
-  const isDraftStale = Boolean(
-    draft && activeVersionQuery.data && draft.versionId !== activeVersionQuery.data.id
-  );
-  const staleDeletedRef = useRef(false);
-
-  useEffect(() => {
-    if (isDraftStale && draft && !staleDeletedRef.current) {
-      staleDeletedRef.current = true;
-      void deleteDraft(draft.id);
-    }
-  }, [draft, isDraftStale]);
-
-  const defaultValues =
-    draft && !isDraftStale
+  const preparation = useFacultyEvaluationFormPreparation(
+    detailContext.status === "resolved"
       ? {
-          answers: draft.answers,
-          qualitativeComment: draft.qualitativeComment ?? "",
+          detail: detailContext.detail,
+          availableTypes: detailContext.availableTypes,
+          selectedTypeId: detailContext.selectedTypeId,
+          selectedType: detailContext.selectedType,
         }
-      : undefined;
-  const draftHydrationKey = draft && !isDraftStale ? draft.updatedAt : "fresh";
+      : null
+  );
 
-  if (!facultyId || !semesterId) {
-    return {
-      status: "missing-context",
-      message: "Missing faculty evaluation context. Start from the evaluation list page.",
-      availableTypes,
-      selectedTypeId,
-    };
+  if (detailContext.status !== "resolved") {
+    return detailContext;
   }
 
-  if (!selectedTypeIdProp) {
-    return {
-      status: "missing-context",
-      message: "Missing questionnaire type. Start from the evaluation list page.",
-      availableTypes,
-      selectedTypeId,
-    };
-  }
-
-  if (typesQuery.isLoading) {
-    return {
-      status: "loading",
-      message: "Loading questionnaire types...",
-      availableTypes,
-      selectedTypeId,
-    };
-  }
-
-  if (typesQuery.isError) {
-    return {
-      status: "error",
-      message: "Unable to load questionnaire types.",
-      availableTypes,
-      selectedTypeId,
-    };
-  }
-
-  if (availableTypes.length === 0 || !selectedType || !selectedTypeId) {
-    return {
-      status: "no-types",
-      message: "No questionnaire types are currently available for evaluation.",
-      availableTypes,
-      selectedTypeId,
-    };
-  }
-
-  if (activeVersionQuery.isLoading) {
-    return {
-      status: "loading",
-      message: "Loading questionnaire...",
-      availableTypes,
-      selectedTypeId,
-    };
-  }
-
-  if (activeVersionQuery.isError) {
-    return {
-      status: "error",
-      message: "Unable to load the selected questionnaire.",
-      availableTypes,
-      selectedTypeId,
-    };
-  }
-
-  if (!activeVersionQuery.data || !model) {
-    return {
-      status: "no-version",
-      message: "No active questionnaire is available for the selected type.",
-      availableTypes,
-      selectedTypeId,
-      detail,
-    };
-  }
-
-  if (submissionCheck.isLoading || draftQuery.isLoading) {
-    return {
-      status: "loading",
-      message: "Preparing your evaluation form...",
-      availableTypes,
-      selectedTypeId,
-    };
-  }
-
-  if (submissionCheck.isError || draftQuery.isError) {
-    return {
-      status: "error",
-      message: "Unable to prepare the evaluation form.",
-      availableTypes,
-      selectedTypeId,
-    };
-  }
-
-  if (submissionCheck.data?.submitted) {
-    return {
-      status: "already-submitted",
-      submittedAt: submissionCheck.data.submittedAt,
-      availableTypes,
-      selectedTypeId,
-      detail,
-    };
-  }
-
-  return {
-    status: "ready",
-    data: {
-      ...detail,
-      selectedTypeId,
-      selectedType,
-      availableTypes,
-      activeVersion: { id: activeVersionQuery.data.id },
-      model,
-      defaultValues,
-      draftHydrationKey,
-    },
-  };
+  return preparation;
 }

--- a/features/faculty-evaluation/hooks/use-faculty-evaluation-filters.ts
+++ b/features/faculty-evaluation/hooks/use-faculty-evaluation-filters.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useCallback, useDeferredValue, useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { ALL_PROGRAMS_VALUE } from "@/features/faculty-analytics/constants/filters";
+
+function setSearchParams(
+  pathname: string,
+  currentParams: URLSearchParams,
+  updates: Record<string, string | null>
+) {
+  const nextParams = new URLSearchParams(currentParams);
+
+  Object.entries(updates).forEach(([key, value]) => {
+    if (value && value.trim().length > 0) {
+      nextParams.set(key, value);
+    } else {
+      nextParams.delete(key);
+    }
+  });
+
+  const query = nextParams.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}
+
+type SyncEvaluationFiltersOptions = {
+  selectedSemesterId: string | null;
+  selectedProgramId: string | null;
+};
+
+export function useFacultyEvaluationFilters() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
+  const selectedSemesterIdParam = searchParams.get("semesterId");
+  const selectedProgramIdParam = searchParams.get("programId");
+  const searchParamValue = searchParams.get("search") ?? "";
+
+  const [searchValue, setSearchValueState] = useState(searchParamValue);
+  const deferredSearchValue = useDeferredValue(searchValue.trim());
+
+  useEffect(() => {
+    setSearchValueState(searchParamValue);
+  }, [searchParamValue]);
+
+  const replaceParams = useCallback(
+    (updates: Record<string, string | null>) => {
+      const nextHref = setSearchParams(pathname, new URLSearchParams(searchParamsString), updates);
+      router.replace(nextHref, { scroll: false });
+    },
+    [pathname, router, searchParamsString]
+  );
+
+  const syncFilters = useCallback(
+    ({ selectedSemesterId, selectedProgramId }: SyncEvaluationFiltersOptions) => {
+      if (!selectedSemesterId) return;
+
+      const nextHref = setSearchParams(pathname, new URLSearchParams(searchParamsString), {
+        semesterId: selectedSemesterId,
+        programId: selectedProgramId,
+        search: searchValue.trim() || null,
+      });
+      const currentHref = searchParamsString ? `${pathname}?${searchParamsString}` : pathname;
+
+      if (nextHref !== currentHref) {
+        router.replace(nextHref, { scroll: false });
+      }
+    },
+    [pathname, router, searchParamsString, searchValue]
+  );
+
+  return {
+    selectedSemesterIdParam,
+    selectedProgramIdParam,
+    searchValue,
+    deferredSearchValue,
+    searchParamsString,
+    syncFilters,
+    setSearchValue: setSearchValueState,
+    setSelectedSemesterId: (value: string) => {
+      replaceParams({
+        semesterId: value,
+        programId: null,
+      });
+    },
+    setSelectedProgramId: (value: string) => {
+      replaceParams({
+        programId: value === ALL_PROGRAMS_VALUE ? null : value,
+      });
+    },
+  };
+}

--- a/features/faculty-evaluation/hooks/use-faculty-evaluation-form-preparation.ts
+++ b/features/faculty-evaluation/hooks/use-faculty-evaluation-form-preparation.ts
@@ -1,0 +1,171 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+
+import { deleteDraft } from "@/features/questionnaires/api/questionnaire.requests";
+import { useActiveQuestionnaireVersion } from "@/features/questionnaires/hooks/use-active-questionnaire-version";
+import { useCheckSubmission } from "@/features/questionnaires/hooks/use-check-submission";
+import { useEvaluationDraft } from "@/features/questionnaires/hooks/use-evaluation-draft";
+import { deserializeQuestionnaireVersionToDraft } from "@/features/questionnaires/lib/builder-deserializer";
+import { buildQuestionnairePreviewModel } from "@/features/questionnaires/lib/builder-serializer";
+import type {
+  FacultyEvaluationDetailContext,
+  FacultyEvaluationDetailResult,
+  FacultyEvaluationReadyData,
+} from "@/features/faculty-evaluation/types";
+import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
+
+type UseFacultyEvaluationFormPreparationOptions = {
+  detail: FacultyEvaluationDetailContext;
+  availableTypes: QuestionnaireTypeSummary[];
+  selectedTypeId: string;
+  selectedType: QuestionnaireTypeSummary;
+};
+
+type FacultyEvaluationPreparedResult =
+  | Extract<FacultyEvaluationDetailResult, { status: "loading" | "error" }>
+  | Extract<FacultyEvaluationDetailResult, { status: "no-version" | "already-submitted" }>
+  | { status: "ready"; data: FacultyEvaluationReadyData };
+
+export function useFacultyEvaluationFormPreparation(
+  options: UseFacultyEvaluationFormPreparationOptions | null
+): FacultyEvaluationPreparedResult {
+  const detail = options?.detail ?? null;
+  const availableTypes = options?.availableTypes ?? [];
+  const selectedTypeId = options?.selectedTypeId ?? "";
+  const selectedType = options?.selectedType ?? null;
+  const effectiveSelectedTypeId = selectedTypeId ?? "";
+  const activeVersionQuery = useActiveQuestionnaireVersion(effectiveSelectedTypeId, {
+    enabled: Boolean(effectiveSelectedTypeId),
+  });
+
+  const evaluationParams = useMemo(
+    () =>
+      detail && activeVersionQuery.data
+        ? {
+            versionId: activeVersionQuery.data.id,
+            facultyId: detail.facultyId,
+            semesterId: detail.semesterId,
+          }
+        : null,
+    [activeVersionQuery.data, detail]
+  );
+
+  const submissionCheck = useCheckSubmission(evaluationParams);
+  const draftQuery = useEvaluationDraft(evaluationParams, {
+    enabled:
+      Boolean(evaluationParams) && submissionCheck.isSuccess && !submissionCheck.data?.submitted,
+  });
+
+  const model = useMemo(
+    () =>
+      activeVersionQuery.data
+        ? buildQuestionnairePreviewModel({
+            ...deserializeQuestionnaireVersionToDraft(activeVersionQuery.data),
+            hydratedFromServer: true,
+          })
+        : null,
+    [activeVersionQuery.data]
+  );
+
+  const draft = draftQuery.data;
+  const isDraftStale = Boolean(
+    draft && activeVersionQuery.data && draft.versionId !== activeVersionQuery.data.id
+  );
+  const staleDeletedRef = useRef(false);
+
+  useEffect(() => {
+    if (isDraftStale && draft && !staleDeletedRef.current) {
+      staleDeletedRef.current = true;
+      void deleteDraft(draft.id);
+    }
+  }, [draft, isDraftStale]);
+
+  const defaultValues =
+    draft && !isDraftStale
+      ? {
+          answers: draft.answers,
+          qualitativeComment: draft.qualitativeComment ?? "",
+        }
+      : undefined;
+  const draftHydrationKey = draft && !isDraftStale ? draft.updatedAt : "fresh";
+
+  if (!detail || !selectedType) {
+    return {
+      status: "loading",
+      message: "Preparing your evaluation form...",
+      availableTypes: availableTypes ?? [],
+      selectedTypeId: effectiveSelectedTypeId || null,
+    };
+  }
+
+  if (activeVersionQuery.isLoading) {
+    return {
+      status: "loading",
+      message: "Loading questionnaire...",
+      availableTypes,
+      selectedTypeId: effectiveSelectedTypeId,
+    };
+  }
+
+  if (activeVersionQuery.isError) {
+    return {
+      status: "error",
+      message: "Unable to load the selected questionnaire.",
+      availableTypes,
+      selectedTypeId: effectiveSelectedTypeId,
+    };
+  }
+
+  if (!activeVersionQuery.data || !model) {
+    return {
+      status: "no-version",
+      message: "No active questionnaire is available for the selected type.",
+      availableTypes,
+      selectedTypeId: effectiveSelectedTypeId,
+      detail,
+    };
+  }
+
+  if (submissionCheck.isLoading || draftQuery.isLoading) {
+    return {
+      status: "loading",
+      message: "Preparing your evaluation form...",
+      availableTypes,
+      selectedTypeId: effectiveSelectedTypeId,
+    };
+  }
+
+  if (submissionCheck.isError || draftQuery.isError) {
+    return {
+      status: "error",
+      message: "Unable to prepare the evaluation form.",
+      availableTypes,
+      selectedTypeId: effectiveSelectedTypeId,
+    };
+  }
+
+  if (submissionCheck.data?.submitted) {
+    return {
+      status: "already-submitted",
+      submittedAt: submissionCheck.data.submittedAt,
+      availableTypes,
+      selectedTypeId: effectiveSelectedTypeId,
+      detail,
+    };
+  }
+
+  return {
+    status: "ready",
+    data: {
+      ...detail,
+      selectedTypeId,
+      selectedType,
+      availableTypes,
+      activeVersion: { id: activeVersionQuery.data.id },
+      model,
+      defaultValues,
+      draftHydrationKey,
+    },
+  };
+}

--- a/features/faculty-evaluation/hooks/use-faculty-evaluation-list-data.ts
+++ b/features/faculty-evaluation/hooks/use-faculty-evaluation-list-data.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useMe } from "@/features/auth/hooks/use-me";
+import {
+  mapProgramOptionsToViewModel,
+  mapSemesterOptionsToViewModel,
+} from "@/features/faculty-analytics/lib/dean-analytics-view-model";
+import { useProgramOptions } from "@/features/faculty-analytics/hooks/use-program-options";
+import { useSemesterOptions } from "@/features/faculty-analytics/hooks/use-semester-options";
+import { useScopedFacultyList } from "@/features/faculty-evaluation/hooks/use-scoped-faculty-list";
+import type { FacultyEvaluationListItem } from "@/features/faculty-evaluation/types";
+
+const DEFAULT_LIMIT = 100;
+
+function mapRows(
+  facultyRows: readonly {
+    id: string;
+    fullName: string;
+    profilePicture: string | null;
+    subjects: string[];
+  }[]
+): FacultyEvaluationListItem[] {
+  return facultyRows.map((faculty) => ({
+    id: faculty.id,
+    fullName: faculty.fullName,
+    profilePicture: faculty.profilePicture,
+    subjects: faculty.subjects,
+  }));
+}
+
+type UseFacultyEvaluationListDataOptions = {
+  selectedSemesterIdParam: string | null;
+  selectedProgramIdParam: string | null;
+  deferredSearchValue: string;
+};
+
+export function useFacultyEvaluationListData({
+  selectedSemesterIdParam,
+  selectedProgramIdParam,
+  deferredSearchValue,
+}: UseFacultyEvaluationListDataOptions) {
+  const meQuery = useMe();
+  const campusId = meQuery.data?.campus?.id;
+  const semestersQuery = useSemesterOptions(campusId ? { campusId } : undefined, {
+    enabled: !meQuery.isLoading && !meQuery.isError,
+  });
+
+  const semesters = useMemo(
+    () => mapSemesterOptionsToViewModel(semestersQuery.data?.data ?? []),
+    [semestersQuery.data]
+  );
+
+  const selectedSemesterId =
+    selectedSemesterIdParam && semesters.some((semester) => semester.id === selectedSemesterIdParam)
+      ? selectedSemesterIdParam
+      : (semesters[0]?.id ?? null);
+
+  const selectedSemester =
+    semesters.find((semester) => semester.id === selectedSemesterId) ?? semesters[0] ?? null;
+
+  const programOptionsQuery = useProgramOptions(
+    { semesterId: selectedSemesterId ?? "", limit: DEFAULT_LIMIT },
+    { enabled: Boolean(selectedSemesterId) }
+  );
+
+  const programs = useMemo(
+    () => mapProgramOptionsToViewModel(programOptionsQuery.data?.data ?? []),
+    [programOptionsQuery.data]
+  );
+
+  const selectedProgram =
+    programs.find((program) => program.id === selectedProgramIdParam) ?? programs[0] ?? null;
+  const selectedProgramId = selectedProgram?.id ?? null;
+
+  const facultyListQuery = useScopedFacultyList(
+    {
+      semesterId: selectedSemesterId ?? "",
+      programId: selectedProgramId ?? undefined,
+      search: deferredSearchValue || undefined,
+      page: 1,
+      limit: DEFAULT_LIMIT,
+    },
+    { enabled: Boolean(selectedSemesterId) }
+  );
+
+  return {
+    semesters,
+    programs,
+    selectedSemesterId,
+    selectedSemesterLabel: selectedSemester?.label ?? "Select semester",
+    selectedProgramId,
+    selectedProgramLabel: selectedProgram?.label ?? "All Programs",
+    facultyRows: mapRows(facultyListQuery.data?.data ?? []),
+    totalItems: facultyListQuery.data?.meta.totalItems ?? 0,
+    isLoading:
+      meQuery.isLoading ||
+      semestersQuery.isLoading ||
+      (Boolean(selectedSemesterId) && programOptionsQuery.isLoading) ||
+      (Boolean(selectedSemesterId) && facultyListQuery.isLoading),
+    isError:
+      meQuery.isError ||
+      semestersQuery.isError ||
+      programOptionsQuery.isError ||
+      facultyListQuery.isError,
+    retry: () => {
+      void meQuery.refetch();
+      void semestersQuery.refetch();
+      if (selectedSemesterId) {
+        void programOptionsQuery.refetch();
+        void facultyListQuery.refetch();
+      }
+    },
+  };
+}

--- a/features/faculty-evaluation/hooks/use-faculty-evaluation-list-view-model.ts
+++ b/features/faculty-evaluation/hooks/use-faculty-evaluation-list-view-model.ts
@@ -1,0 +1,185 @@
+"use client";
+
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { useMe } from "@/features/auth/hooks/use-me";
+import {
+  ALL_PROGRAMS_LABEL,
+  ALL_PROGRAMS_VALUE,
+} from "@/features/faculty-analytics/constants/filters";
+import { useScopedFacultyList } from "@/features/faculty-evaluation/hooks/use-scoped-faculty-list";
+import type { FacultyEvaluationRow } from "@/features/faculty-evaluation/types";
+import {
+  mapProgramOptionsToViewModel,
+  mapSemesterOptionsToViewModel,
+} from "@/features/faculty-analytics/lib/dean-analytics-view-model";
+import { useProgramOptions } from "@/features/faculty-analytics/hooks/use-program-options";
+import { useSemesterOptions } from "@/features/faculty-analytics/hooks/use-semester-options";
+
+const DEFAULT_LIMIT = 100;
+
+function mapRows(
+  facultyRows: readonly {
+    id: string;
+    fullName: string;
+    profilePicture: string | null;
+    subjects: string[];
+  }[]
+): FacultyEvaluationRow[] {
+  return facultyRows.map((faculty) => ({
+    id: faculty.id,
+    fullName: faculty.fullName,
+    profilePicture: faculty.profilePicture,
+    subjects: faculty.subjects,
+  }));
+}
+
+function setSearchParams(
+  pathname: string,
+  currentParams: URLSearchParams,
+  updates: Record<string, string | null>
+) {
+  const nextParams = new URLSearchParams(currentParams);
+
+  Object.entries(updates).forEach(([key, value]) => {
+    if (value && value.trim().length > 0) {
+      nextParams.set(key, value);
+    } else {
+      nextParams.delete(key);
+    }
+  });
+
+  const query = nextParams.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}
+
+export function useFacultyEvaluationListViewModel() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
+  const searchParamValue = searchParams.get("search") ?? "";
+  const selectedSemesterIdParam = searchParams.get("semesterId");
+  const selectedProgramIdParam = searchParams.get("programId");
+
+  const [searchValue, setSearchValueState] = useState(searchParamValue);
+
+  const deferredSearchValue = useDeferredValue(searchValue.trim());
+
+  const meQuery = useMe();
+  const campusId = meQuery.data?.campus?.id;
+  const semestersQuery = useSemesterOptions(campusId ? { campusId } : undefined, {
+    enabled: !meQuery.isLoading && !meQuery.isError,
+  });
+
+  const semesters = useMemo(
+    () => mapSemesterOptionsToViewModel(semestersQuery.data?.data ?? []),
+    [semestersQuery.data]
+  );
+
+  const selectedSemesterId =
+    selectedSemesterIdParam && semesters.some((semester) => semester.id === selectedSemesterIdParam)
+      ? selectedSemesterIdParam
+      : (semesters[0]?.id ?? null);
+
+  const selectedSemester =
+    semesters.find((semester) => semester.id === selectedSemesterId) ?? semesters[0] ?? null;
+
+  const programOptionsQuery = useProgramOptions(
+    { semesterId: selectedSemesterId ?? "", limit: 100 },
+    { enabled: Boolean(selectedSemesterId) }
+  );
+
+  const programs = useMemo(
+    () => mapProgramOptionsToViewModel(programOptionsQuery.data?.data ?? []),
+    [programOptionsQuery.data]
+  );
+
+  const selectedProgram =
+    programs.find((program) => program.id === selectedProgramIdParam) ?? programs[0] ?? null;
+  const selectedProgramId = selectedProgram?.id ?? null;
+
+  useEffect(() => {
+    setSearchValueState(searchParamValue);
+  }, [searchParamValue]);
+
+  useEffect(() => {
+    if (!selectedSemesterId) return;
+
+    const nextHref = setSearchParams(pathname, new URLSearchParams(searchParamsString), {
+      semesterId: selectedSemesterId,
+      programId: selectedProgramId,
+      search: searchValue.trim() || null,
+    });
+    const currentHref = searchParamsString ? `${pathname}?${searchParamsString}` : pathname;
+
+    if (nextHref !== currentHref) {
+      router.replace(nextHref, { scroll: false });
+    }
+  }, [pathname, router, searchParamsString, searchValue, selectedProgramId, selectedSemesterId]);
+
+  const facultyListQuery = useScopedFacultyList(
+    {
+      semesterId: selectedSemesterId ?? "",
+      programId: selectedProgramId ?? undefined,
+      search: deferredSearchValue || undefined,
+      page: 1,
+      limit: DEFAULT_LIMIT,
+    },
+    { enabled: Boolean(selectedSemesterId) }
+  );
+
+  return {
+    semesters,
+    programs,
+    selectedSemesterId,
+    selectedSemesterLabel: selectedSemester?.label ?? "Select semester",
+    selectedProgramId,
+    selectedProgramLabel: selectedProgram?.label ?? ALL_PROGRAMS_LABEL,
+    facultyRows: mapRows(facultyListQuery.data?.data ?? []),
+    totalItems: facultyListQuery.data?.meta.totalItems ?? 0,
+    searchValue,
+    isLoading:
+      meQuery.isLoading ||
+      semestersQuery.isLoading ||
+      (Boolean(selectedSemesterId) && programOptionsQuery.isLoading) ||
+      (Boolean(selectedSemesterId) && facultyListQuery.isLoading),
+    isError:
+      meQuery.isError ||
+      semestersQuery.isError ||
+      programOptionsQuery.isError ||
+      facultyListQuery.isError,
+    isFetching:
+      meQuery.isFetching ||
+      semestersQuery.isFetching ||
+      programOptionsQuery.isFetching ||
+      facultyListQuery.isFetching,
+    retry: () => {
+      void meQuery.refetch();
+      void semestersQuery.refetch();
+      if (selectedSemesterId) {
+        void programOptionsQuery.refetch();
+      }
+      if (selectedSemesterId) {
+        void facultyListQuery.refetch();
+      }
+    },
+    setSelectedSemesterId: (value: string) => {
+      const nextHref = setSearchParams(pathname, new URLSearchParams(searchParamsString), {
+        semesterId: value,
+        programId: null,
+      });
+
+      router.replace(nextHref, { scroll: false });
+    },
+    setSelectedProgramId: (value: string) => {
+      const nextHref = setSearchParams(pathname, new URLSearchParams(searchParamsString), {
+        programId: value === ALL_PROGRAMS_VALUE ? null : value,
+      });
+
+      router.replace(nextHref, { scroll: false });
+    },
+    setSearchValue: setSearchValueState,
+  };
+}

--- a/features/faculty-evaluation/hooks/use-faculty-evaluation-list-view-model.ts
+++ b/features/faculty-evaluation/hooks/use-faculty-evaluation-list-view-model.ts
@@ -1,185 +1,46 @@
 "use client";
 
-import { useDeferredValue, useEffect, useMemo, useState } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
 
-import { useMe } from "@/features/auth/hooks/use-me";
-import {
-  ALL_PROGRAMS_LABEL,
-  ALL_PROGRAMS_VALUE,
-} from "@/features/faculty-analytics/constants/filters";
-import { useScopedFacultyList } from "@/features/faculty-evaluation/hooks/use-scoped-faculty-list";
-import type { FacultyEvaluationRow } from "@/features/faculty-evaluation/types";
-import {
-  mapProgramOptionsToViewModel,
-  mapSemesterOptionsToViewModel,
-} from "@/features/faculty-analytics/lib/dean-analytics-view-model";
-import { useProgramOptions } from "@/features/faculty-analytics/hooks/use-program-options";
-import { useSemesterOptions } from "@/features/faculty-analytics/hooks/use-semester-options";
-
-const DEFAULT_LIMIT = 100;
-
-function mapRows(
-  facultyRows: readonly {
-    id: string;
-    fullName: string;
-    profilePicture: string | null;
-    subjects: string[];
-  }[]
-): FacultyEvaluationRow[] {
-  return facultyRows.map((faculty) => ({
-    id: faculty.id,
-    fullName: faculty.fullName,
-    profilePicture: faculty.profilePicture,
-    subjects: faculty.subjects,
-  }));
-}
-
-function setSearchParams(
-  pathname: string,
-  currentParams: URLSearchParams,
-  updates: Record<string, string | null>
-) {
-  const nextParams = new URLSearchParams(currentParams);
-
-  Object.entries(updates).forEach(([key, value]) => {
-    if (value && value.trim().length > 0) {
-      nextParams.set(key, value);
-    } else {
-      nextParams.delete(key);
-    }
-  });
-
-  const query = nextParams.toString();
-  return query ? `${pathname}?${query}` : pathname;
-}
+import { useFacultyEvaluationFilters } from "@/features/faculty-evaluation/hooks/use-faculty-evaluation-filters";
+import { useFacultyEvaluationListData } from "@/features/faculty-evaluation/hooks/use-faculty-evaluation-list-data";
 
 export function useFacultyEvaluationListViewModel() {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const searchParamsString = searchParams.toString();
-  const searchParamValue = searchParams.get("search") ?? "";
-  const selectedSemesterIdParam = searchParams.get("semesterId");
-  const selectedProgramIdParam = searchParams.get("programId");
-
-  const [searchValue, setSearchValueState] = useState(searchParamValue);
-
-  const deferredSearchValue = useDeferredValue(searchValue.trim());
-
-  const meQuery = useMe();
-  const campusId = meQuery.data?.campus?.id;
-  const semestersQuery = useSemesterOptions(campusId ? { campusId } : undefined, {
-    enabled: !meQuery.isLoading && !meQuery.isError,
+  const {
+    selectedSemesterIdParam,
+    selectedProgramIdParam,
+    searchValue,
+    deferredSearchValue,
+    searchParamsString,
+    syncFilters,
+    setSearchValue,
+    setSelectedProgramId,
+    setSelectedSemesterId,
+  } = useFacultyEvaluationFilters();
+  const data = useFacultyEvaluationListData({
+    selectedSemesterIdParam,
+    selectedProgramIdParam,
+    deferredSearchValue,
   });
 
-  const semesters = useMemo(
-    () => mapSemesterOptionsToViewModel(semestersQuery.data?.data ?? []),
-    [semestersQuery.data]
-  );
-
-  const selectedSemesterId =
-    selectedSemesterIdParam && semesters.some((semester) => semester.id === selectedSemesterIdParam)
-      ? selectedSemesterIdParam
-      : (semesters[0]?.id ?? null);
-
-  const selectedSemester =
-    semesters.find((semester) => semester.id === selectedSemesterId) ?? semesters[0] ?? null;
-
-  const programOptionsQuery = useProgramOptions(
-    { semesterId: selectedSemesterId ?? "", limit: 100 },
-    { enabled: Boolean(selectedSemesterId) }
-  );
-
-  const programs = useMemo(
-    () => mapProgramOptionsToViewModel(programOptionsQuery.data?.data ?? []),
-    [programOptionsQuery.data]
-  );
-
-  const selectedProgram =
-    programs.find((program) => program.id === selectedProgramIdParam) ?? programs[0] ?? null;
-  const selectedProgramId = selectedProgram?.id ?? null;
-
   useEffect(() => {
-    setSearchValueState(searchParamValue);
-  }, [searchParamValue]);
-
-  useEffect(() => {
-    if (!selectedSemesterId) return;
-
-    const nextHref = setSearchParams(pathname, new URLSearchParams(searchParamsString), {
-      semesterId: selectedSemesterId,
-      programId: selectedProgramId,
-      search: searchValue.trim() || null,
+    syncFilters({
+      selectedSemesterId: data.selectedSemesterId,
+      selectedProgramId: data.selectedProgramId,
     });
-    const currentHref = searchParamsString ? `${pathname}?${searchParamsString}` : pathname;
-
-    if (nextHref !== currentHref) {
-      router.replace(nextHref, { scroll: false });
-    }
-  }, [pathname, router, searchParamsString, searchValue, selectedProgramId, selectedSemesterId]);
-
-  const facultyListQuery = useScopedFacultyList(
-    {
-      semesterId: selectedSemesterId ?? "",
-      programId: selectedProgramId ?? undefined,
-      search: deferredSearchValue || undefined,
-      page: 1,
-      limit: DEFAULT_LIMIT,
-    },
-    { enabled: Boolean(selectedSemesterId) }
-  );
+  }, [
+    data.selectedProgramId,
+    data.selectedSemesterId,
+    searchParamsString,
+    searchValue,
+    syncFilters,
+  ]);
 
   return {
-    semesters,
-    programs,
-    selectedSemesterId,
-    selectedSemesterLabel: selectedSemester?.label ?? "Select semester",
-    selectedProgramId,
-    selectedProgramLabel: selectedProgram?.label ?? ALL_PROGRAMS_LABEL,
-    facultyRows: mapRows(facultyListQuery.data?.data ?? []),
-    totalItems: facultyListQuery.data?.meta.totalItems ?? 0,
+    ...data,
     searchValue,
-    isLoading:
-      meQuery.isLoading ||
-      semestersQuery.isLoading ||
-      (Boolean(selectedSemesterId) && programOptionsQuery.isLoading) ||
-      (Boolean(selectedSemesterId) && facultyListQuery.isLoading),
-    isError:
-      meQuery.isError ||
-      semestersQuery.isError ||
-      programOptionsQuery.isError ||
-      facultyListQuery.isError,
-    isFetching:
-      meQuery.isFetching ||
-      semestersQuery.isFetching ||
-      programOptionsQuery.isFetching ||
-      facultyListQuery.isFetching,
-    retry: () => {
-      void meQuery.refetch();
-      void semestersQuery.refetch();
-      if (selectedSemesterId) {
-        void programOptionsQuery.refetch();
-      }
-      if (selectedSemesterId) {
-        void facultyListQuery.refetch();
-      }
-    },
-    setSelectedSemesterId: (value: string) => {
-      const nextHref = setSearchParams(pathname, new URLSearchParams(searchParamsString), {
-        semesterId: value,
-        programId: null,
-      });
-
-      router.replace(nextHref, { scroll: false });
-    },
-    setSelectedProgramId: (value: string) => {
-      const nextHref = setSearchParams(pathname, new URLSearchParams(searchParamsString), {
-        programId: value === ALL_PROGRAMS_VALUE ? null : value,
-      });
-
-      router.replace(nextHref, { scroll: false });
-    },
-    setSearchValue: setSearchValueState,
+    setSelectedSemesterId,
+    setSelectedProgramId,
+    setSearchValue,
   };
 }

--- a/features/faculty-evaluation/hooks/use-role-submit-faculty-evaluation.ts
+++ b/features/faculty-evaluation/hooks/use-role-submit-faculty-evaluation.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useCallback } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { isAxiosError } from "axios";
+import { toast } from "sonner";
+
+import { submitEvaluation } from "@/features/questionnaires/api/questionnaire.requests";
+
+export function useRoleSubmitFacultyEvaluation(returnHref: string) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: submitEvaluation,
+    onError: (error) => {
+      if (isAxiosError(error) && error.response?.status === 409) {
+        toast.error("You have already submitted this evaluation.");
+        router.push(returnHref);
+        return;
+      }
+
+      toast.error("Failed to submit evaluation. Please try again.");
+    },
+  });
+
+  const invalidateAndNavigate = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: ["questionnaires", "submissions", "check"],
+    });
+    void queryClient.invalidateQueries({ queryKey: ["questionnaires", "drafts"] });
+    void queryClient.invalidateQueries({ queryKey: ["faculty-evaluation", "faculty-list"] });
+    router.push(returnHref);
+  }, [queryClient, returnHref, router]);
+
+  return { ...mutation, invalidateAndNavigate };
+}

--- a/features/faculty-evaluation/hooks/use-scoped-faculty-list.ts
+++ b/features/faculty-evaluation/hooks/use-scoped-faculty-list.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { fetchScopedFacultyList } from "@/features/faculty-evaluation/api/faculty-evaluation.requests";
+import type { FacultyEvaluationListQuery } from "@/features/faculty-evaluation/types";
+import { useAuthStore } from "@/stores/auth-store";
+
+type UseScopedFacultyListOptions = {
+  enabled?: boolean;
+};
+
+export function useScopedFacultyList(
+  params: FacultyEvaluationListQuery,
+  options?: UseScopedFacultyListOptions
+) {
+  const token = useAuthStore((state) => state.token);
+  const isEnabled = options?.enabled ?? true;
+
+  return useQuery({
+    queryKey: ["faculty-evaluation", "faculty-list", params, token],
+    enabled: Boolean(token) && Boolean(params.semesterId) && isEnabled,
+    placeholderData: keepPreviousData,
+    queryFn: () => fetchScopedFacultyList(params),
+  });
+}

--- a/features/faculty-evaluation/index.ts
+++ b/features/faculty-evaluation/index.ts
@@ -1,0 +1,6 @@
+export { FacultyEvaluationListScreen } from "@/features/faculty-evaluation/components/faculty-evaluation-list-screen";
+export { FacultyEvaluationDetailScreen } from "@/features/faculty-evaluation/components/faculty-evaluation-detail-screen";
+export type {
+  FacultyEvaluationRoleContext,
+  FacultyEvaluationRow,
+} from "@/features/faculty-evaluation/types";

--- a/features/faculty-evaluation/index.ts
+++ b/features/faculty-evaluation/index.ts
@@ -1,6 +1,6 @@
 export { FacultyEvaluationListScreen } from "@/features/faculty-evaluation/components/faculty-evaluation-list-screen";
 export { FacultyEvaluationDetailScreen } from "@/features/faculty-evaluation/components/faculty-evaluation-detail-screen";
 export type {
+  FacultyEvaluationListItem,
   FacultyEvaluationRoleContext,
-  FacultyEvaluationRow,
 } from "@/features/faculty-evaluation/types";

--- a/features/faculty-evaluation/lib/faculty-evaluation-routes.ts
+++ b/features/faculty-evaluation/lib/faculty-evaluation-routes.ts
@@ -1,0 +1,28 @@
+import type { FacultyEvaluationRoleContext } from "@/features/faculty-evaluation/types";
+
+type BuildFacultyEvaluationHrefOptions = {
+  role: FacultyEvaluationRoleContext;
+  facultyId: string;
+  facultyName: string;
+  semesterId: string;
+  semesterLabel: string;
+  typeId: string;
+};
+
+export function buildFacultyEvaluationHref({
+  role,
+  facultyId,
+  facultyName,
+  semesterId,
+  semesterLabel,
+  typeId,
+}: BuildFacultyEvaluationHrefOptions) {
+  const params = new URLSearchParams({
+    facultyName,
+    semesterId,
+    semesterLabel,
+    typeId,
+  });
+
+  return `${role.rolePath}/evaluation/${facultyId}?${params.toString()}`;
+}

--- a/features/faculty-evaluation/lib/questionnaire-types.ts
+++ b/features/faculty-evaluation/lib/questionnaire-types.ts
@@ -1,0 +1,11 @@
+import type { QuestionnaireTypeSummary } from "@/features/questionnaires/types";
+
+export const STUDENT_ONLY_QUESTIONNAIRE_TYPE_CODE = "FACULTY_FEEDBACK";
+
+export function getEvaluatorQuestionnaireTypes(
+  questionnaireTypes: QuestionnaireTypeSummary[] | undefined
+) {
+  return (questionnaireTypes ?? []).filter(
+    (type) => type.code !== STUDENT_ONLY_QUESTIONNAIRE_TYPE_CODE
+  );
+}

--- a/features/faculty-evaluation/types/index.ts
+++ b/features/faculty-evaluation/types/index.ts
@@ -33,13 +33,6 @@ export type FacultyEvaluationListResponse = {
   meta: FacultyEvaluationListMeta;
 };
 
-export type FacultyEvaluationRow = {
-  id: string;
-  fullName: string;
-  profilePicture: string | null;
-  subjects: string[];
-};
-
 export type FacultyEvaluationRoleContext = {
   roleLabel: "Dean" | "Chairperson";
   rolePath: "/dean" | "/chairperson";

--- a/features/faculty-evaluation/types/index.ts
+++ b/features/faculty-evaluation/types/index.ts
@@ -1,0 +1,105 @@
+import type {
+  QuestionnaireFormValues,
+  QuestionnaireTypeSummary,
+} from "@/features/questionnaires/types";
+
+export type FacultyEvaluationViewMode = "card" | "list";
+
+export type FacultyEvaluationListQuery = {
+  semesterId: string;
+  programId?: string;
+  search?: string;
+  page?: number;
+  limit?: number;
+};
+
+export type FacultyEvaluationListItem = {
+  id: string;
+  fullName: string;
+  profilePicture: string | null;
+  subjects: string[];
+};
+
+export type FacultyEvaluationListMeta = {
+  totalItems: number;
+  itemCount: number;
+  itemsPerPage: number;
+  totalPages: number;
+  currentPage: number;
+};
+
+export type FacultyEvaluationListResponse = {
+  data: FacultyEvaluationListItem[];
+  meta: FacultyEvaluationListMeta;
+};
+
+export type FacultyEvaluationRow = {
+  id: string;
+  fullName: string;
+  profilePicture: string | null;
+  subjects: string[];
+};
+
+export type FacultyEvaluationRoleContext = {
+  roleLabel: "Dean" | "Chairperson";
+  rolePath: "/dean" | "/chairperson";
+};
+
+export type FacultyEvaluationDetailContext = {
+  facultyId: string;
+  facultyName?: string;
+  semesterId: string;
+};
+
+export type FacultyEvaluationReadyData = FacultyEvaluationDetailContext & {
+  selectedTypeId: string;
+  selectedType: QuestionnaireTypeSummary;
+  availableTypes: QuestionnaireTypeSummary[];
+  activeVersion: { id: string };
+  model: Parameters<
+    typeof import("@/features/questionnaires/components/form/questionnaire-form-renderer").QuestionnaireFormRenderer
+  >[0]["model"];
+  defaultValues: Partial<QuestionnaireFormValues> | undefined;
+  draftHydrationKey: string;
+};
+
+export type FacultyEvaluationDetailResult =
+  | {
+      status: "loading";
+      message: string;
+      availableTypes: QuestionnaireTypeSummary[];
+      selectedTypeId: string | null;
+    }
+  | {
+      status: "error";
+      message: string;
+      availableTypes: QuestionnaireTypeSummary[];
+      selectedTypeId: string | null;
+    }
+  | {
+      status: "missing-context";
+      message: string;
+      availableTypes: QuestionnaireTypeSummary[];
+      selectedTypeId: string | null;
+    }
+  | {
+      status: "no-types";
+      message: string;
+      availableTypes: QuestionnaireTypeSummary[];
+      selectedTypeId: string | null;
+    }
+  | {
+      status: "no-version";
+      message: string;
+      availableTypes: QuestionnaireTypeSummary[];
+      selectedTypeId: string | null;
+      detail: FacultyEvaluationDetailContext;
+    }
+  | {
+      status: "already-submitted";
+      submittedAt?: string;
+      availableTypes: QuestionnaireTypeSummary[];
+      selectedTypeId: string | null;
+      detail: FacultyEvaluationDetailContext;
+    }
+  | { status: "ready"; data: FacultyEvaluationReadyData };


### PR DESCRIPTION
## Summary
- add dedicated dean and chairperson evaluation routes and sidebar entry points
- implement scoped faculty evaluation list and detail flows with semester and program filtering
- reuse the questionnaire engine for evaluator submission, draft handling, and submitted states

## Test plan
- [x] bun run typecheck
- [x] bun run lint
- [x] Manually verify dean evaluation list filtering by semester and program
- [x] Manually verify chairperson evaluation is scoped to allowed program options
- [x] Manually verify questionnaire type selection, draft save, and successful submission flow
- [ ] Manually verify already-submitted state on both evaluator and student flows

Closes #65