### PR TITLE
[FEAT] FAC-WEB analysis pipeline triggering and themes/recommendations surfacing

### DIFF
--- a/components/animated-number.tsx
+++ b/components/animated-number.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { easings, useCountUp, type EasingFn } from "@/lib/use-count-up";
+
+type AnimatedNumberProps = {
+  value: number;
+  /** Fixed decimal places (kept stable during animation). Default 0. */
+  decimals?: number;
+  /** ms, default 1000 */
+  duration?: number;
+  /** Starting value on first mount; default 0 */
+  from?: number;
+  /** Override easing curve; default easings.outExpo */
+  easing?: EasingFn;
+  /** Locale for thousand separators etc. Default "en-US". */
+  locale?: string;
+  /** Rendered before the number. */
+  prefix?: string;
+  /** Rendered after the number (e.g. "%"). */
+  suffix?: string;
+  /** Render as a specific element (default <span>) — useful inside headings. */
+  as?: keyof React.JSX.IntrinsicElements;
+  className?: string;
+};
+
+/**
+ * Count-up primitive that animates to `value` on mount and on every change.
+ * Uses `Intl.NumberFormat` for locale-aware thousand separators and fixed
+ * decimal places; tabular-nums styling is applied so digit widths don't jump.
+ */
+export function AnimatedNumber({
+  value,
+  decimals = 0,
+  duration,
+  from,
+  easing,
+  locale = "en-US",
+  prefix,
+  suffix,
+  as: Tag = "span",
+  className,
+}: AnimatedNumberProps) {
+  const animated = useCountUp(value, { duration, from, easing });
+
+  const formatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+      }),
+    [locale, decimals]
+  );
+
+  const rendered = formatter.format(animated);
+
+  return (
+    <Tag className={className} style={{ fontVariantNumeric: "tabular-nums" }}>
+      {prefix}
+      {rendered}
+      {suffix}
+    </Tag>
+  );
+}
+
+export { easings };

--- a/features/faculty-analytics/api/analysis-pipeline.requests.ts
+++ b/features/faculty-analytics/api/analysis-pipeline.requests.ts
@@ -1,0 +1,49 @@
+import { apiClient } from "@/network/axios";
+import { Endpoints } from "@/network/endpoints";
+import type {
+  CreatePipelineRequest,
+  ListPipelinesQuery,
+  PipelineStatusResponse,
+  PipelineSummary,
+  RecommendationsResponse,
+} from "@/features/faculty-analytics/types";
+
+export async function listPipelines(query: ListPipelinesQuery) {
+  const response = await apiClient.get<PipelineSummary[]>(Endpoints.analysisPipelines, {
+    params: query,
+  });
+  return response.data;
+}
+
+export async function createPipeline(body: CreatePipelineRequest) {
+  const response = await apiClient.post<PipelineSummary>(Endpoints.analysisPipelines, body);
+  return response.data;
+}
+
+export async function confirmPipeline(id: string) {
+  const response = await apiClient.post<PipelineSummary>(
+    Endpoints.analysisPipelinesConfirm.replace(":id", id)
+  );
+  return response.data;
+}
+
+export async function cancelPipeline(id: string) {
+  const response = await apiClient.post<PipelineSummary>(
+    Endpoints.analysisPipelinesCancel.replace(":id", id)
+  );
+  return response.data;
+}
+
+export async function fetchPipelineStatus(id: string) {
+  const response = await apiClient.get<PipelineStatusResponse>(
+    Endpoints.analysisPipelinesStatus.replace(":id", id)
+  );
+  return response.data;
+}
+
+export async function fetchPipelineRecommendations(id: string) {
+  const response = await apiClient.get<RecommendationsResponse>(
+    Endpoints.analysisPipelinesRecommendations.replace(":id", id)
+  );
+  return response.data;
+}

--- a/features/faculty-analytics/components/faculty-report-screen.tsx
+++ b/features/faculty-analytics/components/faculty-report-screen.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { ScopedAnalyticsEmptyState } from "@/features/faculty-analytics/components/scoped-analytics-empty-state";
 import { ScopedAnalyticsErrorState } from "@/features/faculty-analytics/components/scoped-analytics-error-state";
 import { ScopedAnalyticsLoadingState } from "@/features/faculty-analytics/components/scoped-analytics-loading-state";
 import { ReportExportDialog } from "@/features/faculty-analytics/components/report-export-dialog";
+import { PipelineStatusBadge } from "@/features/faculty-analytics/components/pipeline-status-badge";
+import { RecommendationsCard } from "@/features/faculty-analytics/components/recommendations-card";
+import { ThemesChipList } from "@/features/faculty-analytics/components/themes-chip-list";
 import { useFacultyReportDetailViewModel } from "@/features/faculty-analytics/hooks/use-faculty-report-detail-view-model";
+import { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
+import { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
+import { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
+import { aggregateThemes } from "@/features/faculty-analytics/lib/pipeline-themes";
 import { hasFacultyReportAnalyticsData } from "@/features/faculty-analytics/lib/faculty-report-detail";
+import type { PipelineStatus } from "@/features/faculty-analytics/types";
 
 import { FacultyReportComments } from "./faculty-report-comments";
 import { FacultyReportHeader } from "./faculty-report-header";
@@ -20,9 +28,40 @@ type FacultyReportScreenProps = {
   facultyId: string;
 };
 
+const RUNNING_STATUSES: ReadonlySet<PipelineStatus> = new Set<PipelineStatus>([
+  "AWAITING_CONFIRMATION",
+  "EMBEDDING_CHECK",
+  "SENTIMENT_ANALYSIS",
+  "SENTIMENT_GATE",
+  "TOPIC_MODELING",
+  "GENERATING_RECOMMENDATIONS",
+]);
+
 export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const viewModel = useFacultyReportDetailViewModel({ facultyId });
+
+  const pipelineScope = useMemo(
+    () => ({ semesterId: viewModel.semesterId ?? "", facultyId }),
+    [viewModel.semesterId, facultyId]
+  );
+  const { latestPipeline } = useLatestPipelineForScope(pipelineScope, {
+    enabled: Boolean(viewModel.semesterId),
+  });
+  // Poll live status — without this, a completed pipeline's themes+recs
+  // don't appear until the next list refetch or a page refresh.
+  const pipelineStatusQuery = usePipelineStatus(latestPipeline?.id ?? null, {
+    enabled: Boolean(latestPipeline?.id),
+  });
+  const livePipelineStatus = pipelineStatusQuery.data?.status ?? latestPipeline?.status;
+  const recommendationsQuery = usePipelineRecommendations(
+    latestPipeline?.id ?? null,
+    livePipelineStatus
+  );
+  const themes = useMemo(
+    () => (recommendationsQuery.data ? aggregateThemes(recommendationsQuery.data.actions) : []),
+    [recommendationsQuery.data]
+  );
 
   if (!viewModel.hasSemesterContext) {
     return (
@@ -75,6 +114,10 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
   }
 
   const hasAnalyticsData = hasFacultyReportAnalyticsData(viewModel.report, viewModel.commentsCount);
+  const pipelineStatus = livePipelineStatus;
+  const isPipelineRunning = pipelineStatus ? RUNNING_STATUSES.has(pipelineStatus) : false;
+  const showCompletedAnalysis =
+    pipelineStatus === "COMPLETED" && recommendationsQuery.data !== undefined;
 
   return (
     <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
@@ -95,6 +138,17 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
         onExport={() => setIsExportDialogOpen(true)}
       />
 
+      {pipelineStatus ? (
+        <div className="flex items-center gap-3">
+          <PipelineStatusBadge status={pipelineStatus} />
+          {isPipelineRunning ? (
+            <span className="font-sans text-xs text-muted-foreground">
+              Analysis in progress. Themes and recommendations will appear once complete.
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
       {!hasAnalyticsData ? (
         <ScopedAnalyticsEmptyState description="No evaluation analytics are available for this faculty in the selected filters." />
       ) : (
@@ -105,6 +159,12 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
             commentsCount={viewModel.commentsCount}
             overallInterpretation={viewModel.report.overallInterpretation}
           />
+
+          {showCompletedAnalysis && themes.length > 0 ? <ThemesChipList themes={themes} /> : null}
+
+          {showCompletedAnalysis && recommendationsQuery.data ? (
+            <RecommendationsCard recommendations={recommendationsQuery.data} />
+          ) : null}
 
           <FacultyReportSectionPerformanceChart sections={viewModel.report.sections} />
 

--- a/features/faculty-analytics/components/faculty-report-summary-cards.tsx
+++ b/features/faculty-analytics/components/faculty-report-summary-cards.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import {
-  formatFacultyReportScore,
-  getFacultyReportInterpretationTextClass,
-} from "@/features/faculty-analytics/lib/faculty-report-detail";
+import { AnimatedNumber } from "@/components/animated-number";
+import { getFacultyReportInterpretationTextClass } from "@/features/faculty-analytics/lib/faculty-report-detail";
 
 type FacultyReportSummaryCardsProps = {
   submissionCount: number;
@@ -42,17 +40,19 @@ export function FacultyReportSummaryCards({
     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
       <SummaryCard
         label="Submissions"
-        value={String(submissionCount)}
+        value={<AnimatedNumber value={submissionCount} />}
         description="Submitted evaluation responses included in this report context"
       />
       <SummaryCard
         label="Overall Rating"
-        value={formatFacultyReportScore(overallRating)}
+        value={
+          overallRating === null ? "N/A" : <AnimatedNumber value={overallRating} decimals={2} />
+        }
         description="Weighted average score across all sections in this report"
       />
       <SummaryCard
         label="Comments"
-        value={String(commentsCount)}
+        value={<AnimatedNumber value={commentsCount} />}
         description="Qualitative comments submitted for this faculty report"
       />
       <SummaryCard

--- a/features/faculty-analytics/components/pipeline-confirm-dialog.tsx
+++ b/features/faculty-analytics/components/pipeline-confirm-dialog.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { PipelineSummary } from "@/features/faculty-analytics/types";
+
+type PipelineConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  pipeline: PipelineSummary | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isConfirming: boolean;
+  isCancelling: boolean;
+};
+
+function formatPercent(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  return `${Math.round(n * 100)}`;
+}
+
+export function PipelineConfirmDialog({
+  open,
+  onOpenChange,
+  pipeline,
+  onConfirm,
+  onCancel,
+  isConfirming,
+  isCancelling,
+}: PipelineConfirmDialogProps) {
+  if (!pipeline) return null;
+
+  const coverage = pipeline.coverage;
+  const warnings = pipeline.warnings ?? [];
+  const busy = isConfirming || isCancelling;
+
+  return (
+    <Dialog open={open} onOpenChange={busy ? undefined : onOpenChange}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader className="space-y-1">
+          <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+            Review analysis snapshot
+          </p>
+          <DialogTitle className="font-playfair text-2xl tracking-tight">
+            Start analysis pipeline?
+          </DialogTitle>
+          <DialogDescription className="font-sans text-sm">
+            These numbers lock when you confirm. The run typically takes a few minutes and cannot be
+            edited once it starts.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-3 divide-x divide-border rounded-xl border border-border/70 bg-muted/20">
+          <div className="p-4">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+              Response rate
+            </p>
+            <p className="mt-1.5 font-playfair text-3xl leading-none tabular-nums">
+              {formatPercent(coverage.responseRate)}
+              <span className="ml-0.5 text-lg text-muted-foreground">%</span>
+            </p>
+            <p className="mt-1 font-mono text-[11px] tabular-nums text-muted-foreground">
+              {coverage.submissionCount}/{coverage.totalEnrolled} enrolled
+            </p>
+          </div>
+          <div className="p-4">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+              Submissions
+            </p>
+            <p className="mt-1.5 font-playfair text-3xl leading-none tabular-nums">
+              {coverage.submissionCount}
+            </p>
+            <p className="mt-1 font-mono text-[11px] tabular-nums text-muted-foreground">
+              received
+            </p>
+          </div>
+          <div className="p-4">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+              Comments
+            </p>
+            <p className="mt-1.5 font-playfair text-3xl leading-none tabular-nums">
+              {coverage.commentCount}
+            </p>
+            <p className="mt-1 font-mono text-[11px] tabular-nums text-muted-foreground">
+              with qualitative text
+            </p>
+          </div>
+        </div>
+
+        {warnings.length > 0 ? (
+          <div className="rounded-xl border border-amber-500/40 bg-amber-50/70 p-4 dark:bg-amber-950/20">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              <div className="flex-1 space-y-2">
+                <p className="font-sans text-sm font-semibold text-amber-900 dark:text-amber-200">
+                  Coverage warnings · {warnings.length}
+                </p>
+                <ul className="ml-5 list-disc space-y-1 font-sans text-sm text-amber-900/90 dark:text-amber-100/90">
+                  {warnings.map((w, i) => (
+                    <li key={i}>{w}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-xl border border-emerald-500/40 bg-emerald-50/70 p-4 dark:bg-emerald-950/20">
+            <div className="flex items-start gap-3">
+              <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+              <p className="font-sans text-sm font-medium text-emerald-900 dark:text-emerald-200">
+                No coverage warnings — the snapshot looks healthy.
+              </p>
+            </div>
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button variant="outline" onClick={onCancel} disabled={busy} className="font-sans">
+            {isCancelling ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Cancelling…
+              </>
+            ) : (
+              "Cancel this run"
+            )}
+          </Button>
+          <Button onClick={onConfirm} disabled={busy} className="font-sans">
+            {isConfirming ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Starting…
+              </>
+            ) : (
+              "Start analysis"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/faculty-analytics/components/pipeline-status-badge.tsx
+++ b/features/faculty-analytics/components/pipeline-status-badge.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import type { PipelineStatus } from "@/features/faculty-analytics/types";
+
+type PipelineStatusBadgeProps = {
+  status: PipelineStatus;
+  className?: string;
+};
+
+const LABELS: Record<PipelineStatus, string> = {
+  AWAITING_CONFIRMATION: "Awaiting confirmation",
+  EMBEDDING_CHECK: "Checking embeddings",
+  SENTIMENT_ANALYSIS: "Analyzing sentiment",
+  SENTIMENT_GATE: "Filtering results",
+  TOPIC_MODELING: "Extracting themes",
+  GENERATING_RECOMMENDATIONS: "Generating recommendations",
+  COMPLETED: "Completed",
+  FAILED: "Failed",
+  CANCELLED: "Cancelled",
+};
+
+const VARIANTS: Record<
+  PipelineStatus,
+  "default" | "secondary" | "destructive" | "outline" | "ghost"
+> = {
+  AWAITING_CONFIRMATION: "secondary",
+  EMBEDDING_CHECK: "default",
+  SENTIMENT_ANALYSIS: "default",
+  SENTIMENT_GATE: "default",
+  TOPIC_MODELING: "default",
+  GENERATING_RECOMMENDATIONS: "default",
+  COMPLETED: "default",
+  FAILED: "destructive",
+  CANCELLED: "outline",
+};
+
+export function PipelineStatusBadge({ status, className }: PipelineStatusBadgeProps) {
+  return (
+    <Badge variant={VARIANTS[status]} className={className}>
+      {LABELS[status]}
+    </Badge>
+  );
+}

--- a/features/faculty-analytics/components/pipeline-status-dialog.tsx
+++ b/features/faculty-analytics/components/pipeline-status-dialog.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import {
+  AlertTriangle,
+  Ban,
+  CheckCircle2,
+  Circle,
+  Loader2,
+  MinusCircle,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { PipelineStatusBadge } from "@/features/faculty-analytics/components/pipeline-status-badge";
+import {
+  RUNNING_STATUSES,
+  STAGE_DESCRIPTIONS,
+  STAGE_LABELS,
+  STAGE_ORDER,
+  STATUS_HEADLINE,
+  TERMINAL_STATUSES,
+  type StageKey,
+  activeStageIndex,
+  overallElapsedLabel,
+  stageElapsedLabel,
+} from "@/features/faculty-analytics/lib/pipeline-formatting";
+import type {
+  PipelineStageStatus,
+  PipelineStatusResponse,
+} from "@/features/faculty-analytics/types";
+import { cn } from "@/lib/utils";
+
+type PipelineStatusDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  status: PipelineStatusResponse | undefined;
+  isLoading?: boolean;
+  onCancelPipeline: () => void;
+  isCancelling: boolean;
+};
+
+type StageNodeProps = {
+  stageKey: StageKey;
+  stage: PipelineStageStatus;
+  isActive: boolean;
+  showConnector: boolean;
+  extraDetail?: string;
+};
+
+function StageIcon({
+  status,
+  isActive,
+  className,
+}: {
+  status: PipelineStageStatus["status"];
+  isActive: boolean;
+  className?: string;
+}) {
+  const map: Record<PipelineStageStatus["status"], { Icon: LucideIcon; tone: string }> = {
+    completed: { Icon: CheckCircle2, tone: "text-emerald-500" },
+    processing: { Icon: Loader2, tone: "text-primary" },
+    failed: { Icon: XCircle, tone: "text-destructive" },
+    skipped: { Icon: MinusCircle, tone: "text-muted-foreground" },
+    pending: { Icon: Circle, tone: "text-muted-foreground/60" },
+  };
+  const { Icon, tone } = map[status];
+  return (
+    <Icon
+      className={cn(
+        "size-4",
+        tone,
+        status === "processing" && "animate-spin",
+        isActive && "drop-shadow-[0_0_6px_currentColor]",
+        className
+      )}
+    />
+  );
+}
+
+function StageNode({ stageKey, stage, isActive, showConnector, extraDetail }: StageNodeProps) {
+  const status = stage.status;
+  const isCompleted = status === "completed";
+  const isFailed = status === "failed";
+  const isPending = status === "pending";
+  const progress = stage.progress;
+  const elapsed = stageElapsedLabel(stage);
+
+  return (
+    <li className="relative pb-6 last:pb-0">
+      {showConnector ? (
+        <span
+          aria-hidden
+          className={cn(
+            "absolute left-[9px] top-6 bottom-0 w-px",
+            isCompleted ? "bg-emerald-500/40" : isActive ? "bg-primary/40" : "bg-border"
+          )}
+        />
+      ) : null}
+      <div className="flex items-start gap-4">
+        <div
+          className={cn(
+            "relative mt-0.5 flex size-[19px] shrink-0 items-center justify-center rounded-full border-2 bg-background transition-colors",
+            isCompleted && "border-emerald-500/60",
+            isActive && !isCompleted && "border-primary shadow-[0_0_0_4px_var(--color-primary)]/10",
+            isFailed && "border-destructive/70",
+            !isActive && !isCompleted && !isFailed && "border-border"
+          )}
+        >
+          {isActive && !isCompleted && !isFailed ? (
+            <span
+              aria-hidden
+              className="absolute inset-0 animate-ping rounded-full bg-primary/30"
+            />
+          ) : null}
+          <StageIcon status={status} isActive={isActive} />
+        </div>
+        <div className="flex-1 pt-0.5">
+          <div className="flex items-baseline justify-between gap-3">
+            <p
+              className={cn("font-sans text-sm font-medium", isPending && "text-muted-foreground")}
+            >
+              {STAGE_LABELS[stageKey]}
+            </p>
+            {elapsed ? (
+              <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+                {elapsed}
+              </span>
+            ) : null}
+          </div>
+          <p className="mt-0.5 font-sans text-xs text-muted-foreground">
+            {STAGE_DESCRIPTIONS[stageKey]}
+          </p>
+          {progress && progress.total > 0 ? (
+            <div className="mt-2 flex items-center gap-2">
+              <div className="h-1 flex-1 overflow-hidden rounded-full bg-muted">
+                <div
+                  className={cn(
+                    "h-full rounded-full transition-[width]",
+                    isCompleted ? "bg-emerald-500" : "bg-primary"
+                  )}
+                  style={{
+                    width: `${Math.min(100, (progress.current / progress.total) * 100)}%`,
+                  }}
+                />
+              </div>
+              <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+                {progress.current}/{progress.total}
+              </span>
+            </div>
+          ) : null}
+          {extraDetail ? (
+            <p className="mt-1 font-mono text-[11px] tabular-nums text-muted-foreground">
+              {extraDetail}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function formatClock(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function StatusDialogSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="h-8 w-3/4 animate-pulse rounded-md bg-muted" />
+      <div className="h-4 w-1/2 animate-pulse rounded-md bg-muted" />
+      <ul className="space-y-4 pt-2">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <li key={i} className="flex items-start gap-4">
+            <div className="mt-0.5 size-5 animate-pulse rounded-full bg-muted" />
+            <div className="flex-1 space-y-2">
+              <div className="h-3 w-1/3 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-2/3 animate-pulse rounded bg-muted/70" />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function PipelineStatusDialog({
+  open,
+  onOpenChange,
+  status,
+  isLoading,
+  onCancelPipeline,
+  isCancelling,
+}: PipelineStatusDialogProps) {
+  // Loading shim — the status query fires once on mount even for a cached
+  // terminal pipeline, so briefly the dialog may open before data arrives.
+  if (!status) {
+    if (!open) return null;
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+              Loading run
+            </p>
+            <DialogTitle className="font-playfair text-2xl tracking-tight">
+              Fetching pipeline record…
+            </DialogTitle>
+            <DialogDescription className="font-sans text-sm">
+              {isLoading
+                ? "Reading stages and timing from the analysis service."
+                : "No data available yet."}
+            </DialogDescription>
+          </DialogHeader>
+          <StatusDialogSkeleton />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)} className="font-sans">
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  const stages = status.stages;
+  const active = activeStageIndex(stages);
+  const elapsed = overallElapsedLabel(status.createdAt, status.completedAt);
+  const isRunning = RUNNING_STATUSES.has(status.status);
+  const isTerminal = TERMINAL_STATUSES.has(status.status);
+  const isCompleted = status.status === "COMPLETED";
+  const isFailed = status.status === "FAILED";
+  const isCancelled = status.status === "CANCELLED";
+
+  const eyebrow = isRunning ? "Live telemetry" : "Run record";
+
+  const gateExtra =
+    stages.sentimentGate.included != null || stages.sentimentGate.excluded != null
+      ? `${stages.sentimentGate.included ?? 0} included · ${stages.sentimentGate.excluded ?? 0} excluded`
+      : undefined;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader className="space-y-2">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                {eyebrow}
+              </p>
+              <DialogTitle className="font-playfair text-2xl tracking-tight">
+                {STATUS_HEADLINE[status.status]}
+              </DialogTitle>
+              <DialogDescription className="flex flex-wrap items-center gap-x-2 gap-y-1 font-sans text-sm">
+                <span>
+                  Started{" "}
+                  <span className="font-mono tabular-nums">{formatClock(status.createdAt)}</span>
+                </span>
+                <span className="text-muted-foreground/50">·</span>
+                <span className="font-mono tabular-nums text-muted-foreground">
+                  {elapsed} {isTerminal ? "total" : "elapsed"}
+                </span>
+              </DialogDescription>
+            </div>
+            <PipelineStatusBadge status={status.status} />
+          </div>
+        </DialogHeader>
+
+        {/* Terminal state summary rail — lives ABOVE the timeline, so the
+            reader sees the final result first, then scans the record. */}
+        {isTerminal ? (
+          <div
+            className={cn(
+              "flex items-start gap-3 rounded-xl border p-4 text-sm",
+              isCompleted && "border-emerald-500/35 bg-emerald-50/60 dark:bg-emerald-950/20",
+              isFailed && "border-destructive/40 bg-destructive/5",
+              isCancelled && "border-border/70 bg-muted/30"
+            )}
+          >
+            {isCompleted ? (
+              <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+            ) : isFailed ? (
+              <XCircle className="mt-0.5 size-5 shrink-0 text-destructive" />
+            ) : (
+              <Ban className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+            )}
+            <div className="flex-1">
+              <p
+                className={cn(
+                  "font-sans font-medium",
+                  isCompleted && "text-emerald-900 dark:text-emerald-200",
+                  isFailed && "text-destructive",
+                  isCancelled && "text-foreground"
+                )}
+              >
+                {isCompleted
+                  ? `Finished in ${elapsed}`
+                  : isFailed
+                    ? "Run ended in failure"
+                    : "Run was cancelled"}
+              </p>
+              <p className="mt-0.5 font-mono text-[11px] tabular-nums text-muted-foreground">
+                {status.completedAt
+                  ? `Closed ${formatClock(status.completedAt)} · ${new Date(status.completedAt).toLocaleDateString()}`
+                  : `Last update ${formatClock(status.updatedAt)}`}
+              </p>
+            </div>
+          </div>
+        ) : null}
+
+        <ol className="relative">
+          {STAGE_ORDER.map((key, i) => (
+            <StageNode
+              key={key}
+              stageKey={key}
+              stage={stages[key]}
+              isActive={i === active && isRunning}
+              showConnector={i < STAGE_ORDER.length - 1}
+              extraDetail={key === "sentimentGate" ? gateExtra : undefined}
+            />
+          ))}
+        </ol>
+
+        {status.warnings.length > 0 ? (
+          <div className="rounded-xl border border-amber-500/40 bg-amber-50/70 p-3 text-sm dark:bg-amber-950/20">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              <div className="space-y-1">
+                <p className="font-sans font-semibold text-amber-900 dark:text-amber-200">
+                  Warnings
+                </p>
+                <ul className="ml-4 list-disc space-y-0.5 font-sans text-xs text-amber-900/90 dark:text-amber-100/90">
+                  {status.warnings.map((w, i) => (
+                    <li key={i}>{w}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        {status.errorMessage ? (
+          <div className="rounded-xl border border-destructive/50 bg-destructive/10 p-3 text-sm">
+            <div className="flex items-start gap-2">
+              <XCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
+              <div>
+                <p className="font-sans font-semibold text-destructive">Error</p>
+                <p className="mt-0.5 font-sans text-xs text-destructive/90">
+                  {status.errorMessage}
+                </p>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          {isRunning ? (
+            <Button
+              variant="outline"
+              onClick={onCancelPipeline}
+              disabled={isCancelling}
+              className="font-sans"
+            >
+              {isCancelling ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  Cancelling…
+                </>
+              ) : (
+                "Cancel pipeline"
+              )}
+            </Button>
+          ) : null}
+          <Button
+            variant={isRunning || isTerminal ? "default" : "outline"}
+            onClick={() => onOpenChange(false)}
+            className="font-sans"
+          >
+            {isTerminal ? "Close record" : "Close"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/faculty-analytics/components/pipeline-trigger-card.tsx
+++ b/features/faculty-analytics/components/pipeline-trigger-card.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  ActivityIcon,
+  CheckCircle2,
+  Loader2,
+  PlayIcon,
+  RefreshCcw,
+  ScrollTextIcon,
+  XCircle,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { APP_ROLES, type AppRole } from "@/constants/roles";
+import { useActiveRole } from "@/features/auth/hooks/use-active-role";
+import { PipelineConfirmDialog } from "@/features/faculty-analytics/components/pipeline-confirm-dialog";
+import { PipelineStatusDialog } from "@/features/faculty-analytics/components/pipeline-status-dialog";
+import { PipelineStatusBadge } from "@/features/faculty-analytics/components/pipeline-status-badge";
+import { useCancelPipeline } from "@/features/faculty-analytics/hooks/use-cancel-pipeline";
+import { useConfirmPipeline } from "@/features/faculty-analytics/hooks/use-confirm-pipeline";
+import { useCreatePipeline } from "@/features/faculty-analytics/hooks/use-create-pipeline";
+import { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
+import {
+  RUNNING_STATUSES,
+  STATUS_HEADLINE,
+  TERMINAL_STATUSES,
+  activeStageIndex,
+  overallElapsedLabel,
+  STAGE_LABELS,
+  STAGE_ORDER,
+} from "@/features/faculty-analytics/lib/pipeline-formatting";
+import type {
+  PipelineScopeIds,
+  PipelineStatus,
+  PipelineSummary,
+} from "@/features/faculty-analytics/types";
+import { cn } from "@/lib/utils";
+
+type PipelineTriggerCardProps = {
+  scope: PipelineScopeIds;
+  pipeline: PipelineSummary | null;
+  onStatusChange?: (status: PipelineStatus) => void;
+};
+
+const TRIGGER_ROLES: ReadonlySet<AppRole> = new Set<AppRole>([
+  APP_ROLES.DEAN,
+  APP_ROLES.CHAIRPERSON,
+  APP_ROLES.CAMPUS_HEAD,
+  APP_ROLES.SUPER_ADMIN,
+]);
+
+function extractErrorMessage(err: unknown): string {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "response" in err &&
+    typeof (err as { response?: unknown }).response === "object" &&
+    (err as { response?: { data?: unknown } }).response !== null
+  ) {
+    const data = (err as { response: { data?: { message?: unknown } } }).response.data;
+    if (typeof data?.message === "string") return data.message;
+  }
+  if (err instanceof Error) return err.message;
+  return "Something went wrong. Please try again.";
+}
+
+export function PipelineTriggerCard({ scope, pipeline, onStatusChange }: PipelineTriggerCardProps) {
+  const queryClient = useQueryClient();
+  const { activeRole } = useActiveRole();
+  const canTrigger = activeRole ? TRIGGER_ROLES.has(activeRole) : false;
+
+  const statusQuery = usePipelineStatus(pipeline?.id ?? null, {
+    enabled: Boolean(pipeline?.id),
+  });
+  const liveStatus: PipelineStatus | undefined = statusQuery.data?.status ?? pipeline?.status;
+
+  useEffect(() => {
+    if (liveStatus) onStatusChange?.(liveStatus);
+  }, [liveStatus, onStatusChange]);
+
+  // Reactivity fix: when polling detects a terminal transition, refresh the
+  // list-pipelines-for-scope cache so `latestPipeline.status` in the parent
+  // screen becomes COMPLETED/FAILED/CANCELLED — which in turn unlocks the
+  // recommendations query gate so themes + recs render without refresh.
+  useEffect(() => {
+    if (liveStatus && TERMINAL_STATUSES.has(liveStatus)) {
+      queryClient.invalidateQueries({
+        queryKey: ["analysis", "list-pipelines-for-scope"],
+      });
+    }
+  }, [liveStatus, queryClient]);
+
+  const createMutation = useCreatePipeline();
+  const confirmMutation = useConfirmPipeline();
+  const cancelMutation = useCancelPipeline();
+
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isStatusOpen, setIsStatusOpen] = useState(false);
+
+  const confirmPipelinePayload: PipelineSummary | null = useMemo(() => {
+    // If polling has fresher coverage/warnings than the list summary, prefer
+    // those. We shape the status-response fields into the summary contract
+    // for the confirm dialog which expects PipelineSummary.
+    if (statusQuery.data && pipeline) {
+      return {
+        ...pipeline,
+        status: statusQuery.data.status,
+        coverage: statusQuery.data.coverage,
+        warnings: statusQuery.data.warnings,
+        updatedAt: statusQuery.data.updatedAt,
+      };
+    }
+    return pipeline;
+  }, [statusQuery.data, pipeline]);
+
+  const handleRun = () => {
+    // If there's an existing AWAITING pipeline, don't recreate — just open
+    // the dialog against it. Backend is idempotent via the unique index.
+    if (pipeline && pipeline.status === "AWAITING_CONFIRMATION") {
+      setIsConfirmOpen(true);
+      return;
+    }
+    createMutation.mutate(scope, {
+      onSuccess: () => setIsConfirmOpen(true),
+    });
+  };
+
+  const handleConfirm = () => {
+    if (!pipeline?.id) return;
+    confirmMutation.mutate(pipeline.id, {
+      onSuccess: () => {
+        setIsConfirmOpen(false);
+      },
+    });
+  };
+
+  const handleCancelFromConfirm = () => {
+    if (!pipeline?.id) return;
+    cancelMutation.mutate(pipeline.id, {
+      onSuccess: () => setIsConfirmOpen(false),
+    });
+  };
+
+  const handleCancelFromStatus = () => {
+    if (!pipeline?.id) return;
+    cancelMutation.mutate(pipeline.id, {
+      onSuccess: () => setIsStatusOpen(false),
+    });
+  };
+
+  // ─── Faculty view ───────────────────────────────────────────────────────
+  if (!canTrigger) {
+    if (!pipeline || !liveStatus) return null;
+    return (
+      <section className="flex items-center gap-3 rounded-2xl border border-border/70 bg-card px-5 py-4 shadow-sm">
+        <ActivityIcon className="size-4 text-muted-foreground" />
+        <div className="flex-1">
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+            Analysis
+          </p>
+          <p className="font-sans text-sm">
+            Last updated{" "}
+            <span className="font-mono tabular-nums">
+              {new Date(pipeline.updatedAt).toLocaleString()}
+            </span>
+          </p>
+        </div>
+        <PipelineStatusBadge status={liveStatus} />
+      </section>
+    );
+  }
+
+  // ─── Scoped-role view ───────────────────────────────────────────────────
+  const isRunning = Boolean(liveStatus && RUNNING_STATUSES.has(liveStatus));
+  const isTerminal = Boolean(liveStatus && TERMINAL_STATUSES.has(liveStatus));
+  const isAwaiting = liveStatus === "AWAITING_CONFIRMATION";
+  const hasNoPipeline = pipeline === null;
+
+  const mutationError = createMutation.error ?? confirmMutation.error ?? cancelMutation.error;
+
+  const stagesView = statusQuery.data ? activeStageIndex(statusQuery.data.stages) : null;
+
+  const activeStageLabel =
+    isRunning && stagesView !== null && stagesView < STAGE_ORDER.length
+      ? STAGE_LABELS[STAGE_ORDER[stagesView]]
+      : null;
+
+  return (
+    <>
+      <section
+        className={cn(
+          "relative overflow-hidden rounded-2xl border bg-card shadow-sm transition-colors",
+          isRunning
+            ? "border-primary/30"
+            : isTerminal && liveStatus === "COMPLETED"
+              ? "border-emerald-500/30"
+              : isTerminal && liveStatus === "FAILED"
+                ? "border-destructive/40"
+                : "border-border/70"
+        )}
+      >
+        {isRunning ? (
+          <span
+            aria-hidden
+            className="absolute inset-x-0 top-0 h-[2px] animate-[pulse_2s_ease-in-out_infinite] bg-gradient-to-r from-transparent via-primary to-transparent"
+          />
+        ) : null}
+
+        <div className="flex items-start justify-between gap-6 px-6 pt-5">
+          <div className="space-y-1">
+            <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+              Faculty feedback analysis
+            </p>
+            <h2 className="font-playfair text-xl tracking-tight">
+              {liveStatus ? STATUS_HEADLINE[liveStatus] : "Pipeline ready"}
+            </h2>
+            <p className="font-sans text-sm text-muted-foreground">
+              {hasNoPipeline
+                ? "Trigger the pipeline to generate themes and recommendations from qualitative feedback."
+                : isAwaiting
+                  ? "Snapshot captured. Review coverage and confirm to run."
+                  : isRunning && activeStageLabel
+                    ? `Step ${stagesView! + 1} of ${STAGE_ORDER.length} · ${activeStageLabel}`
+                    : liveStatus === "COMPLETED"
+                      ? "Analysis complete. Themes and recommendations are surfaced below."
+                      : liveStatus === "FAILED"
+                        ? "The pipeline failed. Review the error and re-run when ready."
+                        : liveStatus === "CANCELLED"
+                          ? "The last run was cancelled. Re-run when ready."
+                          : "Ready."}
+            </p>
+          </div>
+          {liveStatus ? <PipelineStatusBadge status={liveStatus} /> : null}
+        </div>
+
+        {/* Live progress track for running pipelines */}
+        {isRunning && statusQuery.data ? (
+          <div className="mx-6 mt-5 rounded-xl border border-border/60 bg-muted/30 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+                In progress
+              </p>
+              <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+                {overallElapsedLabel(statusQuery.data.createdAt, statusQuery.data.completedAt)}{" "}
+                elapsed
+              </span>
+            </div>
+            <div className="mt-3 flex items-center gap-1">
+              {STAGE_ORDER.map((key) => {
+                const s = statusQuery.data!.stages[key];
+                const done = s.status === "completed";
+                const active = s.status === "processing";
+                const failed = s.status === "failed";
+                return (
+                  <div
+                    key={key}
+                    className={cn(
+                      "h-1.5 flex-1 rounded-full transition-colors",
+                      done
+                        ? "bg-emerald-500"
+                        : active
+                          ? "bg-primary"
+                          : failed
+                            ? "bg-destructive"
+                            : "bg-muted"
+                    )}
+                    title={STAGE_LABELS[key]}
+                  />
+                );
+              })}
+            </div>
+            <p className="mt-2 font-sans text-xs text-muted-foreground">
+              {activeStageLabel ?? "Waiting"}
+            </p>
+          </div>
+        ) : null}
+
+        {/* Terminal completion summary */}
+        {liveStatus === "COMPLETED" && statusQuery.data ? (
+          <div className="mx-6 mt-5 flex items-center gap-3 rounded-xl border border-emerald-500/30 bg-emerald-50/60 p-4 text-sm dark:bg-emerald-950/20">
+            <CheckCircle2 className="size-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+            <div className="flex-1">
+              <p className="font-sans font-medium text-emerald-900 dark:text-emerald-200">
+                Analysis completed in{" "}
+                <span className="font-mono tabular-nums">
+                  {overallElapsedLabel(statusQuery.data.createdAt, statusQuery.data.completedAt)}
+                </span>
+              </p>
+              <p className="mt-0.5 font-sans text-xs text-emerald-800/80 dark:text-emerald-100/70">
+                Themes and recommendations are ready below.
+              </p>
+            </div>
+          </div>
+        ) : null}
+
+        {liveStatus === "FAILED" && statusQuery.data?.errorMessage ? (
+          <div className="mx-6 mt-5 flex items-start gap-3 rounded-xl border border-destructive/40 bg-destructive/5 p-4 text-sm">
+            <XCircle className="mt-0.5 size-5 shrink-0 text-destructive" />
+            <div className="flex-1">
+              <p className="font-sans font-medium text-destructive">Pipeline failed</p>
+              <p className="mt-0.5 font-sans text-xs text-destructive/90">
+                {statusQuery.data.errorMessage}
+              </p>
+            </div>
+          </div>
+        ) : null}
+
+        {mutationError ? (
+          <div className="mx-6 mt-5 rounded-xl border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+            {extractErrorMessage(mutationError)}
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap items-center justify-between gap-3 px-6 pb-5 pt-5">
+          <p className="font-mono text-[11px] tabular-nums text-muted-foreground">
+            {pipeline
+              ? `Last updated ${new Date(pipeline.updatedAt).toLocaleString()}`
+              : "No previous run"}
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            {/* Status dialog entry — available whenever a pipeline exists
+                (running OR terminal). Muted ghost style so it doesn't
+                compete with the primary Run / Re-run action. */}
+            {pipeline && !isAwaiting ? (
+              <Button
+                variant="ghost"
+                onClick={() => setIsStatusOpen(true)}
+                className="font-sans text-muted-foreground hover:text-foreground"
+              >
+                {isRunning ? (
+                  <>
+                    <ActivityIcon className="mr-2 size-4" />
+                    View live status
+                  </>
+                ) : (
+                  <>
+                    <ScrollTextIcon className="mr-2 size-4" />
+                    View run details
+                  </>
+                )}
+              </Button>
+            ) : null}
+            {isAwaiting ? (
+              <Button onClick={handleRun} className="font-sans">
+                Review &amp; start
+              </Button>
+            ) : null}
+            {(hasNoPipeline || isTerminal) && !isAwaiting ? (
+              <Button
+                onClick={handleRun}
+                disabled={createMutation.isPending || !scope.semesterId}
+                className="font-sans"
+              >
+                {createMutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                    Preparing snapshot…
+                  </>
+                ) : isTerminal ? (
+                  <>
+                    <RefreshCcw className="mr-2 size-4" />
+                    Re-run analysis
+                  </>
+                ) : (
+                  <>
+                    <PlayIcon className="mr-2 size-4" />
+                    Run analysis
+                  </>
+                )}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <PipelineConfirmDialog
+        open={isConfirmOpen}
+        onOpenChange={setIsConfirmOpen}
+        pipeline={confirmPipelinePayload}
+        onConfirm={handleConfirm}
+        onCancel={handleCancelFromConfirm}
+        isConfirming={confirmMutation.isPending}
+        isCancelling={cancelMutation.isPending}
+      />
+
+      <PipelineStatusDialog
+        open={isStatusOpen}
+        onOpenChange={setIsStatusOpen}
+        status={statusQuery.data}
+        isLoading={statusQuery.isLoading || statusQuery.isFetching}
+        onCancelPipeline={handleCancelFromStatus}
+        isCancelling={cancelMutation.isPending}
+      />
+    </>
+  );
+}

--- a/features/faculty-analytics/components/recommendations-card.tsx
+++ b/features/faculty-analytics/components/recommendations-card.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useMemo } from "react";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type {
+  ActionPriority,
+  RecommendationsResponse,
+  RecommendedActionDto,
+  TopicSource,
+} from "@/features/faculty-analytics/types";
+
+type RecommendationsCardProps = {
+  recommendations: RecommendationsResponse;
+};
+
+const PRIORITY_VARIANT: Record<
+  ActionPriority,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  HIGH: "destructive",
+  MEDIUM: "secondary",
+  LOW: "outline",
+};
+
+function ActionItem({ action }: { action: RecommendedActionDto }) {
+  const topicSources = action.supportingEvidence?.sources.filter(
+    (s): s is TopicSource => s.type === "topic"
+  );
+  const evidenceKey = `evidence-${action.id}`;
+
+  return (
+    <div className="rounded-xl border border-border/70 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="font-playfair text-base font-semibold text-foreground">{action.headline}</h3>
+        <Badge variant={PRIORITY_VARIANT[action.priority]}>{action.priority}</Badge>
+      </div>
+      <p className="mt-2 font-sans text-sm text-muted-foreground">{action.description}</p>
+      <p className="mt-3 font-sans text-sm text-foreground">
+        <span className="font-medium">Plan: </span>
+        {action.actionPlan}
+      </p>
+
+      {topicSources && topicSources.length > 0 ? (
+        <Accordion type="single" collapsible className="mt-3">
+          <AccordionItem value={evidenceKey}>
+            <AccordionTrigger className="text-sm">Evidence</AccordionTrigger>
+            <AccordionContent>
+              <ul className="space-y-3 font-sans text-sm">
+                {topicSources.map((source) => (
+                  <li key={source.topicLabel} className="space-y-1">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="font-medium">{source.topicLabel}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {source.commentCount} mention
+                        {source.commentCount === 1 ? "" : "s"}
+                      </span>
+                    </div>
+                    {source.sampleQuotes.length > 0 ? (
+                      <ul className="ml-4 list-disc space-y-1 text-muted-foreground">
+                        {source.sampleQuotes.map((quote, idx) => (
+                          <li key={`${source.topicLabel}-${idx}`}>{quote}</li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      ) : null}
+    </div>
+  );
+}
+
+export function RecommendationsCard({ recommendations }: RecommendationsCardProps) {
+  const { strengths, improvements } = useMemo(() => {
+    const strengths: RecommendedActionDto[] = [];
+    const improvements: RecommendedActionDto[] = [];
+    for (const action of recommendations.actions) {
+      if (action.category === "STRENGTH") strengths.push(action);
+      else improvements.push(action);
+    }
+    return { strengths, improvements };
+  }, [recommendations.actions]);
+
+  if (recommendations.actions.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl">Recommendations</CardTitle>
+        <CardDescription>
+          Generated insights from faculty feedback, grouped by category.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue="improvements">
+          <TabsList>
+            <TabsTrigger value="improvements">Improvements · {improvements.length}</TabsTrigger>
+            <TabsTrigger value="strengths">Strengths · {strengths.length}</TabsTrigger>
+          </TabsList>
+          <TabsContent value="improvements" className="mt-4 space-y-3">
+            {improvements.map((action) => (
+              <ActionItem key={action.id} action={action} />
+            ))}
+            {improvements.length === 0 ? (
+              <p className="font-sans text-sm text-muted-foreground">
+                No improvement actions identified.
+              </p>
+            ) : null}
+          </TabsContent>
+          <TabsContent value="strengths" className="mt-4 space-y-3">
+            {strengths.map((action) => (
+              <ActionItem key={action.id} action={action} />
+            ))}
+            {strengths.length === 0 ? (
+              <p className="font-sans text-sm text-muted-foreground">
+                No strength actions identified.
+              </p>
+            ) : null}
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
+++ b/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
@@ -1,10 +1,19 @@
 "use client";
 
+import { useMemo } from "react";
+
 import { ScopedDashboardHeader } from "@/features/faculty-analytics/components/scoped-dashboard-header";
 import { ScopedAttentionCard } from "@/features/faculty-analytics/components/scoped-attention-card";
 import { ScopedOverallSentimentBarChart } from "@/features/faculty-analytics/components/scoped-charts";
 import { ScopedAnalyticsAsyncContent } from "@/features/faculty-analytics/components/scoped-analytics-async-content";
 import { ScopedMetricsGrid } from "@/features/faculty-analytics/components/scoped-metrics-grid";
+import { PipelineTriggerCard } from "@/features/faculty-analytics/components/pipeline-trigger-card";
+import { RecommendationsCard } from "@/features/faculty-analytics/components/recommendations-card";
+import { ThemesRankedList } from "@/features/faculty-analytics/components/themes-ranked-list";
+import { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
+import { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
+import { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
+import { aggregateThemes } from "@/features/faculty-analytics/lib/pipeline-themes";
 import { useScopedAnalyticsDashboardViewModel } from "@/features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model";
 
 export type ScopeLabel = "Campus" | "Department";
@@ -29,6 +38,29 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
     isError,
     retry,
   } = useScopedAnalyticsDashboardViewModel();
+
+  // No departmentId needed — the backend fills the DEAN/CAMPUS_HEAD's
+  // resolved scope per FAC-132 TD-2 List rules.
+  const pipelineQuery = useMemo(
+    () => ({ semesterId: selectedSemesterId ?? "" }),
+    [selectedSemesterId]
+  );
+  const { latestPipeline } = useLatestPipelineForScope(pipelineQuery, {
+    enabled: Boolean(selectedSemesterId),
+  });
+  // Poll status at the screen level so themes/recs gating reacts to the
+  // live terminal transition — without this, `latestPipeline.status` comes
+  // from the stale list cache and the completed-state UI doesn't appear
+  // until the next list refetch or page reload.
+  const pipelineStatusQuery = usePipelineStatus(latestPipeline?.id ?? null, {
+    enabled: Boolean(latestPipeline?.id),
+  });
+  const liveStatus = pipelineStatusQuery.data?.status ?? latestPipeline?.status;
+  const recommendationsQuery = usePipelineRecommendations(latestPipeline?.id ?? null, liveStatus);
+  const themes = useMemo(
+    () => (recommendationsQuery.data ? aggregateThemes(recommendationsQuery.data.actions) : []),
+    [recommendationsQuery.data]
+  );
 
   const scopeLower = scopeLabel.toLowerCase();
   const facultiesHref = scopeLabel === "Campus" ? "/campus-head/faculties" : "/dean/faculties";
@@ -59,6 +91,13 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
           lastUpdatedLabel={lastUpdatedLabel}
         />
 
+        {selectedSemesterId ? (
+          <PipelineTriggerCard
+            scope={{ semesterId: selectedSemesterId }}
+            pipeline={latestPipeline}
+          />
+        ) : null}
+
         {semesters.length === 0 ? (
           <div className="flex min-h-44 flex-col items-center justify-center rounded-lg border border-dashed px-6 text-center">
             <p className="max-w-xl font-sans text-sm text-muted-foreground">
@@ -79,6 +118,15 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
                 facultiesHref={facultiesHref}
               />
             </div>
+
+            {liveStatus === "COMPLETED" && themes.length > 0 ? (
+              <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                <ThemesRankedList themes={themes} />
+                {recommendationsQuery.data ? (
+                  <RecommendationsCard recommendations={recommendationsQuery.data} />
+                ) : null}
+              </div>
+            ) : null}
           </>
         )}
       </section>

--- a/features/faculty-analytics/components/scoped-metrics-grid.tsx
+++ b/features/faculty-analytics/components/scoped-metrics-grid.tsx
@@ -1,30 +1,29 @@
 import type { ScopedDashboardViewModel } from "@/features/faculty-analytics/lib/scoped-analytics-view-model";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { AnimatedNumber } from "@/components/animated-number";
 
-function formatMetric(value: number, suffix?: string) {
-  const formattedValue = Number.isInteger(value)
-    ? new Intl.NumberFormat("en-US").format(value)
-    : value.toFixed(1);
-
-  return suffix ? `${formattedValue}${suffix}` : formattedValue;
-}
+type ScopedMetricCardProps = {
+  title: string;
+  value: number;
+  decimals?: number;
+  suffix?: string;
+  description: string;
+};
 
 function ScopedMetricCard({
   title,
   value,
+  decimals = 0,
+  suffix,
   description,
-}: {
-  title: string;
-  value: string;
-  description: string;
-}) {
+}: ScopedMetricCardProps) {
   return (
     <Card className="gap-4 rounded-2xl border-border/70 shadow-sm">
       <CardHeader className="pb-0">
         <div className="space-y-2">
           <CardDescription className="font-sans text-sm">{title}</CardDescription>
           <CardTitle className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl">
-            {value}
+            <AnimatedNumber value={value} decimals={decimals} suffix={suffix} />
           </CardTitle>
         </div>
       </CardHeader>
@@ -40,22 +39,24 @@ export function ScopedMetricsGrid({ summary }: { summary: ScopedDashboardViewMod
     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
       <ScopedMetricCard
         title="Total Faculty"
-        value={formatMetric(summary.totalFaculty)}
+        value={summary.totalFaculty}
         description="Faculty included in the selected semester overview"
       />
       <ScopedMetricCard
         title="Total Submissions"
-        value={formatMetric(summary.totalSubmissions)}
+        value={summary.totalSubmissions}
         description="Submitted evaluation responses in the selected semester"
       />
       <ScopedMetricCard
         title="Total Analyzed"
-        value={formatMetric(summary.totalAnalyzed)}
+        value={summary.totalAnalyzed}
         description="Faculty records with generated analytics available"
       />
       <ScopedMetricCard
         title="Positive Sentiment Rate"
-        value={formatMetric(summary.positiveSentimentRate, "%")}
+        value={summary.positiveSentimentRate}
+        decimals={1}
+        suffix="%"
         description="Share of analyzed sentiment marked positive in the selected semester"
       />
     </div>

--- a/features/faculty-analytics/components/themes-chip-list.tsx
+++ b/features/faculty-analytics/components/themes-chip-list.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import type { RankedTheme } from "@/features/faculty-analytics/lib/pipeline-themes";
+
+type ThemesChipListProps = {
+  themes: RankedTheme[];
+  maxVisible?: number;
+  className?: string;
+};
+
+export function ThemesChipList({ themes, maxVisible = 8, className }: ThemesChipListProps) {
+  if (themes.length === 0) return null;
+
+  const visible = themes.slice(0, maxVisible);
+  const overflow = themes.length - visible.length;
+
+  return (
+    <div className={className}>
+      <div className="flex flex-wrap gap-2">
+        {visible.map((theme) => (
+          <Badge
+            key={theme.topicLabel}
+            variant="secondary"
+            className="gap-1.5 py-1"
+            title={theme.sampleQuotes.join("\n")}
+          >
+            <span className="font-medium">{theme.topicLabel}</span>
+            <span className="text-muted-foreground text-[0.7rem]">{theme.commentCount}</span>
+          </Badge>
+        ))}
+        {overflow > 0 ? (
+          <Badge variant="outline" className="text-muted-foreground">
+            +{overflow} more
+          </Badge>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/features/faculty-analytics/components/themes-ranked-list.tsx
+++ b/features/faculty-analytics/components/themes-ranked-list.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { RankedTheme } from "@/features/faculty-analytics/lib/pipeline-themes";
+
+type ThemesRankedListProps = {
+  themes: RankedTheme[];
+  maxVisible?: number;
+};
+
+function clamp01(n: number) {
+  if (!Number.isFinite(n)) return 0;
+  return Math.min(1, Math.max(0, n));
+}
+
+export function ThemesRankedList({ themes, maxVisible = 10 }: ThemesRankedListProps) {
+  if (themes.length === 0) return null;
+
+  const visible = themes.slice(0, maxVisible);
+
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl">Top Themes</CardTitle>
+        <CardDescription>Ranked by comment volume with sentiment breakdown.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3">
+          {visible.map((theme) => {
+            const pos = clamp01(theme.sentimentBreakdown.positive) * 100;
+            const neu = clamp01(theme.sentimentBreakdown.neutral) * 100;
+            const neg = clamp01(theme.sentimentBreakdown.negative) * 100;
+            return (
+              <li key={theme.topicLabel} className="space-y-1.5">
+                <div className="flex items-center justify-between gap-4">
+                  <span className="font-sans text-sm font-medium text-foreground">
+                    {theme.topicLabel}
+                  </span>
+                  <span className="font-sans text-xs text-muted-foreground">
+                    {theme.commentCount} mention{theme.commentCount === 1 ? "" : "s"}
+                  </span>
+                </div>
+                <div className="flex h-2 overflow-hidden rounded-full bg-muted">
+                  <span
+                    className="h-full bg-emerald-500"
+                    style={{ width: `${pos}%` }}
+                    aria-label={`positive ${pos.toFixed(0)}%`}
+                  />
+                  <span
+                    className="h-full bg-muted-foreground/40"
+                    style={{ width: `${neu}%` }}
+                    aria-label={`neutral ${neu.toFixed(0)}%`}
+                  />
+                  <span
+                    className="h-full bg-rose-500"
+                    style={{ width: `${neg}%` }}
+                    aria-label={`negative ${neg.toFixed(0)}%`}
+                  />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/faculty-analytics/hooks/use-cancel-pipeline.ts
+++ b/features/faculty-analytics/hooks/use-cancel-pipeline.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { cancelPipeline } from "@/features/faculty-analytics/api/analysis-pipeline.requests";
+
+export function useCancelPipeline() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: cancelPipeline,
+    onSuccess: (_pipeline, pipelineId) => {
+      queryClient.invalidateQueries({
+        queryKey: ["analysis", "pipeline-status", pipelineId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["analysis", "list-pipelines-for-scope"],
+      });
+    },
+  });
+}

--- a/features/faculty-analytics/hooks/use-confirm-pipeline.ts
+++ b/features/faculty-analytics/hooks/use-confirm-pipeline.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { confirmPipeline } from "@/features/faculty-analytics/api/analysis-pipeline.requests";
+
+export function useConfirmPipeline() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: confirmPipeline,
+    onSuccess: (_pipeline, pipelineId) => {
+      queryClient.invalidateQueries({
+        queryKey: ["analysis", "pipeline-status", pipelineId],
+      });
+      // Also refresh scoped list caches so any subscriber rendering the
+      // summary's `status` field (not just the live status hook) sees the
+      // new running state.
+      queryClient.invalidateQueries({
+        queryKey: ["analysis", "list-pipelines-for-scope"],
+      });
+    },
+  });
+}

--- a/features/faculty-analytics/hooks/use-create-pipeline.ts
+++ b/features/faculty-analytics/hooks/use-create-pipeline.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { createPipeline } from "@/features/faculty-analytics/api/analysis-pipeline.requests";
+import type { CreatePipelineRequest, PipelineSummary } from "@/features/faculty-analytics/types";
+
+export function useCreatePipeline() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createPipeline,
+    onSuccess: (createdPipeline: PipelineSummary, variables: CreatePipelineRequest) => {
+      // Seed the same cache key as useLatestPipelineForScope so the trigger
+      // card transitions Run → Awaiting Confirmation in a single render,
+      // without waiting for a list refetch. Key + value shape MUST match
+      // that hook's query exactly (`list-pipelines-for-scope`,
+      // single-element array) or the seed is invisible to subscribers.
+      queryClient.setQueryData(
+        ["analysis", "list-pipelines-for-scope", variables],
+        [createdPipeline]
+      );
+      // Background-refresh any other scoped listings that might exist.
+      queryClient.invalidateQueries({
+        queryKey: ["analysis", "list-pipelines-for-scope"],
+      });
+    },
+  });
+}

--- a/features/faculty-analytics/hooks/use-latest-pipeline-for-scope.ts
+++ b/features/faculty-analytics/hooks/use-latest-pipeline-for-scope.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { listPipelines } from "@/features/faculty-analytics/api/analysis-pipeline.requests";
+import type { ListPipelinesQuery } from "@/features/faculty-analytics/types";
+import { useAuthStore } from "@/stores/auth-store";
+
+type UseLatestPipelineForScopeOptions = {
+  enabled?: boolean;
+};
+
+// Caches the full array (not first-or-null) so that `useCreatePipeline`'s
+// onSuccess can seed the same cache key with a single-element array,
+// matching the shape `listPipelines` returns. Consumers derive
+// `latestPipeline = data?.[0] ?? null`.
+export function useLatestPipelineForScope(
+  query: ListPipelinesQuery,
+  options?: UseLatestPipelineForScopeOptions
+) {
+  const token = useAuthStore((state) => state.token);
+  const isEnabled = options?.enabled ?? true;
+
+  const result = useQuery({
+    // Intentionally no token in queryKey — token is an Axios interceptor
+    // header, not cache identity (diverges from use-faculty-report.ts which
+    // includes the token). This ensures invalidation works consistently.
+    queryKey: ["analysis", "list-pipelines-for-scope", query],
+    enabled: Boolean(token) && Boolean(query.semesterId) && isEnabled,
+    queryFn: () => listPipelines(query),
+  });
+
+  return {
+    ...result,
+    latestPipeline: result.data?.[0] ?? null,
+  };
+}

--- a/features/faculty-analytics/hooks/use-pipeline-recommendations.ts
+++ b/features/faculty-analytics/hooks/use-pipeline-recommendations.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchPipelineRecommendations } from "@/features/faculty-analytics/api/analysis-pipeline.requests";
+import type { PipelineStatus } from "@/features/faculty-analytics/types";
+import { useAuthStore } from "@/stores/auth-store";
+
+// Gate on PIPELINE status `'COMPLETED'` — NOT recommendations.status
+// (that's RunStatus, a different enum). The recommendations run finishes
+// before the pipeline transitions to COMPLETED, so pipeline.status is the
+// correct readiness signal.
+export function usePipelineRecommendations(
+  pipelineId: string | null,
+  pipelineStatus: PipelineStatus | undefined
+) {
+  const token = useAuthStore((state) => state.token);
+
+  return useQuery({
+    queryKey: ["analysis", "pipeline-recommendations", pipelineId],
+    enabled: Boolean(token) && Boolean(pipelineId) && pipelineStatus === "COMPLETED",
+    queryFn: () => fetchPipelineRecommendations(pipelineId!),
+  });
+}

--- a/features/faculty-analytics/hooks/use-pipeline-status.ts
+++ b/features/faculty-analytics/hooks/use-pipeline-status.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchPipelineStatus } from "@/features/faculty-analytics/api/analysis-pipeline.requests";
+import type { PipelineStatus } from "@/features/faculty-analytics/types";
+import { useAuthStore } from "@/stores/auth-store";
+
+const TERMINAL_STATUSES: ReadonlySet<PipelineStatus> = new Set<PipelineStatus>([
+  "COMPLETED",
+  "FAILED",
+  "CANCELLED",
+]);
+
+type UsePipelineStatusOptions = {
+  enabled?: boolean;
+};
+
+export function usePipelineStatus(pipelineId: string | null, options?: UsePipelineStatusOptions) {
+  const token = useAuthStore((state) => state.token);
+  const isEnabled = options?.enabled ?? true;
+
+  return useQuery({
+    // No token in queryKey — see use-latest-pipeline-for-scope comment.
+    queryKey: ["analysis", "pipeline-status", pipelineId],
+    enabled: Boolean(token) && Boolean(pipelineId) && isEnabled,
+    queryFn: () => fetchPipelineStatus(pipelineId!),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && TERMINAL_STATUSES.has(status) ? false : 3000;
+    },
+  });
+}

--- a/features/faculty-analytics/index.ts
+++ b/features/faculty-analytics/index.ts
@@ -2,3 +2,44 @@ export { ScopedAnalyticsDashboardScreen } from "@/features/faculty-analytics/com
 export type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-analytics-dashboard-screen";
 export { ScopedFacultyListScreen } from "@/features/faculty-analytics/components/scoped-faculty-list-screen";
 export { FacultyReportScreen } from "@/features/faculty-analytics/components/faculty-report-screen";
+
+// FAC-132: analysis pipeline surfaces
+export { PipelineStatusBadge } from "@/features/faculty-analytics/components/pipeline-status-badge";
+export { PipelineTriggerCard } from "@/features/faculty-analytics/components/pipeline-trigger-card";
+export { PipelineConfirmDialog } from "@/features/faculty-analytics/components/pipeline-confirm-dialog";
+export { PipelineStatusDialog } from "@/features/faculty-analytics/components/pipeline-status-dialog";
+export { RecommendationsCard } from "@/features/faculty-analytics/components/recommendations-card";
+export { ThemesChipList } from "@/features/faculty-analytics/components/themes-chip-list";
+export { ThemesRankedList } from "@/features/faculty-analytics/components/themes-ranked-list";
+
+export { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
+export { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
+export { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
+export { useCreatePipeline } from "@/features/faculty-analytics/hooks/use-create-pipeline";
+export { useConfirmPipeline } from "@/features/faculty-analytics/hooks/use-confirm-pipeline";
+export { useCancelPipeline } from "@/features/faculty-analytics/hooks/use-cancel-pipeline";
+
+export {
+  aggregateThemes,
+  type RankedTheme,
+} from "@/features/faculty-analytics/lib/pipeline-themes";
+
+export type {
+  PipelineStatus,
+  PipelineScopeIds,
+  PipelineScopeDisplay,
+  PipelineCoverage,
+  PipelineStageStatus,
+  PipelineStatusResponse,
+  PipelineSummary,
+  CreatePipelineRequest,
+  ListPipelinesQuery,
+  RecommendationsResponse,
+  RecommendedActionDto,
+  SupportingEvidence,
+  TopicSource,
+  DimensionScoresSource,
+  ActionCategory,
+  ActionPriority,
+  RunStatus,
+} from "@/features/faculty-analytics/types";

--- a/features/faculty-analytics/lib/pipeline-formatting.ts
+++ b/features/faculty-analytics/lib/pipeline-formatting.ts
@@ -1,0 +1,95 @@
+import type { PipelineStageStatus, PipelineStatus } from "@/features/faculty-analytics/types";
+
+export type StageKey =
+  | "embeddings"
+  | "sentiment"
+  | "sentimentGate"
+  | "topicModeling"
+  | "recommendations";
+
+export const STAGE_ORDER: readonly StageKey[] = [
+  "embeddings",
+  "sentiment",
+  "sentimentGate",
+  "topicModeling",
+  "recommendations",
+] as const;
+
+export const STAGE_LABELS: Record<StageKey, string> = {
+  embeddings: "Embedding check",
+  sentiment: "Sentiment analysis",
+  sentimentGate: "Sentiment gate",
+  topicModeling: "Topic modeling",
+  recommendations: "Recommendations",
+};
+
+export const STAGE_DESCRIPTIONS: Record<StageKey, string> = {
+  embeddings: "Backfilling vector embeddings for each comment",
+  sentiment: "Classifying each comment as positive, neutral, or negative",
+  sentimentGate: "Filtering comments that qualify for topic modeling",
+  topicModeling: "Clustering qualifying comments into themes",
+  recommendations: "Generating LLM-powered action plans",
+};
+
+export const STATUS_HEADLINE: Record<PipelineStatus, string> = {
+  AWAITING_CONFIRMATION: "Awaiting confirmation",
+  EMBEDDING_CHECK: "Checking embeddings",
+  SENTIMENT_ANALYSIS: "Analyzing sentiment",
+  SENTIMENT_GATE: "Filtering comments",
+  TOPIC_MODELING: "Extracting themes",
+  GENERATING_RECOMMENDATIONS: "Generating recommendations",
+  COMPLETED: "Analysis complete",
+  FAILED: "Analysis failed",
+  CANCELLED: "Analysis cancelled",
+};
+
+export const TERMINAL_STATUSES: ReadonlySet<PipelineStatus> = new Set<PipelineStatus>([
+  "COMPLETED",
+  "FAILED",
+  "CANCELLED",
+]);
+
+export const RUNNING_STATUSES: ReadonlySet<PipelineStatus> = new Set<PipelineStatus>([
+  "EMBEDDING_CHECK",
+  "SENTIMENT_ANALYSIS",
+  "SENTIMENT_GATE",
+  "TOPIC_MODELING",
+  "GENERATING_RECOMMENDATIONS",
+]);
+
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remSeconds = seconds % 60;
+  if (minutes < 60) {
+    return remSeconds === 0
+      ? `${minutes}m`
+      : `${minutes}m ${remSeconds.toString().padStart(2, "0")}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return `${hours}h ${remMinutes.toString().padStart(2, "0")}m`;
+}
+
+export function stageElapsedLabel(stage: PipelineStageStatus): string | null {
+  if (!stage.startedAt) return null;
+  const start = new Date(stage.startedAt).getTime();
+  const end = stage.completedAt ? new Date(stage.completedAt).getTime() : Date.now();
+  return formatDuration(end - start);
+}
+
+export function overallElapsedLabel(createdAt: string, completedAt: string | null): string {
+  const start = new Date(createdAt).getTime();
+  const end = completedAt ? new Date(completedAt).getTime() : Date.now();
+  return formatDuration(end - start);
+}
+
+export function activeStageIndex(stages: Record<StageKey, PipelineStageStatus>): number {
+  const processing = STAGE_ORDER.findIndex((key) => stages[key].status === "processing");
+  if (processing !== -1) return processing;
+  const pending = STAGE_ORDER.findIndex((key) => stages[key].status === "pending");
+  if (pending !== -1) return pending;
+  return STAGE_ORDER.length;
+}

--- a/features/faculty-analytics/lib/pipeline-themes.ts
+++ b/features/faculty-analytics/lib/pipeline-themes.ts
@@ -1,0 +1,98 @@
+import type { RecommendedActionDto, TopicSource } from "@/features/faculty-analytics/types";
+
+export type RankedTheme = {
+  topicLabel: string;
+  commentCount: number;
+  sentimentBreakdown: {
+    positive: number;
+    neutral: number;
+    negative: number;
+  };
+  sampleQuotes: string[];
+  referencedBy: number;
+};
+
+// Max sampleQuotes per theme — matches the backend's Zod cap at
+// recommendations.dto.ts:15 (`z.array(z.string()).max(3)`). Do NOT raise
+// this without updating the backend schema in lockstep.
+const MAX_SAMPLE_QUOTES = 3;
+
+// TODO(post-vitest-adoption): cover in unit test. Pure function, no I/O —
+// the single most worth-testing helper on the frontend once RTL lands.
+export function aggregateThemes(actions: RecommendedActionDto[]): RankedTheme[] {
+  // first-occurrence-wins dedup preserves the LLM emission order — the
+  // recommendation engine orders topics by salience, not alphabetically.
+  const byLabel = new Map<
+    string,
+    {
+      insertionOrder: number;
+      topicLabel: string;
+      totalComments: number;
+      weightedPositive: number;
+      weightedNeutral: number;
+      weightedNegative: number;
+      quotes: string[];
+      actionIds: Set<string>;
+    }
+  >();
+
+  let insertionCounter = 0;
+
+  for (const action of actions) {
+    const sources = action.supportingEvidence?.sources ?? [];
+    for (const source of sources) {
+      if (source.type !== "topic") continue;
+      const topic = source as TopicSource;
+      const existing = byLabel.get(topic.topicLabel);
+      if (existing) {
+        existing.totalComments += topic.commentCount;
+        existing.weightedPositive += topic.sentimentBreakdown.positive * topic.commentCount;
+        existing.weightedNeutral += topic.sentimentBreakdown.neutral * topic.commentCount;
+        existing.weightedNegative += topic.sentimentBreakdown.negative * topic.commentCount;
+        for (const quote of topic.sampleQuotes) {
+          if (existing.quotes.length < MAX_SAMPLE_QUOTES && !existing.quotes.includes(quote)) {
+            existing.quotes.push(quote);
+          }
+        }
+        existing.actionIds.add(action.id);
+      } else {
+        byLabel.set(topic.topicLabel, {
+          insertionOrder: insertionCounter++,
+          topicLabel: topic.topicLabel,
+          totalComments: topic.commentCount,
+          weightedPositive: topic.sentimentBreakdown.positive * topic.commentCount,
+          weightedNeutral: topic.sentimentBreakdown.neutral * topic.commentCount,
+          weightedNegative: topic.sentimentBreakdown.negative * topic.commentCount,
+          quotes: topic.sampleQuotes.slice(0, MAX_SAMPLE_QUOTES),
+          actionIds: new Set([action.id]),
+        });
+      }
+    }
+  }
+
+  const themes: RankedTheme[] = Array.from(byLabel.values()).map((t) => {
+    const total = t.totalComments || 1;
+    return {
+      topicLabel: t.topicLabel,
+      commentCount: t.totalComments,
+      sentimentBreakdown: {
+        positive: t.weightedPositive / total,
+        neutral: t.weightedNeutral / total,
+        negative: t.weightedNegative / total,
+      },
+      sampleQuotes: t.quotes,
+      referencedBy: t.actionIds.size,
+    };
+  });
+
+  // Sort by descending commentCount; tiebreak by original insertion order
+  // (preserves LLM emission order for equal-weight topics).
+  themes.sort((a, b) => {
+    if (b.commentCount !== a.commentCount) return b.commentCount - a.commentCount;
+    const aInsert = byLabel.get(a.topicLabel)!.insertionOrder;
+    const bInsert = byLabel.get(b.topicLabel)!.insertionOrder;
+    return aInsert - bInsert;
+  });
+
+  return themes;
+}

--- a/features/faculty-analytics/types/index.ts
+++ b/features/faculty-analytics/types/index.ts
@@ -294,3 +294,174 @@ export type FacultyReportCourseOption = {
   id: string;
   label: string;
 };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Analysis Pipeline (FAC-132)
+//
+// Mirrors backend shapes from api.faculytics:
+//   - src/modules/analysis/enums/pipeline-status.enum.ts   (PipelineStatus)
+//   - src/modules/analysis/enums/run-status.enum.ts        (RunStatus)
+//   - src/modules/analysis/dto/pipeline-status.dto.ts      (PipelineStatusResponse)
+//   - src/modules/analysis/dto/responses/pipeline-summary.response.dto.ts
+//   - src/modules/analysis/dto/responses/recommendations.response.dto.ts
+//   - src/modules/analysis/dto/recommendations.dto.ts      (SupportingEvidence)
+// Enum string values are UPPERCASE, matching the backend verbatim.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type PipelineStatus =
+  | "AWAITING_CONFIRMATION"
+  | "EMBEDDING_CHECK"
+  | "SENTIMENT_ANALYSIS"
+  | "SENTIMENT_GATE"
+  | "TOPIC_MODELING"
+  | "GENERATING_RECOMMENDATIONS"
+  | "COMPLETED"
+  | "FAILED"
+  | "CANCELLED";
+
+export type RunStatus = "PENDING" | "PROCESSING" | "COMPLETED" | "FAILED";
+
+// IDs only — used for CreatePipelineRequest and ListPipelinesQuery inputs.
+// Every scope field is optional at the type level; the BACKEND enforces (per
+// TD-2) that non-SUPER_ADMIN callers supply at least one scope filter beyond
+// `semesterId`, else 400 Bad Request. Type-level branching by role is
+// deliberately avoided here — a clear comment + runtime contract is simpler.
+export type PipelineScopeIds = {
+  semesterId: string;
+  facultyId?: string;
+  departmentId?: string;
+  programId?: string;
+  campusId?: string;
+  courseId?: string;
+  questionnaireVersionId?: string;
+};
+
+// IDs + display values paired — shape of pipeline.status response's `scope`
+// (TD-9). IDs are used by the frontend for cache keys and lookups; display
+// values for UI rendering.
+export type PipelineScopeDisplay = {
+  semesterId: string;
+  semesterCode: string;
+  departmentId: string | null;
+  departmentCode: string | null;
+  facultyId: string | null;
+  facultyName: string | null;
+  programId: string | null;
+  programCode: string | null;
+  campusId: string | null;
+  campusCode: string | null;
+  courseId: string | null;
+  courseShortname: string | null;
+  questionnaireVersionId: string | null;
+};
+
+export type PipelineCoverage = {
+  totalEnrolled: number;
+  submissionCount: number;
+  commentCount: number;
+  responseRate: number;
+  lastEnrollmentSyncAt: string | null;
+};
+
+export type PipelineStageStatus = {
+  status: "pending" | "processing" | "completed" | "failed" | "skipped";
+  progress: { current: number; total: number } | null;
+  startedAt: string | null;
+  completedAt: string | null;
+};
+
+export type PipelineSentimentGateStatus = PipelineStageStatus & {
+  included: number | null;
+  excluded: number | null;
+};
+
+export type PipelineStatusResponse = {
+  id: string;
+  status: PipelineStatus;
+  scope: PipelineScopeDisplay;
+  coverage: PipelineCoverage;
+  stages: {
+    embeddings: PipelineStageStatus;
+    sentiment: PipelineStageStatus;
+    sentimentGate: PipelineSentimentGateStatus;
+    topicModeling: PipelineStageStatus;
+    recommendations: PipelineStageStatus;
+  };
+  warnings: string[];
+  errorMessage: string | null;
+  retryable: boolean;
+  createdAt: string;
+  updatedAt: string;
+  confirmedAt: string | null;
+  completedAt: string | null;
+};
+
+export type PipelineSummary = {
+  id: string;
+  status: PipelineStatus;
+  scope: PipelineScopeDisplay;
+  coverage: PipelineCoverage;
+  warnings: string[];
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+};
+
+export type CreatePipelineRequest = PipelineScopeIds;
+export type ListPipelinesQuery = PipelineScopeIds;
+
+// ─── Recommendations ──────────────────────────────────────────────────────
+
+export type TopicSource = {
+  type: "topic";
+  topicLabel: string;
+  commentCount: number;
+  sentimentBreakdown: {
+    positive: number;
+    neutral: number;
+    negative: number;
+  };
+  // Backend caps at 3 items (recommendations.dto.ts:15: `.max(3)`). The
+  // aggregateThemes helper must respect this ceiling when deduplicating.
+  sampleQuotes: string[];
+};
+
+export type DimensionScoresSource = {
+  type: "dimension";
+  dimensionLabel: string;
+  averageScore: number;
+  responseCount: number;
+};
+
+export type SupportingEvidenceSource = TopicSource | DimensionScoresSource;
+
+export type SupportingEvidence = {
+  sources: SupportingEvidenceSource[];
+  confidenceLevel: "HIGH" | "MEDIUM" | "LOW";
+  basedOnSubmissions: number;
+};
+
+export type ActionCategory = "STRENGTH" | "IMPROVEMENT";
+export type ActionPriority = "HIGH" | "MEDIUM" | "LOW";
+
+export type RecommendedActionDto = {
+  id: string;
+  category: ActionCategory;
+  headline: string;
+  description: string;
+  actionPlan: string;
+  priority: ActionPriority;
+  supportingEvidence: SupportingEvidence;
+  createdAt: string;
+};
+
+export type RecommendationsResponse = {
+  pipelineId: string;
+  runId: string | null;
+  // This is RunStatus, not PipelineStatus — the recommendations run
+  // completes BEFORE the pipeline transitions to COMPLETED, so gates keying
+  // off `pipeline.status === 'COMPLETED'` are the correct readiness signal.
+  status: RunStatus;
+  actions: RecommendedActionDto[];
+  completedAt: string | null;
+};

--- a/lib/use-count-up.ts
+++ b/lib/use-count-up.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Smoothly animates a numeric value from its current display toward `target`
+ * using requestAnimationFrame. Honors `prefers-reduced-motion` by snapping
+ * to the target instead of animating.
+ *
+ * Animating from the *current display* (not the previous target) handles
+ * rapid successive changes gracefully — if the target flips mid-animation
+ * the number continues from wherever it is, instead of snapping back to 0.
+ */
+export type EasingFn = (t: number) => number;
+
+export const easings = {
+  // Punchy arrival — quick start, soft landing. Best for counters.
+  outExpo: (t: number) => (t === 1 ? 1 : 1 - Math.pow(2, -10 * t)),
+  outCubic: (t: number) => 1 - Math.pow(1 - t, 3),
+  outQuart: (t: number) => 1 - Math.pow(1 - t, 4),
+  linear: (t: number) => t,
+} as const;
+
+export type UseCountUpOptions = {
+  /** ms, default 1000 */
+  duration?: number;
+  /** starting value on first mount; default 0 */
+  from?: number;
+  /** default easings.outExpo */
+  easing?: EasingFn;
+  /** default true — snaps to target instead of animating */
+  respectReducedMotion?: boolean;
+};
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function useCountUp(target: number, options: UseCountUpOptions = {}): number {
+  const {
+    duration = 1000,
+    from = 0,
+    easing = easings.outExpo,
+    respectReducedMotion = true,
+  } = options;
+
+  const [display, setDisplay] = useState<number>(() => {
+    if (respectReducedMotion && prefersReducedMotion()) return target;
+    return Number.isFinite(from) ? from : 0;
+  });
+
+  useEffect(() => {
+    if (!Number.isFinite(target)) return;
+    if (respectReducedMotion && prefersReducedMotion()) {
+      // Prop-driven snap-to-target when motion is disabled.
+      setDisplay(target);
+      return;
+    }
+
+    const start = performance.now();
+    // `display` in the closure is captured at effect-run time — React
+    // commits pending setDisplay updates before running effects, so this
+    // is the latest animated value. Mid-flight target changes resume
+    // smoothly from wherever the animation happened to be. `display` is
+    // intentionally NOT in the dep array: including it would re-run the
+    // effect on every RAF tick and loop forever.
+    const startValue = display;
+    const delta = target - startValue;
+
+    // No-op: already there. Avoids a wasted RAF cycle.
+    if (Math.abs(delta) < 1e-9) {
+      return;
+    }
+
+    let rafId = 0;
+    const tick = (now: number) => {
+      const progress = Math.min(1, (now - start) / duration);
+      const eased = easing(progress);
+      const next = startValue + delta * eased;
+      setDisplay(next);
+      if (progress < 1) {
+        rafId = requestAnimationFrame(tick);
+      }
+    };
+
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [target, duration, easing, respectReducedMotion]);
+
+  return display;
+}

--- a/network/endpoints.ts
+++ b/network/endpoints.ts
@@ -56,4 +56,13 @@ export enum Endpoints {
   // Faculty
   faculty = "/api/v1/faculty",
   facultyEnrollments = "/api/v1/faculty/:facultyId/enrollments",
+
+  // Analysis Pipeline (FAC-132). `analysisPipelines` covers both the list
+  // (GET) and create (POST) calls since they share the same URL; HTTP verb
+  // distinguishes them at the call site.
+  analysisPipelines = "/api/v1/analysis/pipelines",
+  analysisPipelinesConfirm = "/api/v1/analysis/pipelines/:id/confirm",
+  analysisPipelinesCancel = "/api/v1/analysis/pipelines/:id/cancel",
+  analysisPipelinesStatus = "/api/v1/analysis/pipelines/:id/status",
+  analysisPipelinesRecommendations = "/api/v1/analysis/pipelines/:id/recommendations",
 }


### PR DESCRIPTION
Closes #76

## Summary

Frontend half of the FAC-132 integration slice. The analysis pipeline produced topics, sentiment outcomes, and LLM recommendations on the API but had **zero callers** in `app.faculytics` — this PR ships the trigger UI, status surfacing, and the themes + recommendations cards that finally close the loop for Faculty / Dean / Campus Head.

- **Trigger flow** — `PipelineTriggerCard` (role-gated) opens `PipelineConfirmDialog` immediately on **Run analysis**; the dialog shows the coverage snapshot + warnings and exits via Confirm or Cancel in one step.
- **Live + archival status dialog** — `PipelineStatusDialog` is a vertical timeline of all five stages with per-stage timing, progress bars, and gate counts. Two modes: **Live telemetry** (polls every 3s, ping ring on active stage, cancel button) while running, and **Run record** (top summary rail with total time + close timestamp, Close-as-primary, no cancel) for terminal pipelines. A discreet ghost button on the card opens it whenever a pipeline exists, even after completion.
- **Output surfaces** — `ThemesChipList` (faculty report) + `ThemesRankedList` (scoped dashboard) driven by the `aggregateThemes` pure helper that dedupes topics across recommendation actions, sums `commentCount`, weight-averages sentiment, and caps `sampleQuotes` at 3 (matches backend Zod schema). `RecommendationsCard` splits actions into Strengths / Improvements tabs with expandable Evidence accordion.
- **Reactivity fix** — Themes + recommendations now render the moment polling sees `COMPLETED` (no browser refresh / navigation needed). Parent screens consume the live status from `usePipelineStatus`; the trigger card invalidates the list cache on terminal transition so subsequent mounts also see fresh state.
- **Reusable count-up primitive** — `lib/use-count-up.ts` + `components/animated-number.tsx` with `easeOutExpo` default, `prefers-reduced-motion` snap, `Intl.NumberFormat` formatting, and `tabular-nums` styling. Wired into `ScopedMetricsGrid` (Total Faculty / Submissions / Analyzed / Positive Rate) and `FacultyReportSummaryCards` (Submissions / Overall Rating / Comments).
- **Backend-mirrored types** — `PipelineStatus` / `RunStatus` UPPERCASE unions, `PipelineScopeIds` vs `PipelineScopeDisplay` (TD-9 paired shape), `PipelineSummary`, `PipelineStatusResponse`, `RecommendationsResponse`, `SupportingEvidence`. 6 TanStack Query hooks with token-free query keys.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] Rebased onto latest `origin/develop` (resolved additive conflicts in `network/endpoints.ts` and `features/faculty-analytics/types/index.ts`)
- [ ] **Manual E2E (per AC):**
  - [ ] DEAN: dashboard trigger card → confirm dialog → start pipeline → live status dialog → completion → themes + recs render without refresh
  - [ ] DEAN: re-open completed pipeline via **View run details** → run-record mode displays correctly
  - [ ] FACULTY: report page shows status badge + themes chip-list + recommendations card; no trigger buttons
  - [ ] CAMPUS_HEAD: same flow as DEAN on `/campus-head/dashboard`
  - [ ] Multi-dept DEAN: explicit 400 if backend can't auto-fill (picker UI is future work)
  - [ ] Counter cards animate on mount; respect `prefers-reduced-motion`

## Related

- Backend ticket / API PR: https://github.com/CtrlAltElite-Devs/api.faculytics/pull/336