### PR TITLE
[FEAT][FAC-WEB-30] add faculty report export flows

### DIFF
--- a/app/(dashboard)/dean/faculties/[facultyId]/analysis/_components/faculty-report-header.tsx
+++ b/app/(dashboard)/dean/faculties/[facultyId]/analysis/_components/faculty-report-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, RefreshCw } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -23,9 +23,7 @@ type FacultyReportHeaderProps = {
     label: string;
   }>;
   isQuestionnaireTypeLoading: boolean;
-  isRefreshing: boolean;
   onQuestionnaireTypeChange: (value: string) => void;
-  onRefresh: () => void;
   onExport: () => void;
 };
 
@@ -37,9 +35,7 @@ export function FacultyReportHeader({
   questionnaireTypeCode,
   availableQuestionnaireTypes,
   isQuestionnaireTypeLoading,
-  isRefreshing,
   onQuestionnaireTypeChange,
-  onRefresh,
   onExport,
 }: FacultyReportHeaderProps) {
   return (
@@ -94,17 +90,6 @@ export function FacultyReportHeader({
           onClick={onExport}
         >
           Export PDF
-        </Button>
-
-        <Button
-          type="button"
-          variant="outline"
-          className="w-full px-4 py-2.5 font-sans text-sm sm:w-auto"
-          onClick={onRefresh}
-          disabled={isRefreshing}
-        >
-          <RefreshCw className={`mr-2 size-4 ${isRefreshing ? "animate-spin" : ""}`} />
-          Refresh
         </Button>
 
         <Button

--- a/app/(dashboard)/dean/faculties/[facultyId]/analysis/_components/faculty-report-header.tsx
+++ b/app/(dashboard)/dean/faculties/[facultyId]/analysis/_components/faculty-report-header.tsx
@@ -26,6 +26,7 @@ type FacultyReportHeaderProps = {
   isRefreshing: boolean;
   onQuestionnaireTypeChange: (value: string) => void;
   onRefresh: () => void;
+  onExport: () => void;
 };
 
 export function FacultyReportHeader({
@@ -39,6 +40,7 @@ export function FacultyReportHeader({
   isRefreshing,
   onQuestionnaireTypeChange,
   onRefresh,
+  onExport,
 }: FacultyReportHeaderProps) {
   return (
     <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
@@ -84,6 +86,15 @@ export function FacultyReportHeader({
             </DropdownMenuRadioGroup>
           </DropdownMenuContent>
         </DropdownMenu>
+
+        <Button
+          type="button"
+          variant="brand"
+          className="w-full px-4 py-2.5 font-sans text-sm sm:w-auto"
+          onClick={onExport}
+        >
+          Export PDF
+        </Button>
 
         <Button
           type="button"

--- a/app/(dashboard)/dean/faculties/[facultyId]/analysis/_components/faculty-report-screen.tsx
+++ b/app/(dashboard)/dean/faculties/[facultyId]/analysis/_components/faculty-report-screen.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { DeanAnalyticsEmptyState } from "@/features/faculty-analytics/components/dean-analytics-empty-state";
 import { DeanAnalyticsErrorState } from "@/features/faculty-analytics/components/dean-analytics-error-state";
 import { DeanAnalyticsLoadingState } from "@/features/faculty-analytics/components/dean-analytics-loading-state";
+import { ReportExportDialog } from "@/features/faculty-analytics/components/report-export-dialog";
 import { useFacultyReportDetailViewModel } from "@/features/faculty-analytics/hooks/use-faculty-report-detail-view-model";
 import { hasFacultyReportAnalyticsData } from "@/features/faculty-analytics/lib/faculty-report-detail";
 
@@ -19,6 +21,7 @@ type FacultyReportScreenProps = {
 };
 
 export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
+  const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const viewModel = useFacultyReportDetailViewModel({ facultyId });
 
   if (!viewModel.hasSemesterContext) {
@@ -86,6 +89,7 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
         isRefreshing={viewModel.isRefreshing}
         onQuestionnaireTypeChange={viewModel.updateQuestionnaireType}
         onRefresh={viewModel.retryAll}
+        onExport={() => setIsExportDialogOpen(true)}
       />
 
       {!hasAnalyticsData ? (
@@ -116,6 +120,17 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
           />
         </>
       )}
+
+      <ReportExportDialog
+        open={isExportDialogOpen}
+        onOpenChange={setIsExportDialogOpen}
+        facultyId={facultyId}
+        facultyName={viewModel.report.faculty.name}
+        semesterId={viewModel.semesterId}
+        semesterLabel={viewModel.semesterLabel}
+        questionnaireTypeCode={viewModel.questionnaireTypeCode}
+        questionnaireTypeLabel={viewModel.questionnaireTypeLabel}
+      />
     </section>
   );
 }

--- a/app/(dashboard)/dean/faculties/[facultyId]/analysis/_components/faculty-report-screen.tsx
+++ b/app/(dashboard)/dean/faculties/[facultyId]/analysis/_components/faculty-report-screen.tsx
@@ -86,9 +86,7 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
         questionnaireTypeCode={viewModel.questionnaireTypeCode}
         availableQuestionnaireTypes={viewModel.availableQuestionnaireTypes}
         isQuestionnaireTypeLoading={viewModel.isQuestionnaireTypeLoading}
-        isRefreshing={viewModel.isRefreshing}
         onQuestionnaireTypeChange={viewModel.updateQuestionnaireType}
-        onRefresh={viewModel.retryAll}
         onExport={() => setIsExportDialogOpen(true)}
       />
 

--- a/app/(dashboard)/dean/faculties/[facultyId]/analysis/_components/faculty-report-section-performance-chart.tsx
+++ b/app/(dashboard)/dean/faculties/[facultyId]/analysis/_components/faculty-report-section-performance-chart.tsx
@@ -51,6 +51,8 @@ export function FacultyReportSectionPerformanceChart({
     average: Number(section.sectionAverage.toFixed(2)),
     weight: section.weight,
   }));
+  const rowHeight = isMobile ? 42 : 48;
+  const chartHeight = Math.max(isMobile ? 280 : 320, chartData.length * rowHeight);
 
   return (
     <Card className="rounded-2xl border-border/70 shadow-sm">
@@ -65,17 +67,21 @@ export function FacultyReportSectionPerformanceChart({
       <CardContent>
         <ChartContainer
           config={sectionPerformanceChartConfig}
-          className="aspect-auto h-[18rem] min-h-[18rem] w-full items-stretch justify-start sm:h-[20rem] lg:h-[22rem]"
+          className="aspect-auto w-full items-stretch justify-start"
+          style={{ height: chartHeight }}
         >
           <BarChart
             accessibilityLayer
             data={chartData}
             layout="vertical"
             margin={{
+              top: 8,
+              bottom: 8,
               right: isMobile ? 18 : 24,
               left: 0,
             }}
-            barCategoryGap={isMobile ? 14 : 16}
+            barCategoryGap={isMobile ? 10 : 12}
+            maxBarSize={isMobile ? 24 : 28}
           >
             <CartesianGrid horizontal={false} />
             <XAxis dataKey="average" type="number" domain={[0, 5]} hide />

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -258,7 +258,7 @@ function Sidebar({
       <div
         data-slot="sidebar-gap"
         className={cn(
-          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
@@ -269,7 +269,7 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] md:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
@@ -331,7 +331,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex",
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
@@ -444,8 +444,8 @@ function SidebarGroupLabel({
     <Comp
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
-      className={cn(
-        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        className={cn(
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className
       )}

--- a/features/faculty-analytics/api/faculty-analytics.requests.ts
+++ b/features/faculty-analytics/api/faculty-analytics.requests.ts
@@ -3,6 +3,8 @@ import { Endpoints } from "@/network/endpoints";
 import type {
   AttentionListQuery,
   AttentionListResponseDto,
+  BatchReportStatusQuery,
+  BatchStatusResponseDto,
   DepartmentOverviewQuery,
   DepartmentOverviewResponseDto,
   FacultyReportCommentsQuery,
@@ -11,9 +13,14 @@ import type {
   FacultyReportResponseDto,
   FacultyListQuery,
   FacultyListResponseDto,
+  GenerateBatchReportRequest,
+  GenerateBatchReportResponse,
+  GenerateSingleReportRequest,
+  GenerateSingleReportResponse,
   ListProgramsQuery,
   ListSemestersQuery,
   ProgramListResponseDto,
+  ReportStatusResponseDto,
   SemesterListResponseDto,
 } from "@/features/faculty-analytics/types";
 
@@ -29,6 +36,41 @@ export async function fetchAttentionList(params: AttentionListQuery) {
   const response = await apiClient.get<AttentionListResponseDto>(Endpoints.analyticsAttention, {
     params,
   });
+
+  return response.data;
+}
+
+export async function generateSingleReport(payload: GenerateSingleReportRequest) {
+  const response = await apiClient.post<GenerateSingleReportResponse>(
+    Endpoints.reportsGenerate,
+    payload
+  );
+
+  return response.data;
+}
+
+export async function fetchReportStatus(jobId: string) {
+  const response = await apiClient.get<ReportStatusResponseDto>(
+    Endpoints.reportsStatus.replace(":jobId", jobId)
+  );
+
+  return response.data;
+}
+
+export async function generateBatchReport(payload: GenerateBatchReportRequest) {
+  const response = await apiClient.post<GenerateBatchReportResponse>(
+    Endpoints.reportsGenerateBatch,
+    payload
+  );
+
+  return response.data;
+}
+
+export async function fetchBatchReportStatus({ batchId, ...params }: BatchReportStatusQuery) {
+  const response = await apiClient.get<BatchStatusResponseDto>(
+    Endpoints.reportsBatchStatus.replace(":batchId", batchId),
+    { params }
+  );
 
   return response.data;
 }

--- a/features/faculty-analytics/components/batch-report-export-dialog.tsx
+++ b/features/faculty-analytics/components/batch-report-export-dialog.tsx
@@ -1,0 +1,513 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, LoaderCircle } from "lucide-react";
+import { toast } from "sonner";
+
+import { PaginationFooter } from "@/components/shared/pagination-footer";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Progress } from "@/components/ui/progress";
+import { Separator } from "@/components/ui/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useBatchReportStatus } from "@/features/faculty-analytics/hooks/use-batch-report-status";
+import { ReportExportStateCard } from "@/features/faculty-analytics/components/report-export-state-card";
+import { useGenerateBatchReport } from "@/features/faculty-analytics/hooks/use-generate-batch-report";
+import { ALL_PROGRAMS_VALUE } from "@/features/faculty-analytics/constants/filters";
+import {
+  formatReportJobStatusLabel,
+  getBatchProgressValue,
+  isPresignedUrlExpired,
+  resolveBatchSetupMessage,
+} from "@/features/faculty-analytics/lib/report-export";
+import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import { resolveQuestionnaireTypeLabel } from "@/features/questionnaires/types";
+import { resolveApiErrorMessage } from "@/lib/api-errors";
+import { formatDateTime, formatRelativeTime } from "@/lib/date";
+import { DEFAULT_PAGE_SIZE } from "@/lib/pagination";
+
+type BatchReportExportDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  semesterId: string | null;
+  semesterLabel: string;
+  programId: string | null;
+  programs: Array<{
+    id: string | null;
+    label: string;
+  }>;
+};
+
+export function BatchReportExportDialog({
+  open,
+  onOpenChange,
+  semesterId,
+  semesterLabel,
+  programId,
+  programs,
+}: BatchReportExportDialogProps) {
+  const [selectedQuestionnaireTypeCode, setSelectedQuestionnaireTypeCode] = useState("");
+  const [selectedProgramId, setSelectedProgramId] = useState<string | null>(programId);
+  const [batchId, setBatchId] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [rowsPerPage, setRowsPerPage] = useState<number>(DEFAULT_PAGE_SIZE);
+  const [setupMessage, setSetupMessage] = useState<string | null>(null);
+  const [batchSummary, setBatchSummary] = useState<{
+    jobCount: number;
+    skippedCount: number;
+  } | null>(null);
+  const questionnaireTypesQuery = useQuestionnaireTypes({ enabled: open });
+  const questionnaireTypes = questionnaireTypesQuery.data ?? [];
+  const generateBatchReportMutation = useGenerateBatchReport();
+  const batchStatusQuery = useBatchReportStatus(
+    batchId
+      ? {
+          batchId,
+          page: currentPage,
+          limit: rowsPerPage,
+        }
+      : null,
+    { enabled: open && Boolean(batchId) }
+  );
+
+  const effectiveQuestionnaireTypeCode =
+    selectedQuestionnaireTypeCode || questionnaireTypes[0]?.code || "";
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setBatchId(null);
+      setCurrentPage(1);
+      setRowsPerPage(DEFAULT_PAGE_SIZE);
+      setSetupMessage(null);
+      setBatchSummary(null);
+      setSelectedProgramId(programId);
+      setSelectedQuestionnaireTypeCode("");
+      generateBatchReportMutation.reset();
+    }
+
+    onOpenChange(nextOpen);
+  }
+
+  async function handleGenerate() {
+    if (!semesterId) {
+      toast.error("Select a semester before generating batch exports.");
+      return;
+    }
+
+    if (!effectiveQuestionnaireTypeCode) {
+      toast.error("Select a questionnaire type for the batch export.");
+      return;
+    }
+
+    try {
+      const response = await generateBatchReportMutation.mutateAsync({
+        semesterId,
+        questionnaireTypeCode: effectiveQuestionnaireTypeCode,
+        programId: selectedProgramId ?? undefined,
+      });
+
+      if (response.jobCount === 0) {
+        setBatchId(null);
+        setBatchSummary(null);
+        setCurrentPage(1);
+        setSetupMessage(resolveBatchSetupMessage(response.jobCount, response.skippedCount));
+        return;
+      }
+
+      setBatchId(response.batchId);
+      setBatchSummary({
+        jobCount: response.jobCount,
+        skippedCount: response.skippedCount,
+      });
+      setSetupMessage(null);
+      setCurrentPage(1);
+    } catch (error) {
+      toast.error(resolveApiErrorMessage(error, "Unable to queue the batch export right now."));
+    }
+  }
+
+  const batchStatus = batchStatusQuery.data;
+  const selectedQuestionnaireTypeLabel =
+    questionnaireTypes.find((type) => type.code === effectiveQuestionnaireTypeCode)?.name ?? null;
+  const selectedProgramLabel =
+    programs.find((program) => program.id === selectedProgramId)?.label ??
+    programs[0]?.label ??
+    "All Programs";
+  const progressValue = getBatchProgressValue(
+    batchStatus?.total ?? 0,
+    batchStatus?.completed ?? 0,
+    batchStatus?.failed ?? 0,
+    batchStatus?.skipped ?? 0
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Batch Report Export</DialogTitle>
+          <DialogDescription>
+            Generate faculty report PDFs for the currently selected semester and program scope.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <div className="rounded-lg border border-border/70 bg-muted/20 p-4">
+            <dl className="space-y-2 font-sans text-sm">
+              <div className="flex items-center justify-between gap-4">
+                <dt className="text-muted-foreground">Semester</dt>
+                <dd className="text-right font-medium">{semesterLabel}</dd>
+              </div>
+              {batchId ? (
+                <>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-muted-foreground">Program</dt>
+                    <dd className="text-right font-medium">{selectedProgramLabel}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-muted-foreground">Questionnaire Type</dt>
+                    <dd className="text-right font-medium">
+                      {selectedQuestionnaireTypeCode
+                        ? resolveQuestionnaireTypeLabel(
+                            selectedQuestionnaireTypeCode,
+                            selectedQuestionnaireTypeLabel
+                          )
+                        : "Not selected"}
+                    </dd>
+                  </div>
+                </>
+              ) : null}
+            </dl>
+          </div>
+
+          {!batchId ? (
+            <>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <p className="font-sans text-sm font-medium text-foreground">Program</p>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-between px-4 py-2.5 font-sans text-sm"
+                      >
+                        <span className="truncate">{selectedProgramLabel}</span>
+                        <ChevronDown className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align="start"
+                      className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
+                    >
+                      <DropdownMenuRadioGroup
+                        value={selectedProgramId ?? ALL_PROGRAMS_VALUE}
+                        onValueChange={(value) => {
+                          setSelectedProgramId(value === ALL_PROGRAMS_VALUE ? null : value);
+                        }}
+                      >
+                        {programs.map((program) => (
+                          <DropdownMenuRadioItem
+                            key={program.id ?? ALL_PROGRAMS_VALUE}
+                            value={program.id ?? ALL_PROGRAMS_VALUE}
+                            className="font-sans text-sm"
+                          >
+                            {program.label}
+                          </DropdownMenuRadioItem>
+                        ))}
+                      </DropdownMenuRadioGroup>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+
+                <div className="space-y-2">
+                  <p className="font-sans text-sm font-medium text-foreground">
+                    Questionnaire type
+                  </p>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-between px-4 py-2.5 font-sans text-sm"
+                        disabled={
+                          questionnaireTypesQuery.isLoading || questionnaireTypes.length === 0
+                        }
+                      >
+                      <span className="truncate">
+                        {effectiveQuestionnaireTypeCode
+                          ? resolveQuestionnaireTypeLabel(
+                              effectiveQuestionnaireTypeCode,
+                              selectedQuestionnaireTypeLabel
+                            )
+                          : "Select questionnaire type"}
+                        </span>
+                        <ChevronDown className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align="start"
+                      className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
+                    >
+                    <DropdownMenuRadioGroup
+                      value={effectiveQuestionnaireTypeCode}
+                      onValueChange={setSelectedQuestionnaireTypeCode}
+                    >
+                        {questionnaireTypes.map((type) => (
+                          <DropdownMenuRadioItem
+                            key={type.code}
+                            value={type.code}
+                            className="font-sans text-sm"
+                          >
+                            {resolveQuestionnaireTypeLabel(type.code, type.name)}
+                          </DropdownMenuRadioItem>
+                        ))}
+                      </DropdownMenuRadioGroup>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </div>
+
+              {setupMessage ? (
+                <ReportExportStateCard
+                  title="No export generated"
+                  badgeLabel="Skipped"
+                  tone="warning"
+                  message={setupMessage}
+                />
+              ) : null}
+            </>
+          ) : null}
+
+          {batchId ? (
+            <>
+              <div className="space-y-4 rounded-lg border border-border/70 bg-muted/20 p-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="font-sans text-sm font-medium text-foreground">Batch progress</p>
+                    <p className="font-sans text-sm text-muted-foreground">Batch ID: {batchId}</p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => void batchStatusQuery.refetch()}
+                  >
+                    Refresh Status
+                  </Button>
+                </div>
+
+                <Progress value={progressValue} className="h-2" />
+
+                <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-6">
+                  <div className="rounded-md border border-border/70 px-3 py-2">
+                    <p className="font-sans text-xs text-muted-foreground">Total</p>
+                    <p className="font-sans text-lg font-semibold">{batchStatus?.total ?? 0}</p>
+                  </div>
+                  <div className="rounded-md border border-border/70 px-3 py-2">
+                    <p className="font-sans text-xs text-muted-foreground">Completed</p>
+                    <p className="font-sans text-lg font-semibold">{batchStatus?.completed ?? 0}</p>
+                  </div>
+                  <div className="rounded-md border border-border/70 px-3 py-2">
+                    <p className="font-sans text-xs text-muted-foreground">Failed</p>
+                    <p className="font-sans text-lg font-semibold">{batchStatus?.failed ?? 0}</p>
+                  </div>
+                  <div className="rounded-md border border-border/70 px-3 py-2">
+                    <p className="font-sans text-xs text-muted-foreground">Skipped</p>
+                    <p className="font-sans text-lg font-semibold">{batchStatus?.skipped ?? 0}</p>
+                  </div>
+                  <div className="rounded-md border border-border/70 px-3 py-2">
+                    <p className="font-sans text-xs text-muted-foreground">Active</p>
+                    <p className="font-sans text-lg font-semibold">{batchStatus?.active ?? 0}</p>
+                  </div>
+                  <div className="rounded-md border border-border/70 px-3 py-2">
+                    <p className="font-sans text-xs text-muted-foreground">Waiting</p>
+                    <p className="font-sans text-lg font-semibold">{batchStatus?.waiting ?? 0}</p>
+                  </div>
+                </div>
+
+                {batchSummary ? (
+                  <p className="font-sans text-sm text-muted-foreground">
+                    Queued {batchSummary.jobCount} report job
+                    {batchSummary.jobCount === 1 ? "" : "s"}.
+                    {batchSummary.skippedCount > 0
+                      ? ` ${batchSummary.skippedCount} entr${
+                          batchSummary.skippedCount === 1 ? "y was" : "ies were"
+                        } skipped before queueing.`
+                      : null}
+                  </p>
+                ) : null}
+              </div>
+
+              <Separator />
+
+              {generateBatchReportMutation.isPending || batchStatusQuery.isLoading ? (
+                <div className="rounded-lg border border-border/70 bg-muted/20 px-4 py-5">
+                  <div className="flex items-center gap-3">
+                    <LoaderCircle className="size-5 animate-spin text-brand-blue" />
+                    <p className="font-sans text-sm text-muted-foreground">
+                      Loading batch export progress...
+                    </p>
+                  </div>
+                </div>
+              ) : null}
+
+              {!batchStatusQuery.isLoading && batchStatus && batchStatus.jobs.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border/70 px-4 py-5">
+                  <p className="font-sans text-sm text-muted-foreground">
+                    No report jobs were queued for this batch scope.
+                  </p>
+                </div>
+              ) : null}
+
+              {!batchStatusQuery.isLoading && batchStatus && batchStatus.jobs.length > 0 ? (
+                <div className="space-y-4">
+                  <div className="data-table-wrapper">
+                    <Table className="w-full table-fixed [&_td]:whitespace-normal [&_th]:whitespace-normal">
+                      <TableHeader className="data-table-header">
+                        <TableRow>
+                          <TableHead className="data-table-head w-[24%]">Faculty</TableHead>
+                          <TableHead className="data-table-head w-[18%]">Status</TableHead>
+                          <TableHead className="data-table-head w-[38%]">Details</TableHead>
+                          <TableHead className="data-table-head w-[20%] text-right">
+                            Action
+                          </TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {batchStatus.jobs.map((job) => {
+                          const expired = isPresignedUrlExpired(job.expiresAt);
+
+                          return (
+                            <TableRow key={job.jobId} className="data-table-row">
+                              <TableCell className="data-table-cell align-top">
+                                <div>
+                                  <p className="font-sans text-sm font-semibold text-foreground">
+                                    {job.facultyName}
+                                  </p>
+                                  <p className="mt-1 font-sans text-xs text-muted-foreground">
+                                    Created {formatRelativeTime(job.createdAt)}
+                                  </p>
+                                </div>
+                              </TableCell>
+                              <TableCell className="data-table-cell align-top">
+                                <Badge variant="outline">
+                                  {formatReportJobStatusLabel(job.status)}
+                                </Badge>
+                              </TableCell>
+                              <TableCell className="data-table-cell align-top">
+                                <div className="space-y-1 font-sans text-sm text-muted-foreground">
+                                  {job.status === "completed" ? (
+                                    <>
+                                      <p>
+                                        {expired
+                                          ? "Secure link expired. Refresh status to get a new URL."
+                                          : `Secure link expires ${formatRelativeTime(job.expiresAt ?? "")}.`}
+                                      </p>
+                                      {job.completedAt ? (
+                                        <p className="text-xs">
+                                          Completed {formatDateTime(job.completedAt)}
+                                        </p>
+                                      ) : null}
+                                    </>
+                                  ) : null}
+                                  {job.status === "failed" ? (
+                                    <p>{job.error ?? "Export failed."}</p>
+                                  ) : null}
+                                  {job.status === "skipped" ? (
+                                    <p>{job.message ?? "Export skipped for this faculty."}</p>
+                                  ) : null}
+                                  {(job.status === "waiting" || job.status === "active") && (
+                                    <p>Report generation is still in progress.</p>
+                                  )}
+                                </div>
+                              </TableCell>
+                              <TableCell className="data-table-cell align-top text-right">
+                                {job.status === "completed" ? (
+                                  <div className="flex flex-wrap justify-end gap-2">
+                                    <Button
+                                      asChild
+                                      size="sm"
+                                      disabled={!job.downloadUrl || expired}
+                                    >
+                                      <a href={job.downloadUrl} target="_blank" rel="noreferrer">
+                                        View
+                                      </a>
+                                    </Button>
+                                  </div>
+                                ) : (
+                                  <span className="font-sans text-xs text-muted-foreground">
+                                    No action
+                                  </span>
+                                )}
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </div>
+
+                  <PaginationFooter
+                    itemCount={batchStatus.meta.itemCount}
+                    totalItems={batchStatus.meta.totalItems}
+                    currentPage={batchStatus.meta.currentPage}
+                    totalPages={batchStatus.meta.totalPages}
+                    itemLabel="report jobs"
+                    rowsPerPage={batchStatus.meta.itemsPerPage}
+                    onPageChange={setCurrentPage}
+                    onRowsPerPageChange={setRowsPerPage}
+                  />
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+
+        <DialogFooter className="gap-2 justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={generateBatchReportMutation.isPending}
+          >
+            Close
+          </Button>
+
+          {!batchId ? (
+            <Button
+              type="button"
+              onClick={handleGenerate}
+              disabled={
+                generateBatchReportMutation.isPending ||
+                !semesterId ||
+                !selectedQuestionnaireTypeCode ||
+                questionnaireTypesQuery.isLoading
+              }
+            >
+              {generateBatchReportMutation.isPending ? "Queueing..." : "Generate Batch"}
+            </Button>
+          ) : null}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/faculty-analytics/components/batch-report-export-dialog.tsx
+++ b/features/faculty-analytics/components/batch-report-export-dialog.tsx
@@ -268,9 +268,9 @@ export function BatchReportExportDialog({
                       align="start"
                       className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
                     >
-                    <DropdownMenuRadioGroup
-                      value={effectiveQuestionnaireTypeCode}
-                      onValueChange={setSelectedQuestionnaireTypeCode}
+                      <DropdownMenuRadioGroup
+                        value={effectiveQuestionnaireTypeCode}
+                        onValueChange={setSelectedQuestionnaireTypeCode}
                     >
                         {questionnaireTypes.map((type) => (
                           <DropdownMenuRadioItem
@@ -499,7 +499,7 @@ export function BatchReportExportDialog({
               disabled={
                 generateBatchReportMutation.isPending ||
                 !semesterId ||
-                !selectedQuestionnaireTypeCode ||
+                !effectiveQuestionnaireTypeCode ||
                 questionnaireTypesQuery.isLoading
               }
             >

--- a/features/faculty-analytics/components/dean-dashboard-header.tsx
+++ b/features/faculty-analytics/components/dean-dashboard-header.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { ChevronDown, RefreshCw } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 
 import { ALL_PROGRAMS_VALUE } from "@/features/faculty-analytics/constants/filters";
 import type {
   DeanProgramOption,
   DeanSemesterOption,
 } from "@/features/faculty-analytics/lib/dean-analytics-view-model";
-import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -27,8 +26,6 @@ type DeanDashboardHeaderProps = {
   selectedProgramLabel: string;
   onProgramChange: (value: string) => void;
   lastUpdatedLabel: string;
-  isRefreshing: boolean;
-  onRefresh: () => void;
 };
 
 export function DeanDashboardHeader({
@@ -41,8 +38,6 @@ export function DeanDashboardHeader({
   selectedProgramLabel,
   onProgramChange,
   lastUpdatedLabel,
-  isRefreshing,
-  onRefresh,
 }: DeanDashboardHeaderProps) {
   return (
     <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
@@ -118,16 +113,6 @@ export function DeanDashboardHeader({
               </DropdownMenuRadioGroup>
             </DropdownMenuContent>
           </DropdownMenu>
-          <Button
-            type="button"
-            variant="outline"
-            className="w-full px-4 py-2.5 font-sans text-sm md:w-auto"
-            onClick={onRefresh}
-            disabled={isRefreshing}
-          >
-            <RefreshCw className={cn("mr-2 size-4", isRefreshing && "animate-spin")} />
-            Refresh
-          </Button>
         </div>
         <p className="mt-2 font-sans text-sm text-muted-foreground">
           Last updated: {lastUpdatedLabel}

--- a/features/faculty-analytics/components/dean-dashboard-screen.tsx
+++ b/features/faculty-analytics/components/dean-dashboard-screen.tsx
@@ -24,9 +24,7 @@ export function DeanDashboardScreen() {
     overview,
     isLoading,
     isAttentionLoading,
-    isRefreshing,
     isError,
-    refresh,
     retry,
   } = useDeanDashboardViewModel();
 
@@ -55,8 +53,6 @@ export function DeanDashboardScreen() {
           selectedProgramLabel={selectedProgramLabel}
           onProgramChange={setSelectedProgramCode}
           lastUpdatedLabel={lastUpdatedLabel}
-          isRefreshing={isRefreshing}
-          onRefresh={refresh}
         />
 
         {semesters.length === 0 ? (

--- a/features/faculty-analytics/components/dean-dashboard-screen.tsx
+++ b/features/faculty-analytics/components/dean-dashboard-screen.tsx
@@ -31,8 +31,7 @@ export function DeanDashboardScreen() {
   const emptyStateDescription =
     semesters.length === 0
       ? "Semester options will appear here once academic terms are available."
-      : "Analytics data has not been refreshed yet for the selected semester.";
-  const shouldShowInlineNotice = semesters.length > 0 && overview?.lastRefreshedAt === null;
+      : "No analyzed faculty data is available for the selected semester yet.";
 
   return (
     <DeanAnalyticsAsyncContent
@@ -63,12 +62,6 @@ export function DeanDashboardScreen() {
           </div>
         ) : (
           <>
-            {shouldShowInlineNotice ? (
-              <div className="rounded-lg border border-dashed px-4 py-3">
-                <p className="font-sans text-sm text-muted-foreground">{emptyStateDescription}</p>
-              </div>
-            ) : null}
-
             <DeanMetricsGrid summary={summary} />
 
             <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1.15fr)_minmax(19rem,0.85fr)]">

--- a/features/faculty-analytics/components/dean-faculty-analysis-table.tsx
+++ b/features/faculty-analytics/components/dean-faculty-analysis-table.tsx
@@ -88,7 +88,7 @@ export function DeanFacultyAnalysisTable({
                     asChild
                     variant="secondary"
                     size="sm"
-                    className="h-auto max-w-full px-3 py-2 font-sans"
+                    className="h-auto max-w-full whitespace-normal px-3 py-2 text-center font-sans leading-tight"
                   >
                     <Link
                       href={buildDeanFacultyAnalysisHref({
@@ -97,6 +97,7 @@ export function DeanFacultyAnalysisTable({
                         semesterId: selectedSemesterId,
                         semesterLabel: selectedSemesterLabel,
                       })}
+                      className="block whitespace-normal text-center leading-tight"
                     >
                       View Analysis
                     </Link>

--- a/features/faculty-analytics/components/dean-faculty-analysis-table.tsx
+++ b/features/faculty-analytics/components/dean-faculty-analysis-table.tsx
@@ -6,7 +6,7 @@ import { PaginationFooter } from "@/components/shared/pagination-footer";
 import { FacultySubjects } from "@/features/faculty-analytics/components/faculty-subjects";
 import { buildDeanFacultyAnalysisHref } from "@/features/faculty-analytics/lib/faculty-analysis-routes";
 import type { FacultyListItemDto, PaginationMetaDto } from "@/features/faculty-analytics/types";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -66,6 +66,9 @@ export function DeanFacultyAnalysisTable({
                 <TableCell className="data-table-cell px-2 md:px-3 lg:px-5">
                   <div className="flex min-w-0 items-center gap-3">
                     <Avatar size="default" className="hidden border border-border/70 xl:flex">
+                      {faculty.profilePicture ? (
+                        <AvatarImage src={faculty.profilePicture} alt={faculty.fullName} />
+                      ) : null}
                       <AvatarFallback className="bg-slate-100 font-sans text-xs font-semibold text-slate-700">
                         {getFacultyInitials(faculty.fullName)}
                       </AvatarFallback>

--- a/features/faculty-analytics/components/dean-faculty-analytics-screen.tsx
+++ b/features/faculty-analytics/components/dean-faculty-analytics-screen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, RefreshCw, Search } from "lucide-react";
+import { ChevronDown, Search } from "lucide-react";
 
 import { DeanAnalyticsEmptyState } from "@/features/faculty-analytics/components/dean-analytics-empty-state";
 import { DeanAnalyticsErrorState } from "@/features/faculty-analytics/components/dean-analytics-error-state";
@@ -10,7 +10,6 @@ import { DeanFacultyAnalysisTable } from "@/features/faculty-analytics/component
 import { BatchReportExportDialog } from "@/features/faculty-analytics/components/batch-report-export-dialog";
 import { ALL_PROGRAMS_VALUE } from "@/features/faculty-analytics/constants/filters";
 import { useDeanFacultyAnalyticsListViewModel } from "@/features/faculty-analytics/hooks/use-dean-faculty-analytics-list-view-model";
-import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -35,9 +34,7 @@ export function DeanFacultyAnalyticsScreen() {
     searchValue,
     isLoading,
     isError,
-    isFetching,
     retry,
-    refresh,
     setSelectedSemesterId,
     setSelectedProgramId,
     setSearchValue,
@@ -139,16 +136,6 @@ export function DeanFacultyAnalyticsScreen() {
                 </DropdownMenuRadioGroup>
               </DropdownMenuContent>
             </DropdownMenu>
-            <Button
-              type="button"
-              variant="outline"
-              className="w-full px-4 py-2.5 font-sans text-sm md:w-auto md:shrink-0"
-              onClick={refresh}
-              disabled={isFetching}
-            >
-              <RefreshCw className={cn("mr-2 size-4", isFetching && "animate-spin")} />
-              Refresh
-            </Button>
           </div>
         </div>
       </div>

--- a/features/faculty-analytics/components/dean-faculty-analytics-screen.tsx
+++ b/features/faculty-analytics/components/dean-faculty-analytics-screen.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import { ChevronDown, RefreshCw, Search } from "lucide-react";
 
 import { DeanAnalyticsEmptyState } from "@/features/faculty-analytics/components/dean-analytics-empty-state";
 import { DeanAnalyticsErrorState } from "@/features/faculty-analytics/components/dean-analytics-error-state";
 import { DeanAnalyticsLoadingState } from "@/features/faculty-analytics/components/dean-analytics-loading-state";
 import { DeanFacultyAnalysisTable } from "@/features/faculty-analytics/components/dean-faculty-analysis-table";
+import { BatchReportExportDialog } from "@/features/faculty-analytics/components/batch-report-export-dialog";
 import { ALL_PROGRAMS_VALUE } from "@/features/faculty-analytics/constants/filters";
 import { useDeanFacultyAnalyticsListViewModel } from "@/features/faculty-analytics/hooks/use-dean-faculty-analytics-list-view-model";
 import { cn } from "@/lib/utils";
@@ -20,6 +22,7 @@ import {
 import { Input } from "@/components/ui/input";
 
 export function DeanFacultyAnalyticsScreen() {
+  const [isBatchExportDialogOpen, setIsBatchExportDialogOpen] = useState(false);
   const {
     semesters,
     programs,
@@ -50,12 +53,21 @@ export function DeanFacultyAnalyticsScreen() {
             Faculties
           </h1>
           <p className="mt-4 max-w-3xl font-sans text-sm text-muted-foreground sm:mt-5">
-            Review faculty teaching assignments for the selected semester.
+            All faculties for the selected semester.
           </p>
         </div>
-        <div className="flex w-full flex-col gap-3 xl:max-w-4xl">
-          <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-center lg:justify-end">
-            <div className="relative w-full lg:min-w-[20rem] lg:flex-1">
+        <div className="flex w-full flex-col gap-3 xl:max-w-5xl">
+          <div className="flex w-full flex-col gap-3 md:flex-row md:flex-wrap md:items-center md:justify-end">
+            <Button
+              type="button"
+              variant="brand"
+              className="w-full px-4 py-2.5 font-sans text-sm md:w-auto md:shrink-0"
+              onClick={() => setIsBatchExportDialogOpen(true)}
+              disabled={!selectedSemesterId}
+            >
+              Batch Export PDF
+            </Button>
+            <div className="relative w-full md:min-w-[18rem] md:flex-1">
               <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 value={searchValue}
@@ -69,7 +81,7 @@ export function DeanFacultyAnalyticsScreen() {
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="outline"
-                  className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm lg:w-56 lg:shrink-0"
+                  className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-[13rem] md:shrink-0"
                   disabled={programs.length === 0}
                 >
                   <span className="truncate">{selectedProgramLabel}</span>
@@ -100,7 +112,7 @@ export function DeanFacultyAnalyticsScreen() {
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="outline"
-                  className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm lg:w-56 lg:shrink-0"
+                  className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-[13rem] md:shrink-0"
                   disabled={semesters.length === 0}
                 >
                   <span className="truncate">{selectedSemesterLabel}</span>
@@ -130,7 +142,7 @@ export function DeanFacultyAnalyticsScreen() {
             <Button
               type="button"
               variant="outline"
-              className="w-full px-4 py-2.5 font-sans text-sm lg:w-auto lg:shrink-0"
+              className="w-full px-4 py-2.5 font-sans text-sm md:w-auto md:shrink-0"
               onClick={refresh}
               disabled={isFetching}
             >
@@ -167,6 +179,18 @@ export function DeanFacultyAnalyticsScreen() {
           onRowsPerPageChange={setRowsPerPage}
         />
       ) : null}
+
+      <BatchReportExportDialog
+        open={isBatchExportDialogOpen}
+        onOpenChange={setIsBatchExportDialogOpen}
+        semesterId={selectedSemesterId}
+        semesterLabel={selectedSemesterLabel}
+        programId={selectedProgramId}
+        programs={programs.map((program) => ({
+          id: program.id,
+          label: program.label,
+        }))}
+      />
     </section>
   );
 }

--- a/features/faculty-analytics/components/report-export-dialog.tsx
+++ b/features/faculty-analytics/components/report-export-dialog.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useState } from "react";
+import { LoaderCircle } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ReportExportStateCard } from "@/features/faculty-analytics/components/report-export-state-card";
+import { useGenerateSingleReport } from "@/features/faculty-analytics/hooks/use-generate-single-report";
+import { useReportStatus } from "@/features/faculty-analytics/hooks/use-report-status";
+import { isPresignedUrlExpired } from "@/features/faculty-analytics/lib/report-export";
+import { resolveApiErrorMessage } from "@/lib/api-errors";
+import { formatDateTime, formatRelativeTime } from "@/lib/date";
+
+type ReportExportDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  facultyId: string;
+  facultyName: string;
+  semesterId: string;
+  semesterLabel: string;
+  questionnaireTypeCode: string;
+  questionnaireTypeLabel: string;
+};
+
+export function ReportExportDialog({
+  open,
+  onOpenChange,
+  facultyId,
+  facultyName,
+  semesterId,
+  semesterLabel,
+  questionnaireTypeCode,
+  questionnaireTypeLabel,
+}: ReportExportDialogProps) {
+  const [jobId, setJobId] = useState<string | null>(null);
+  const generateReportMutation = useGenerateSingleReport();
+  const statusQuery = useReportStatus(jobId, { enabled: open && Boolean(jobId) });
+  const status = statusQuery.data;
+  const urlExpired = isPresignedUrlExpired(status?.expiresAt);
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setJobId(null);
+      generateReportMutation.reset();
+    }
+
+    onOpenChange(nextOpen);
+  }
+
+  async function handleGenerate() {
+    try {
+      const response = await generateReportMutation.mutateAsync({
+        facultyId,
+        semesterId,
+        questionnaireTypeCode,
+      });
+
+      setJobId(response.jobId);
+    } catch (error) {
+      toast.error(resolveApiErrorMessage(error, "Unable to queue the report export right now."));
+    }
+  }
+
+  const isGenerating =
+    generateReportMutation.isPending || status?.status === "waiting" || status?.status === "active";
+  const isCompleted = status?.status === "completed";
+  const isFailed = status?.status === "failed";
+  const isSkipped = status?.status === "skipped";
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Export Faculty Report</DialogTitle>
+          <DialogDescription>
+            Generate a PDF report for the selected faculty analytics view.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="rounded-lg border border-border/70 bg-muted/20 p-4">
+            <dl className="space-y-2 font-sans text-sm">
+              <div className="flex items-center justify-between gap-4">
+                <dt className="text-muted-foreground">Faculty</dt>
+                <dd className="text-right font-medium">{facultyName}</dd>
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <dt className="text-muted-foreground">Semester</dt>
+                <dd className="text-right font-medium">{semesterLabel}</dd>
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <dt className="text-muted-foreground">Questionnaire Type</dt>
+                <dd className="text-right font-medium">{questionnaireTypeLabel}</dd>
+              </div>
+            </dl>
+          </div>
+
+          {isGenerating ? (
+            <div className="rounded-lg border border-border/70 bg-muted/20 px-4 py-5">
+              <div className="flex items-center gap-3">
+                <LoaderCircle className="size-5 animate-spin text-brand-blue" />
+                <div className="space-y-1">
+                  <p className="font-sans text-sm font-medium text-foreground">
+                    Report generation in progress
+                  </p>
+                  <p className="font-sans text-sm text-muted-foreground">
+                    Current status: {status?.status ?? "waiting"}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {isCompleted ? (
+            <ReportExportStateCard
+              title="Report ready"
+              badgeLabel="Completed"
+              tone="success"
+              message={
+                urlExpired
+                  ? "The secure PDF link has expired. Refresh the link to access the report again."
+                  : `Secure link expires ${formatRelativeTime(status?.expiresAt ?? "")}.`
+              }
+              meta={
+                status?.completedAt ? `Completed ${formatDateTime(status.completedAt)}` : undefined
+              }
+            />
+          ) : null}
+
+          {isFailed ? (
+            <ReportExportStateCard
+              title="Export failed"
+              badgeLabel="Failed"
+              tone="error"
+              message={status?.error ?? "The backend could not generate the PDF for this report."}
+            />
+          ) : null}
+
+          {isSkipped ? (
+            <ReportExportStateCard
+              title="No export generated"
+              badgeLabel="Skipped"
+              tone="warning"
+              message="No evaluation data found"
+            />
+          ) : null}
+        </div>
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={generateReportMutation.isPending}
+          >
+            Close
+          </Button>
+
+          <div className="flex flex-wrap justify-end gap-2">
+            {!jobId ? (
+              <Button
+                type="button"
+                onClick={handleGenerate}
+                disabled={generateReportMutation.isPending}
+              >
+                {generateReportMutation.isPending ? "Queueing..." : "Generate PDF"}
+              </Button>
+            ) : null}
+
+            {isFailed || isSkipped ? (
+              <Button
+                type="button"
+                onClick={handleGenerate}
+                disabled={generateReportMutation.isPending}
+              >
+                Retry Export
+              </Button>
+            ) : null}
+
+            {isCompleted ? (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    void statusQuery.refetch();
+                  }}
+                >
+                  Refresh Link
+                </Button>
+                <Button asChild variant="outline" disabled={!status?.downloadUrl || urlExpired}>
+                  <a href={status?.downloadUrl} target="_blank" rel="noreferrer">
+                    View PDF
+                  </a>
+                </Button>
+              </>
+            ) : null}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/faculty-analytics/components/report-export-dialog.tsx
+++ b/features/faculty-analytics/components/report-export-dialog.tsx
@@ -161,16 +161,18 @@ export function ReportExportDialog({
             variant="outline"
             onClick={() => onOpenChange(false)}
             disabled={generateReportMutation.isPending}
+            className="w-full sm:w-auto"
           >
             Close
           </Button>
 
-          <div className="flex flex-wrap justify-end gap-2">
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:justify-end">
             {!jobId ? (
               <Button
                 type="button"
                 onClick={handleGenerate}
                 disabled={generateReportMutation.isPending}
+                className="w-full sm:w-auto"
               >
                 {generateReportMutation.isPending ? "Queueing..." : "Generate PDF"}
               </Button>
@@ -181,6 +183,7 @@ export function ReportExportDialog({
                 type="button"
                 onClick={handleGenerate}
                 disabled={generateReportMutation.isPending}
+                className="w-full sm:w-auto"
               >
                 Retry Export
               </Button>
@@ -194,10 +197,15 @@ export function ReportExportDialog({
                   onClick={() => {
                     void statusQuery.refetch();
                   }}
+                  className="w-full sm:w-auto"
                 >
                   Refresh Link
                 </Button>
-                <Button asChild variant="outline" disabled={!status?.downloadUrl || urlExpired}>
+                <Button
+                  asChild
+                  disabled={!status?.downloadUrl || urlExpired}
+                  className="w-full sm:w-auto"
+                >
                   <a href={status?.downloadUrl} target="_blank" rel="noreferrer">
                     View PDF
                   </a>

--- a/features/faculty-analytics/components/report-export-state-card.tsx
+++ b/features/faculty-analytics/components/report-export-state-card.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+
+type ReportExportStateTone = "success" | "warning" | "error" | "neutral";
+
+type ReportExportStateCardProps = {
+  title: string;
+  message: string;
+  badgeLabel?: string;
+  tone: ReportExportStateTone;
+  meta?: string;
+  centered?: boolean;
+};
+
+const TONE_STYLES: Record<ReportExportStateTone, string> = {
+  success: "border-emerald-500/30 bg-emerald-500/5",
+  warning: "border-amber-500/30 bg-amber-500/5",
+  error: "border-destructive/30 bg-destructive/5",
+  neutral: "border-border/70 bg-muted/20",
+};
+
+const BADGE_STYLES: Record<ReportExportStateTone, string> = {
+  success: "border-emerald-500/30 text-emerald-700",
+  warning: "border-amber-500/30 text-amber-700",
+  error: "border-destructive/30 text-destructive",
+  neutral: "border-border/70 text-foreground",
+};
+
+export function ReportExportStateCard({
+  title,
+  message,
+  badgeLabel,
+  tone,
+  meta,
+  centered = false,
+}: ReportExportStateCardProps) {
+  return (
+    <div className={`space-y-2 rounded-lg border px-4 py-5 ${TONE_STYLES[tone]}`}>
+      <div className="flex items-center justify-between gap-3">
+        <p className="font-sans text-sm font-medium text-foreground">{title}</p>
+        {badgeLabel ? (
+          <Badge variant="outline" className={BADGE_STYLES[tone]}>
+            {badgeLabel}
+          </Badge>
+        ) : null}
+      </div>
+      <p className={`font-sans text-sm text-muted-foreground ${centered ? "text-center" : ""}`}>
+        {message}
+      </p>
+      {meta ? <p className="font-sans text-xs text-muted-foreground">{meta}</p> : null}
+    </div>
+  );
+}

--- a/features/faculty-analytics/hooks/use-batch-report-status.ts
+++ b/features/faculty-analytics/hooks/use-batch-report-status.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { fetchBatchReportStatus } from "@/features/faculty-analytics/api/faculty-analytics.requests";
+import type { BatchReportStatusQuery } from "@/features/faculty-analytics/types";
+import { useAuthStore } from "@/stores/auth-store";
+
+type UseBatchReportStatusOptions = {
+  enabled?: boolean;
+};
+
+export function useBatchReportStatus(
+  params: BatchReportStatusQuery | null,
+  options?: UseBatchReportStatusOptions
+) {
+  const token = useAuthStore((state) => state.token);
+  const isEnabled = options?.enabled ?? true;
+
+  return useQuery({
+    queryKey: ["faculty-analytics", "batch-report-status", params, token],
+    enabled: Boolean(token) && Boolean(params?.batchId) && isEnabled,
+    placeholderData: keepPreviousData,
+    queryFn: () =>
+      fetchBatchReportStatus({
+        batchId: params?.batchId ?? "",
+        page: params?.page,
+        limit: params?.limit,
+      }),
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) {
+        return 2000;
+      }
+
+      const terminalJobs = data.completed + data.failed + data.skipped;
+      return terminalJobs < data.total ? 2000 : false;
+    },
+  });
+}

--- a/features/faculty-analytics/hooks/use-dean-dashboard-view-model.ts
+++ b/features/faculty-analytics/hooks/use-dean-dashboard-view-model.ts
@@ -80,13 +80,6 @@ export function useDeanDashboardViewModel() {
     semestersQuery.isError ||
     programOptionsQuery.isError ||
     overviewQuery.isError;
-  const isRefreshing =
-    meQuery.isFetching ||
-    semestersQuery.isFetching ||
-    programOptionsQuery.isFetching ||
-    overviewQuery.isFetching ||
-    attentionQuery.isFetching;
-
   return {
     semesters,
     programs,
@@ -109,20 +102,8 @@ export function useDeanDashboardViewModel() {
     overview: overviewQuery.data ?? null,
     isAttentionLoading: Boolean(selectedSemesterId) && attentionQuery.isLoading,
     isLoading,
-    isRefreshing,
     isError,
     retry: () => {
-      void meQuery.refetch();
-      void semestersQuery.refetch();
-      if (selectedSemesterId) {
-        void programOptionsQuery.refetch();
-      }
-      if (selectedSemesterId) {
-        void overviewQuery.refetch();
-        void attentionQuery.refetch();
-      }
-    },
-    refresh: () => {
       void meQuery.refetch();
       void semestersQuery.refetch();
       if (selectedSemesterId) {

--- a/features/faculty-analytics/hooks/use-dean-faculty-analytics-list-view-model.ts
+++ b/features/faculty-analytics/hooks/use-dean-faculty-analytics-list-view-model.ts
@@ -107,16 +107,6 @@ export function useDeanFacultyAnalyticsListViewModel() {
         void facultyListQuery.refetch();
       }
     },
-    refresh: () => {
-      void meQuery.refetch();
-      void semestersQuery.refetch();
-      if (selectedSemesterId) {
-        void programOptionsQuery.refetch();
-      }
-      if (selectedSemesterId) {
-        void facultyListQuery.refetch();
-      }
-    },
     setSelectedSemesterId: (value: string) => {
       setSelectedSemesterId(value);
       setSelectedProgramId(null);

--- a/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
+++ b/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
@@ -132,7 +132,6 @@ export function useFacultyReportDetailViewModel({
     commentsQuery,
     questionnaireTypesQuery,
     isQuestionnaireTypeLoading: questionnaireTypesQuery.isLoading,
-    isRefreshing: reportQuery.isFetching || commentsQuery.isFetching,
     hasSemesterContext: Boolean(semesterId),
     updateQuestionnaireType: (value: string) => {
       updateSearchParams({

--- a/features/faculty-analytics/hooks/use-generate-batch-report.ts
+++ b/features/faculty-analytics/hooks/use-generate-batch-report.ts
@@ -1,0 +1,11 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+
+import { generateBatchReport } from "@/features/faculty-analytics/api/faculty-analytics.requests";
+
+export function useGenerateBatchReport() {
+  return useMutation({
+    mutationFn: generateBatchReport,
+  });
+}

--- a/features/faculty-analytics/hooks/use-generate-single-report.ts
+++ b/features/faculty-analytics/hooks/use-generate-single-report.ts
@@ -1,0 +1,11 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+
+import { generateSingleReport } from "@/features/faculty-analytics/api/faculty-analytics.requests";
+
+export function useGenerateSingleReport() {
+  return useMutation({
+    mutationFn: generateSingleReport,
+  });
+}

--- a/features/faculty-analytics/hooks/use-report-status.ts
+++ b/features/faculty-analytics/hooks/use-report-status.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchReportStatus } from "@/features/faculty-analytics/api/faculty-analytics.requests";
+import { useAuthStore } from "@/stores/auth-store";
+
+const TERMINAL_STATUSES = new Set(["completed", "failed", "skipped"]);
+
+type UseReportStatusOptions = {
+  enabled?: boolean;
+};
+
+export function useReportStatus(jobId: string | null, options?: UseReportStatusOptions) {
+  const token = useAuthStore((state) => state.token);
+  const isEnabled = options?.enabled ?? true;
+
+  return useQuery({
+    queryKey: ["faculty-analytics", "report-status", jobId, token],
+    enabled: Boolean(token) && Boolean(jobId) && isEnabled,
+    queryFn: () => fetchReportStatus(jobId ?? ""),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return !status || !TERMINAL_STATUSES.has(status) ? 2000 : false;
+    },
+  });
+}

--- a/features/faculty-analytics/index.ts
+++ b/features/faculty-analytics/index.ts
@@ -1,8 +1,2 @@
-export * from "@/features/faculty-analytics/types";
-export { DeanFacultyAnalysisTable } from "@/features/faculty-analytics/components/dean-faculty-analysis-table";
 export { DeanDashboardScreen } from "@/features/faculty-analytics/components/dean-dashboard-screen";
 export { DeanFacultyAnalyticsScreen } from "@/features/faculty-analytics/components/dean-faculty-analytics-screen";
-export {
-  mapDepartmentOverviewToDashboardViewModel,
-  mapSemesterOptionsToViewModel,
-} from "@/features/faculty-analytics/lib/dean-analytics-view-model";

--- a/features/faculty-analytics/lib/recommendation-utils.ts
+++ b/features/faculty-analytics/lib/recommendation-utils.ts
@@ -1,9 +1,0 @@
-export function buildOverallRecommendation(items: string[]): string {
-  const uniqueItems = Array.from(new Set(items));
-
-  if (uniqueItems.length === 0) {
-    return "No recommendation available for this section.";
-  }
-
-  return uniqueItems.join(" ");
-}

--- a/features/faculty-analytics/lib/report-export.ts
+++ b/features/faculty-analytics/lib/report-export.ts
@@ -1,0 +1,37 @@
+import type { ReportJobStatus } from "@/features/faculty-analytics/types";
+
+export function isPresignedUrlExpired(expiresAt?: string) {
+  return Boolean(expiresAt) && new Date(expiresAt ?? "").getTime() <= Date.now();
+}
+
+export function getBatchProgressValue(
+  total: number,
+  completed: number,
+  failed: number,
+  skipped: number
+) {
+  if (total <= 0) {
+    return 0;
+  }
+
+  return Math.round(((completed + failed + skipped) / total) * 100);
+}
+
+export function formatReportJobStatusLabel(status: ReportJobStatus) {
+  return status
+    .split("_")
+    .map((segment) => segment[0]?.toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+export function resolveBatchSetupMessage(jobCount: number, skippedCount: number) {
+  if (jobCount > 0) {
+    return null;
+  }
+
+  if (skippedCount > 0) {
+    return "No new batch exports were queued because matching reports are already pending for this selection.";
+  }
+
+  return "No eligible faculty report submissions were found for the selected semester, program, and questionnaire type.";
+}

--- a/features/faculty-analytics/types/index.ts
+++ b/features/faculty-analytics/types/index.ts
@@ -160,6 +160,61 @@ export type AttentionListResponseDto = {
   lastRefreshedAt: string | null;
 };
 
+export type GenerateSingleReportRequest = {
+  facultyId: string;
+  semesterId: string;
+  questionnaireTypeCode: string;
+};
+
+export type GenerateSingleReportResponse = {
+  jobId: string;
+};
+
+export type ReportJobStatus = "waiting" | "active" | "completed" | "failed" | "skipped";
+
+export type ReportStatusResponseDto = {
+  jobId: string;
+  status: ReportJobStatus;
+  facultyName: string;
+  downloadUrl?: string;
+  expiresAt?: string;
+  error?: string;
+  message?: string;
+  createdAt: string;
+  completedAt?: string;
+};
+
+export type GenerateBatchReportRequest = {
+  semesterId: string;
+  questionnaireTypeCode: string;
+  departmentId?: string;
+  programId?: string;
+};
+
+export type GenerateBatchReportResponse = {
+  batchId: string;
+  jobCount: number;
+  skippedCount: number;
+};
+
+export type BatchReportStatusQuery = {
+  batchId: string;
+  page?: number;
+  limit?: number;
+};
+
+export type BatchStatusResponseDto = {
+  batchId: string;
+  total: number;
+  completed: number;
+  failed: number;
+  skipped: number;
+  active: number;
+  waiting: number;
+  jobs: ReportStatusResponseDto[];
+  meta: PaginationMetaDto;
+};
+
 export type FacultyReportQuery = {
   facultyId: string;
   semesterId: string;

--- a/network/endpoints.ts
+++ b/network/endpoints.ts
@@ -48,6 +48,10 @@ export enum Endpoints {
   analyticsAttention = "/api/v1/analytics/attention",
   analyticsFacultyReport = "/api/v1/analytics/faculty/:facultyId/report",
   analyticsFacultyReportComments = "/api/v1/analytics/faculty/:facultyId/report/comments",
+  reportsGenerate = "/api/v1/reports/generate",
+  reportsGenerateBatch = "/api/v1/reports/generate/batch",
+  reportsStatus = "/api/v1/reports/status/:jobId",
+  reportsBatchStatus = "/api/v1/reports/batch/:batchId",
 
   // Faculty
   faculty = "/api/v1/faculty",


### PR DESCRIPTION
## Summary
- wire the faculty report export data layer for single-job and batch-job generation/status polling
- add single faculty export and batch export dialogs with progress, result, retry, and expired-link handling
- polish the dean/faculty analysis UX with responsive actions, profile images, chart sizing, and cleanup of redundant refresh/dead code

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint features/faculty-analytics 'app/(dashboard)/dean' components/ui/sidebar.tsx --quiet`
- [x] `bun run lint features/faculty-analytics/components/batch-report-export-dialog.tsx features/faculty-analytics/components/dean-faculty-analysis-table.tsx features/faculty-analytics/components/report-export-dialog.tsx --quiet`
- [x] Manually verify single faculty export from the faculty analysis page
- [x] Manually verify batch export from the dean faculties page, including zero-job and mixed-result cases
- [x] Manually verify responsive dialog/button behavior on small screens
- [x] Manually verify section performance chart sizing with many sections

Closes #71