### PR TITLE
FAC-WEB feat: qualitative analytics view for faculty analysis page

### DIFF
--- a/features/faculty-analytics/api/faculty-analytics.requests.ts
+++ b/features/faculty-analytics/api/faculty-analytics.requests.ts
@@ -20,6 +20,8 @@ import type {
   ListProgramsQuery,
   ListSemestersQuery,
   ProgramListResponseDto,
+  QualitativeSummaryQuery,
+  QualitativeSummaryResponseDto,
   ReportStatusResponseDto,
   SemesterListResponseDto,
 } from "@/features/faculty-analytics/types";
@@ -91,6 +93,15 @@ export async function fetchFacultyReportComments({
 }: FacultyReportCommentsQuery) {
   const response = await apiClient.get<FacultyReportCommentsResponseDto>(
     Endpoints.analyticsFacultyReportComments.replace(":facultyId", facultyId),
+    { params }
+  );
+
+  return response.data;
+}
+
+export async function fetchQualitativeSummary({ facultyId, ...params }: QualitativeSummaryQuery) {
+  const response = await apiClient.get<QualitativeSummaryResponseDto>(
+    Endpoints.analyticsFacultyQualitativeSummary.replace(":facultyId", facultyId),
     { params }
   );
 

--- a/features/faculty-analytics/components/active-filter-chips.tsx
+++ b/features/faculty-analytics/components/active-filter-chips.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { X } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { SentimentLabel } from "@/features/faculty-analytics/types";
+
+type ActiveFilterChipsProps = {
+  sentiment: SentimentLabel | null;
+  themeLabel: string | null;
+  onClearSentiment: () => void;
+  onClearTheme: () => void;
+  onClearAll: () => void;
+};
+
+const SENTIMENT_DISPLAY: Record<SentimentLabel, string> = {
+  positive: "Positive",
+  neutral: "Neutral",
+  negative: "Negative",
+};
+
+export function ActiveFilterChips({
+  sentiment,
+  themeLabel,
+  onClearSentiment,
+  onClearTheme,
+  onClearAll,
+}: ActiveFilterChipsProps) {
+  if (!sentiment && !themeLabel) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="font-sans text-xs uppercase tracking-wide text-muted-foreground">
+        Filters
+      </span>
+      {themeLabel ? (
+        <Badge variant="secondary" className="gap-1 rounded-full pl-3 pr-1 py-1">
+          <span className="font-medium">Theme: {themeLabel}</span>
+          <button
+            type="button"
+            onClick={onClearTheme}
+            className="ml-1 rounded-full p-0.5 hover:bg-background/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={`Clear theme filter ${themeLabel}`}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </Badge>
+      ) : null}
+      {sentiment ? (
+        <Badge variant="secondary" className="gap-1 rounded-full pl-3 pr-1 py-1">
+          <span className="font-medium">Sentiment: {SENTIMENT_DISPLAY[sentiment]}</span>
+          <button
+            type="button"
+            onClick={onClearSentiment}
+            className="ml-1 rounded-full p-0.5 hover:bg-background/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={`Clear sentiment filter ${SENTIMENT_DISPLAY[sentiment]}`}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </Badge>
+      ) : null}
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        className="h-7 px-2 font-sans text-xs text-muted-foreground hover:text-foreground"
+        onClick={onClearAll}
+      >
+        Clear all
+      </Button>
+    </div>
+  );
+}

--- a/features/faculty-analytics/components/faculty-analysis-hero.tsx
+++ b/features/faculty-analytics/components/faculty-analysis-hero.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { X } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { PipelineStatusBadge } from "@/features/faculty-analytics/components/pipeline-status-badge";
+import {
+  formatFacultyReportScore,
+  getFacultyReportInterpretationTextClass,
+} from "@/features/faculty-analytics/lib/faculty-report-detail";
+import { cn } from "@/lib/utils";
+import type {
+  PipelineStatus,
+  SentimentDistributionDto,
+  SentimentLabel,
+} from "@/features/faculty-analytics/types";
+
+type FacultyAnalysisHeroProps = {
+  facultyName: string;
+  semesterLabel: string;
+  questionnaireTypeLabel: string;
+  overallRating: number | null;
+  overallInterpretation: string | null;
+  submissionCount: number;
+  commentsCount: number;
+  sentimentDistribution: SentimentDistributionDto | null;
+  pipelineStatus?: PipelineStatus;
+  sentimentFilter: SentimentLabel | null;
+  themeLabelFilter: string | null;
+  onSentimentClick: (sentiment: SentimentLabel | null) => void;
+  onClearSentiment: () => void;
+  onClearTheme: () => void;
+  onClearAll: () => void;
+};
+
+const SENTIMENT_SWATCH: Record<SentimentLabel, string> = {
+  positive: "bg-emerald-600",
+  neutral: "bg-muted-foreground/50",
+  negative: "bg-rose-600",
+};
+
+const SENTIMENT_LABEL: Record<SentimentLabel, string> = {
+  positive: "Positive",
+  neutral: "Neutral",
+  negative: "Negative",
+};
+
+const SEGMENT_ORDER: SentimentLabel[] = ["positive", "neutral", "negative"];
+
+export function FacultyAnalysisHero({
+  facultyName,
+  semesterLabel,
+  questionnaireTypeLabel,
+  overallRating,
+  overallInterpretation,
+  submissionCount,
+  commentsCount,
+  sentimentDistribution,
+  pipelineStatus,
+  sentimentFilter,
+  themeLabelFilter,
+  onSentimentClick,
+  onClearSentiment,
+  onClearTheme,
+  onClearAll,
+}: FacultyAnalysisHeroProps) {
+  const interpretation = overallInterpretation ?? "Not available";
+  const totalSentiment = sentimentDistribution
+    ? sentimentDistribution.positive +
+      sentimentDistribution.neutral +
+      sentimentDistribution.negative
+    : 0;
+  const hasSentimentData = totalSentiment > 0;
+  const hasActiveFilter = Boolean(sentimentFilter || themeLabelFilter);
+
+  return (
+    <header className="rounded-2xl border border-border/70 bg-card px-6 py-8 shadow-sm sm:px-10 sm:py-10">
+      <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
+        {/* LEFT: identity + verdict */}
+        <div className="min-w-0 flex-1">
+          <p className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+            Faculty evaluation · {semesterLabel}
+          </p>
+          <h1 className="mt-3 text-3xl font-medium tracking-tight text-foreground sm:text-4xl">
+            {facultyName}
+          </h1>
+          <p className="mt-1.5 text-sm text-muted-foreground">{questionnaireTypeLabel}</p>
+
+          {/* Verdict row — big rating + interpretation */}
+          <div className="mt-8 flex flex-wrap items-end gap-x-10 gap-y-4">
+            <div>
+              <p className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                Overall rating
+              </p>
+              <p className="mt-2 font-playfair text-5xl font-semibold leading-none tracking-tight text-foreground tabular-nums sm:text-6xl">
+                {formatFacultyReportScore(overallRating)}
+              </p>
+            </div>
+            <div className="max-w-xs">
+              <p className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                Interpretation
+              </p>
+              <p
+                className={cn(
+                  "mt-2 text-base leading-snug",
+                  getFacultyReportInterpretationTextClass(interpretation)
+                )}
+              >
+                {interpretation}
+              </p>
+            </div>
+          </div>
+
+          {/* Coverage line */}
+          <div className="mt-8 flex flex-wrap items-baseline gap-x-5 gap-y-2 text-sm text-muted-foreground">
+            <span>
+              <span className="font-medium tabular-nums text-foreground">{submissionCount}</span>{" "}
+              submissions
+            </span>
+            <span aria-hidden className="text-border">
+              ·
+            </span>
+            <span>
+              <span className="font-medium tabular-nums text-foreground">{commentsCount}</span>{" "}
+              qualitative comments
+            </span>
+            {pipelineStatus ? (
+              <>
+                <span aria-hidden className="text-border">
+                  ·
+                </span>
+                <PipelineStatusBadge status={pipelineStatus} />
+              </>
+            ) : null}
+          </div>
+        </div>
+
+        {/* RIGHT: sentiment distribution */}
+        {hasSentimentData ? (
+          <div className="w-full max-w-sm lg:w-80">
+            <p className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+              Sentiment distribution
+            </p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Click a segment to filter comments below.
+            </p>
+
+            <div
+              className="mt-4 flex h-2 w-full overflow-hidden rounded-full bg-muted"
+              role="group"
+              aria-label="Sentiment distribution"
+            >
+              {SEGMENT_ORDER.map((sentiment) => {
+                const count = sentimentDistribution![sentiment];
+                if (count === 0) return null;
+                const widthPct = (count / totalSentiment) * 100;
+                const isActive = sentimentFilter === sentiment;
+                return (
+                  <button
+                    key={sentiment}
+                    type="button"
+                    onClick={() => onSentimentClick(isActive ? null : sentiment)}
+                    className={cn(
+                      "h-full transition-all hover:brightness-110",
+                      SENTIMENT_SWATCH[sentiment],
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                      isActive ? "brightness-110 ring-2 ring-ring ring-offset-1" : "",
+                      sentimentFilter && !isActive ? "opacity-40" : ""
+                    )}
+                    style={{ width: `${widthPct}%` }}
+                    aria-label={`Filter comments to ${SENTIMENT_LABEL[sentiment].toLowerCase()} sentiment, ${count} submissions`}
+                    aria-pressed={isActive}
+                  />
+                );
+              })}
+            </div>
+
+            <dl className="mt-4 grid grid-cols-3 gap-3 text-xs">
+              {SEGMENT_ORDER.map((sentiment) => {
+                const count = sentimentDistribution![sentiment];
+                const pct = Math.round((count / totalSentiment) * 100);
+                return (
+                  <div key={sentiment} className="space-y-1">
+                    <div className="flex items-center gap-1.5 text-muted-foreground">
+                      <span
+                        className={cn(
+                          "inline-block h-2 w-2 rounded-full",
+                          SENTIMENT_SWATCH[sentiment]
+                        )}
+                      />
+                      <span>{SENTIMENT_LABEL[sentiment]}</span>
+                    </div>
+                    <div className="text-xl font-semibold leading-none tabular-nums text-foreground">
+                      {count}
+                    </div>
+                    <div className="tabular-nums text-muted-foreground">{pct}%</div>
+                  </div>
+                );
+              })}
+            </dl>
+          </div>
+        ) : null}
+      </div>
+
+      {/* Filter chips tethered to the hero */}
+      {hasActiveFilter ? (
+        <div className="mt-8 flex flex-wrap items-center gap-2 border-t border-border/70 pt-5">
+          <span className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+            Filtering
+          </span>
+          {themeLabelFilter ? (
+            <Badge
+              variant="outline"
+              className="gap-1 rounded-full border-border bg-background px-3 py-1 text-xs"
+            >
+              <span>Theme · {themeLabelFilter}</span>
+              <button
+                type="button"
+                onClick={onClearTheme}
+                className="ml-1 rounded-full p-0.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label={`Clear theme filter ${themeLabelFilter}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ) : null}
+          {sentimentFilter ? (
+            <Badge
+              variant="outline"
+              className="gap-1 rounded-full border-border bg-background px-3 py-1 text-xs"
+            >
+              <span
+                className={cn(
+                  "inline-block h-1.5 w-1.5 rounded-full",
+                  SENTIMENT_SWATCH[sentimentFilter]
+                )}
+              />
+              <span>Sentiment · {SENTIMENT_LABEL[sentimentFilter]}</span>
+              <button
+                type="button"
+                onClick={onClearSentiment}
+                className="ml-1 rounded-full p-0.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label={`Clear sentiment filter ${SENTIMENT_LABEL[sentimentFilter]}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ) : null}
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={onClearAll}
+          >
+            Clear all
+          </Button>
+        </div>
+      ) : null}
+    </header>
+  );
+}

--- a/features/faculty-analytics/components/faculty-analysis-sentiment-strip.tsx
+++ b/features/faculty-analytics/components/faculty-analysis-sentiment-strip.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { X } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { SentimentDistributionDto, SentimentLabel } from "@/features/faculty-analytics/types";
+
+type FacultyAnalysisSentimentStripProps = {
+  distribution: SentimentDistributionDto | null;
+  sentimentFilter: SentimentLabel | null;
+  themeLabelFilter: string | null;
+  onSentimentClick: (sentiment: SentimentLabel | null) => void;
+  onClearSentiment: () => void;
+  onClearTheme: () => void;
+  onClearAll: () => void;
+};
+
+const SWATCH: Record<SentimentLabel, string> = {
+  positive: "bg-emerald-600",
+  neutral: "bg-muted-foreground/50",
+  negative: "bg-rose-600",
+};
+
+const LABEL: Record<SentimentLabel, string> = {
+  positive: "Positive",
+  neutral: "Neutral",
+  negative: "Negative",
+};
+
+const ORDER: SentimentLabel[] = ["positive", "neutral", "negative"];
+
+export function FacultyAnalysisSentimentStrip({
+  distribution,
+  sentimentFilter,
+  themeLabelFilter,
+  onSentimentClick,
+  onClearSentiment,
+  onClearTheme,
+  onClearAll,
+}: FacultyAnalysisSentimentStripProps) {
+  if (!distribution) return null;
+  const total = distribution.positive + distribution.neutral + distribution.negative;
+  if (total === 0) return null;
+
+  const hasActiveFilter = Boolean(sentimentFilter || themeLabelFilter);
+
+  return (
+    <section className="rounded-2xl border border-border/70 bg-card px-5 py-4 shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline justify-between gap-4">
+            <p className="text-sm font-medium text-foreground">Sentiment distribution</p>
+            <p className="text-xs text-muted-foreground">Click a segment to filter comments</p>
+          </div>
+
+          <div
+            className="mt-3 flex h-2 w-full overflow-hidden rounded-full bg-muted"
+            role="group"
+            aria-label="Sentiment distribution"
+          >
+            {ORDER.map((s) => {
+              const count = distribution[s];
+              if (count === 0) return null;
+              const widthPct = (count / total) * 100;
+              const isActive = sentimentFilter === s;
+              return (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => onSentimentClick(isActive ? null : s)}
+                  className={cn(
+                    "h-full transition-all hover:brightness-110",
+                    SWATCH[s],
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                    isActive ? "brightness-110 ring-2 ring-ring ring-offset-1" : "",
+                    sentimentFilter && !isActive ? "opacity-40" : ""
+                  )}
+                  style={{ width: `${widthPct}%` }}
+                  aria-label={`Filter comments to ${LABEL[s].toLowerCase()} sentiment, ${count} submissions`}
+                  aria-pressed={isActive}
+                />
+              );
+            })}
+          </div>
+
+          <dl className="mt-3 flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
+            {ORDER.map((s) => {
+              const count = distribution[s];
+              const pct = Math.round((count / total) * 100);
+              return (
+                <div key={s} className="flex items-center gap-1.5">
+                  <span className={cn("inline-block h-2 w-2 rounded-full", SWATCH[s])} />
+                  <span>{LABEL[s]}</span>
+                  <span className="tabular-nums text-foreground">{count}</span>
+                  <span className="tabular-nums text-muted-foreground/70">({pct}%)</span>
+                </div>
+              );
+            })}
+          </dl>
+        </div>
+      </div>
+
+      {hasActiveFilter ? (
+        <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-border/70 pt-3">
+          <span className="text-xs text-muted-foreground">Filtering</span>
+          {themeLabelFilter ? (
+            <Badge
+              variant="outline"
+              className="gap-1 rounded-full border-border bg-background px-3 py-1 text-xs"
+            >
+              <span>Theme · {themeLabelFilter}</span>
+              <button
+                type="button"
+                onClick={onClearTheme}
+                className="ml-1 rounded-full p-0.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label={`Clear theme filter ${themeLabelFilter}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ) : null}
+          {sentimentFilter ? (
+            <Badge
+              variant="outline"
+              className="gap-1 rounded-full border-border bg-background px-3 py-1 text-xs"
+            >
+              <span
+                className={cn("inline-block h-1.5 w-1.5 rounded-full", SWATCH[sentimentFilter])}
+              />
+              <span>Sentiment · {LABEL[sentimentFilter]}</span>
+              <button
+                type="button"
+                onClick={onClearSentiment}
+                className="ml-1 rounded-full p-0.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label={`Clear sentiment filter ${LABEL[sentimentFilter]}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ) : null}
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={onClearAll}
+          >
+            Clear all
+          </Button>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/features/faculty-analytics/components/faculty-analysis-stats.tsx
+++ b/features/faculty-analytics/components/faculty-analysis-stats.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { AnimatedNumber } from "@/components/animated-number";
+import { getFacultyReportInterpretationTextClass } from "@/features/faculty-analytics/lib/faculty-report-detail";
+import { cn } from "@/lib/utils";
+import type { SentimentDistributionDto } from "@/features/faculty-analytics/types";
+
+type FacultyAnalysisStatsProps = {
+  submissionCount: number;
+  overallRating: number | null;
+  overallInterpretation: string | null;
+  commentsCount: number;
+  sentimentDistribution: SentimentDistributionDto | null;
+};
+
+type StatCardProps = {
+  label: string;
+  value: React.ReactNode;
+  description: string;
+  valueClassName?: string;
+};
+
+function StatCard({ label, value, description, valueClassName }: StatCardProps) {
+  return (
+    <div className="rounded-2xl border border-border/70 bg-card px-5 py-5 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p
+        className={cn(
+          "mt-2 font-playfair text-3xl font-semibold tabular-nums text-foreground",
+          valueClassName
+        )}
+      >
+        {value}
+      </p>
+      <p className="mt-4 text-sm leading-relaxed text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+export function FacultyAnalysisStats({
+  submissionCount,
+  overallRating,
+  overallInterpretation,
+  commentsCount,
+  sentimentDistribution,
+}: FacultyAnalysisStatsProps) {
+  const resolvedInterpretation = overallInterpretation ?? "No interpretation available";
+
+  const sentimentTotal = sentimentDistribution
+    ? sentimentDistribution.positive +
+      sentimentDistribution.neutral +
+      sentimentDistribution.negative
+    : 0;
+  const positivePct =
+    sentimentTotal > 0 && sentimentDistribution
+      ? (sentimentDistribution.positive / sentimentTotal) * 100
+      : null;
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <StatCard
+        label="Overall Rating"
+        value={
+          overallRating === null ? "N/A" : <AnimatedNumber value={overallRating} decimals={2} />
+        }
+        description="Weighted average score across all sections in this report"
+      />
+      <div className="rounded-2xl border border-border/70 bg-card px-5 py-5 shadow-sm">
+        <p className="text-sm text-muted-foreground">Interpretation</p>
+        <p
+          className={cn(
+            "mt-2 text-lg font-semibold leading-snug",
+            getFacultyReportInterpretationTextClass(resolvedInterpretation)
+          )}
+        >
+          {resolvedInterpretation}
+        </p>
+        <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+          Performance label derived from the overall weighted rating
+        </p>
+      </div>
+      <StatCard
+        label="Submissions"
+        value={<AnimatedNumber value={submissionCount} />}
+        description="Submitted evaluation responses included in this report"
+      />
+      <StatCard
+        label="Positive Sentiment"
+        value={
+          positivePct === null ? (
+            "—"
+          ) : (
+            <span>
+              <AnimatedNumber value={positivePct} decimals={1} />
+              <span className="ml-0.5 text-2xl font-medium">%</span>
+            </span>
+          )
+        }
+        description={
+          commentsCount > 0
+            ? `Share of positive sentiment across ${commentsCount} analyzed comment${commentsCount === 1 ? "" : "s"}`
+            : "Awaiting analyzed comments"
+        }
+      />
+    </div>
+  );
+}

--- a/features/faculty-analytics/components/faculty-report-comments.tsx
+++ b/features/faculty-analytics/components/faculty-report-comments.tsx
@@ -1,12 +1,18 @@
 "use client";
 
+import { useMemo } from "react";
+
+import { Badge } from "@/components/ui/badge";
 import { PaginationFooter } from "@/components/shared/pagination-footer";
 import { ScopedAnalyticsEmptyState } from "@/features/faculty-analytics/components/scoped-analytics-empty-state";
 import { ScopedAnalyticsErrorState } from "@/features/faculty-analytics/components/scoped-analytics-error-state";
 import { ScopedAnalyticsLoadingState } from "@/features/faculty-analytics/components/scoped-analytics-loading-state";
+import { cn } from "@/lib/utils";
 import type {
   FacultyReportCommentDto,
   PaginationMetaDto,
+  QualitativeThemeDto,
+  SentimentLabel,
 } from "@/features/faculty-analytics/types";
 import { formatDateTime } from "@/lib/date";
 
@@ -20,6 +26,19 @@ type FacultyReportCommentsProps = {
   onRetry: () => void;
   onPageChange: (page: number) => void;
   onRowsPerPageChange: (value: number) => void;
+  themes?: QualitativeThemeDto[];
+};
+
+const SENTIMENT_CLASSES: Record<SentimentLabel, string> = {
+  positive: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
+  neutral: "bg-muted text-muted-foreground",
+  negative: "bg-rose-100 text-rose-800 dark:bg-rose-950/40 dark:text-rose-300",
+};
+
+const SENTIMENT_LABELS: Record<SentimentLabel, string> = {
+  positive: "Positive",
+  neutral: "Neutral",
+  negative: "Negative",
 };
 
 export function FacultyReportComments({
@@ -32,7 +51,15 @@ export function FacultyReportComments({
   onRetry,
   onPageChange,
   onRowsPerPageChange,
+  themes,
 }: FacultyReportCommentsProps) {
+  const themeLookup = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const theme of themes ?? []) {
+      map.set(theme.themeId, theme.label);
+    }
+    return map;
+  }, [themes]);
   return (
     <section className="overflow-hidden rounded-2xl border border-border/70 bg-card shadow-sm">
       <div className="border-b border-border/70 px-5 py-4">
@@ -67,21 +94,61 @@ export function FacultyReportComments({
 
       {!isLoading && !isError && comments.length > 0 ? (
         <div className="space-y-2 px-5 py-3">
-          {comments.map((comment, index) => (
-            <article
-              key={`${comment.submittedAt}-${index}`}
-              className="rounded-2xl border border-border/70 bg-background/60 px-4 py-2.5"
-            >
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
-                <p className="max-w-3xl font-sans text-sm leading-6 text-foreground">
-                  {comment.text}
-                </p>
-                <p className="shrink-0 font-sans text-xs text-muted-foreground sm:text-right">
-                  Submitted {formatDateTime(comment.submittedAt)}
-                </p>
-              </div>
-            </article>
-          ))}
+          {comments.map((comment, index) => {
+            const themeChipLabels = (comment.themeIds ?? [])
+              .map((id) => themeLookup.get(id))
+              .filter((label): label is string => Boolean(label));
+            const visibleThemes = themeChipLabels.slice(0, 2);
+            const overflowCount = themeChipLabels.length - visibleThemes.length;
+
+            return (
+              <article
+                key={`${comment.submittedAt}-${index}`}
+                className="rounded-2xl border border-border/70 bg-background/60 px-4 py-2.5"
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+                  <div className="flex-1 space-y-2">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      {comment.sentiment ? (
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            "rounded-full border-none px-2 py-0.5 font-sans text-[0.7rem] font-medium",
+                            SENTIMENT_CLASSES[comment.sentiment]
+                          )}
+                        >
+                          {SENTIMENT_LABELS[comment.sentiment]}
+                        </Badge>
+                      ) : null}
+                      {visibleThemes.map((label) => (
+                        <Badge
+                          key={label}
+                          variant="secondary"
+                          className="rounded-full px-2 py-0.5 font-sans text-[0.7rem]"
+                        >
+                          {label}
+                        </Badge>
+                      ))}
+                      {overflowCount > 0 ? (
+                        <Badge
+                          variant="outline"
+                          className="rounded-full px-2 py-0.5 font-sans text-[0.7rem] text-muted-foreground"
+                        >
+                          +{overflowCount} more
+                        </Badge>
+                      ) : null}
+                    </div>
+                    <p className="max-w-3xl font-sans text-sm leading-6 text-foreground">
+                      {comment.text}
+                    </p>
+                  </div>
+                  <p className="shrink-0 font-sans text-xs text-muted-foreground sm:text-right">
+                    Submitted {formatDateTime(comment.submittedAt)}
+                  </p>
+                </div>
+              </article>
+            );
+          })}
 
           <PaginationFooter
             itemCount={commentsMeta?.itemCount ?? 0}

--- a/features/faculty-analytics/components/faculty-report-header.tsx
+++ b/features/faculty-analytics/components/faculty-report-header.tsx
@@ -14,8 +14,6 @@ import {
 
 type FacultyReportHeaderProps = {
   backHref: string;
-  facultyName: string;
-  semesterLabel: string;
   questionnaireTypeLabel: string;
   questionnaireTypeCode: string;
   courseId: string;
@@ -37,8 +35,6 @@ type FacultyReportHeaderProps = {
 
 export function FacultyReportHeader({
   backHref,
-  facultyName,
-  semesterLabel,
   questionnaireTypeLabel,
   questionnaireTypeCode,
   courseId,
@@ -52,27 +48,30 @@ export function FacultyReportHeader({
   onExport,
 }: FacultyReportHeaderProps) {
   return (
-    <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-      <div className="min-w-0">
-        <h1 className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl">
-          {facultyName}
-        </h1>
-        <p className="mt-4 max-w-3xl font-sans text-sm text-muted-foreground">
-          Review per-question faculty evaluation results for{" "}
-          <span className="font-bold text-foreground">{semesterLabel}</span>.
-        </p>
-      </div>
+    <nav
+      aria-label="Faculty report controls"
+      className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between"
+    >
+      <Button
+        asChild
+        variant="ghost"
+        size="sm"
+        className="w-fit px-2 font-sans text-xs uppercase tracking-[0.18em] text-stone-500 hover:text-stone-900"
+      >
+        <Link href={backHref}>← Back to faculties</Link>
+      </Button>
 
-      <div className="flex w-full flex-col gap-3 sm:flex-row sm:flex-wrap sm:justify-end xl:w-auto">
+      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm sm:w-64"
+              size="sm"
+              className="w-full min-w-0 justify-between border-stone-200 bg-white px-3 py-2 font-sans text-xs sm:w-56"
               disabled={isQuestionnaireTypeLoading || availableQuestionnaireTypes.length === 0}
             >
-              <span className="truncate">{questionnaireTypeLabel}</span>
-              <ChevronDown className="size-4" />
+              <span className="truncate text-stone-700">{questionnaireTypeLabel}</span>
+              <ChevronDown className="size-3.5 text-stone-400" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent
@@ -100,11 +99,12 @@ export function FacultyReportHeader({
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm sm:w-72"
+              size="sm"
+              className="w-full min-w-0 justify-between border-stone-200 bg-white px-3 py-2 font-sans text-xs sm:w-56"
               disabled={isCourseLoading || availableCourses.length === 0}
             >
-              <span className="truncate">{courseLabel}</span>
-              <ChevronDown className="size-4" />
+              <span className="truncate text-stone-700">{courseLabel}</span>
+              <ChevronDown className="size-3.5 text-stone-400" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent
@@ -131,20 +131,13 @@ export function FacultyReportHeader({
         <Button
           type="button"
           variant="brand"
-          className="w-full px-4 py-2.5 font-sans text-sm sm:w-auto"
+          size="sm"
+          className="w-full px-4 py-2 font-sans text-xs sm:w-auto"
           onClick={onExport}
         >
           Export PDF
         </Button>
-
-        <Button
-          asChild
-          variant="outline"
-          className="w-full px-4 py-2.5 font-sans text-sm sm:w-auto"
-        >
-          <Link href={backHref}>Back to Faculties</Link>
-        </Button>
       </div>
-    </div>
+    </nav>
   );
 }

--- a/features/faculty-analytics/components/faculty-report-screen.tsx
+++ b/features/faculty-analytics/components/faculty-report-screen.tsx
@@ -2,39 +2,36 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
+
 import { Button } from "@/components/ui/button";
+import { FacultyAnalysisSentimentStrip } from "@/features/faculty-analytics/components/faculty-analysis-sentiment-strip";
+import { FacultyAnalysisStats } from "@/features/faculty-analytics/components/faculty-analysis-stats";
+import { FacultyReportComments } from "@/features/faculty-analytics/components/faculty-report-comments";
+import { PipelineTriggerCard } from "@/features/faculty-analytics/components/pipeline-trigger-card";
+import { QuantitativeScoresSection } from "@/features/faculty-analytics/components/quantitative-scores-section";
 import { ScopedAnalyticsEmptyState } from "@/features/faculty-analytics/components/scoped-analytics-empty-state";
 import { ScopedAnalyticsErrorState } from "@/features/faculty-analytics/components/scoped-analytics-error-state";
 import { ScopedAnalyticsLoadingState } from "@/features/faculty-analytics/components/scoped-analytics-loading-state";
 import { ReportExportDialog } from "@/features/faculty-analytics/components/report-export-dialog";
-import { PipelineStatusBadge } from "@/features/faculty-analytics/components/pipeline-status-badge";
-import { RecommendationsCard } from "@/features/faculty-analytics/components/recommendations-card";
-import { ThemesChipList } from "@/features/faculty-analytics/components/themes-chip-list";
+import { ThemeExplorerList } from "@/features/faculty-analytics/components/theme-explorer-list";
 import { useFacultyReportDetailViewModel } from "@/features/faculty-analytics/hooks/use-faculty-report-detail-view-model";
 import { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
 import { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
 import { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
-import { aggregateThemes } from "@/features/faculty-analytics/lib/pipeline-themes";
 import { hasFacultyReportAnalyticsData } from "@/features/faculty-analytics/lib/faculty-report-detail";
 import type { PipelineStatus } from "@/features/faculty-analytics/types";
 
-import { FacultyReportComments } from "./faculty-report-comments";
 import { FacultyReportHeader } from "./faculty-report-header";
-import { FacultyReportSectionPerformanceChart } from "./faculty-report-section-performance-chart";
-import { FacultyReportSections } from "./faculty-report-sections";
-import { FacultyReportSummaryCards } from "./faculty-report-summary-cards";
 
 type FacultyReportScreenProps = {
   facultyId: string;
 };
 
-const RUNNING_STATUSES: ReadonlySet<PipelineStatus> = new Set<PipelineStatus>([
-  "AWAITING_CONFIRMATION",
-  "EMBEDDING_CHECK",
-  "SENTIMENT_ANALYSIS",
+const SENTIMENT_READY_STATUSES: ReadonlySet<PipelineStatus> = new Set<PipelineStatus>([
   "SENTIMENT_GATE",
   "TOPIC_MODELING",
   "GENERATING_RECOMMENDATIONS",
+  "COMPLETED",
 ]);
 
 export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
@@ -42,14 +39,17 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
   const viewModel = useFacultyReportDetailViewModel({ facultyId });
 
   const pipelineScope = useMemo(
-    () => ({ semesterId: viewModel.semesterId ?? "", facultyId }),
-    [viewModel.semesterId, facultyId]
+    () => ({
+      semesterId: viewModel.semesterId ?? "",
+      facultyId,
+      questionnaireTypeCode: viewModel.questionnaireTypeCode || undefined,
+      courseId: viewModel.courseId || undefined,
+    }),
+    [viewModel.semesterId, viewModel.questionnaireTypeCode, viewModel.courseId, facultyId]
   );
   const { latestPipeline } = useLatestPipelineForScope(pipelineScope, {
-    enabled: Boolean(viewModel.semesterId),
+    enabled: Boolean(viewModel.semesterId && viewModel.questionnaireTypeCode),
   });
-  // Poll live status — without this, a completed pipeline's themes+recs
-  // don't appear until the next list refetch or a page refresh.
   const pipelineStatusQuery = usePipelineStatus(latestPipeline?.id ?? null, {
     enabled: Boolean(latestPipeline?.id),
   });
@@ -58,10 +58,28 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
     latestPipeline?.id ?? null,
     livePipelineStatus
   );
-  const themes = useMemo(
-    () => (recommendationsQuery.data ? aggregateThemes(recommendationsQuery.data.actions) : []),
-    [recommendationsQuery.data]
-  );
+
+  const qualitativeSummary = viewModel.qualitativeSummaryQuery.data;
+  const themes = qualitativeSummary?.themes ?? [];
+  const actions = recommendationsQuery.data?.actions ?? [];
+
+  const showSentimentSurface = livePipelineStatus
+    ? SENTIMENT_READY_STATUSES.has(livePipelineStatus)
+    : false;
+  const showThemesSurface = livePipelineStatus === "COMPLETED";
+
+  const announcement = useMemo(() => {
+    const parts: string[] = [];
+    if (viewModel.themeLabelFilter) parts.push(viewModel.themeLabelFilter);
+    if (viewModel.sentimentFilter) {
+      parts.push(
+        viewModel.sentimentFilter.charAt(0).toUpperCase() + viewModel.sentimentFilter.slice(1)
+      );
+    }
+    if (parts.length === 0) return "";
+    const total = viewModel.commentsMeta?.totalItems ?? 0;
+    return `Filter applied: ${parts.join(", ")}. ${total} comment${total === 1 ? "" : "s"} shown.`;
+  }, [viewModel.themeLabelFilter, viewModel.sentimentFilter, viewModel.commentsMeta?.totalItems]);
 
   if (!viewModel.hasSemesterContext) {
     return (
@@ -82,16 +100,6 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
   if (viewModel.reportQuery.isLoading) {
     return (
       <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h1 className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl">
-              {viewModel.reportTitle}
-            </h1>
-            <p className="mt-3 font-sans text-sm text-muted-foreground">
-              Loading the faculty evaluation report for {viewModel.semesterLabel}.
-            </p>
-          </div>
-        </div>
         <ScopedAnalyticsLoadingState message="Loading faculty report..." />
       </section>
     );
@@ -114,72 +122,123 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
   }
 
   const hasAnalyticsData = hasFacultyReportAnalyticsData(viewModel.report, viewModel.commentsCount);
-  const pipelineStatus = livePipelineStatus;
-  const isPipelineRunning = pipelineStatus ? RUNNING_STATUSES.has(pipelineStatus) : false;
-  const showCompletedAnalysis =
-    pipelineStatus === "COMPLETED" && recommendationsQuery.data !== undefined;
 
   return (
     <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
-      <FacultyReportHeader
-        backHref={viewModel.backHref}
-        facultyName={viewModel.report.faculty.name}
-        semesterLabel={viewModel.semesterLabel}
-        questionnaireTypeLabel={viewModel.questionnaireTypeLabel}
-        questionnaireTypeCode={viewModel.questionnaireTypeCode}
-        courseId={viewModel.courseId}
-        courseLabel={viewModel.selectedCourseLabel}
-        availableQuestionnaireTypes={viewModel.availableQuestionnaireTypes}
-        availableCourses={viewModel.availableCourses}
-        isQuestionnaireTypeLoading={viewModel.isQuestionnaireTypeLoading}
-        isCourseLoading={viewModel.isCourseLoading}
-        onQuestionnaireTypeChange={viewModel.updateQuestionnaireType}
-        onCourseChange={viewModel.updateCourse}
-        onExport={() => setIsExportDialogOpen(true)}
-      />
-
-      {pipelineStatus ? (
-        <div className="flex items-center gap-3">
-          <PipelineStatusBadge status={pipelineStatus} />
-          {isPipelineRunning ? (
-            <span className="font-sans text-xs text-muted-foreground">
-              Analysis in progress. Themes and recommendations will appear once complete.
-            </span>
-          ) : null}
+      {/* Title row — mirrors the dashboard / faculty-list header pattern */}
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+        <div className="min-w-0">
+          <h1 className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl">
+            {viewModel.report.faculty.name}
+          </h1>
+          <p className="mt-3 max-w-3xl text-sm text-muted-foreground">
+            Review per-question faculty evaluation results for{" "}
+            <span className="font-medium text-foreground">{viewModel.semesterLabel}</span>.
+          </p>
         </div>
-      ) : null}
+
+        <FacultyReportHeader
+          backHref={viewModel.backHref}
+          questionnaireTypeLabel={viewModel.questionnaireTypeLabel}
+          questionnaireTypeCode={viewModel.questionnaireTypeCode}
+          courseId={viewModel.courseId}
+          courseLabel={viewModel.selectedCourseLabel}
+          availableQuestionnaireTypes={viewModel.availableQuestionnaireTypes}
+          availableCourses={viewModel.availableCourses}
+          isQuestionnaireTypeLoading={viewModel.isQuestionnaireTypeLoading}
+          isCourseLoading={viewModel.isCourseLoading}
+          onQuestionnaireTypeChange={viewModel.updateQuestionnaireType}
+          onCourseChange={viewModel.updateCourse}
+          onExport={() => setIsExportDialogOpen(true)}
+        />
+      </div>
+
+      <div role="status" aria-live="polite" className="sr-only">
+        {announcement}
+      </div>
 
       {!hasAnalyticsData ? (
         <ScopedAnalyticsEmptyState description="No evaluation analytics are available for this faculty in the selected filters." />
       ) : (
         <>
-          <FacultyReportSummaryCards
-            submissionCount={viewModel.report.submissionCount}
-            overallRating={viewModel.report.overallRating}
-            commentsCount={viewModel.commentsCount}
-            overallInterpretation={viewModel.report.overallInterpretation}
-          />
-
-          {showCompletedAnalysis && themes.length > 0 ? <ThemesChipList themes={themes} /> : null}
-
-          {showCompletedAnalysis && recommendationsQuery.data ? (
-            <RecommendationsCard recommendations={recommendationsQuery.data} />
+          {/* Analysis pipeline status — surfaced prominently, same pattern as
+              dashboard. Not hidden in a collapsible. */}
+          {viewModel.semesterId && viewModel.questionnaireTypeCode ? (
+            <PipelineTriggerCard scope={pipelineScope} pipeline={latestPipeline} />
           ) : null}
 
-          <FacultyReportSectionPerformanceChart sections={viewModel.report.sections} />
+          <FacultyAnalysisStats
+            submissionCount={viewModel.report.submissionCount}
+            overallRating={viewModel.report.overallRating}
+            overallInterpretation={viewModel.report.overallInterpretation}
+            commentsCount={viewModel.commentsCount}
+            sentimentDistribution={
+              showSentimentSurface && qualitativeSummary
+                ? qualitativeSummary.sentimentDistribution
+                : null
+            }
+          />
 
-          <FacultyReportSections sections={viewModel.report.sections} />
+          {showSentimentSurface && qualitativeSummary ? (
+            <FacultyAnalysisSentimentStrip
+              distribution={qualitativeSummary.sentimentDistribution}
+              sentimentFilter={viewModel.sentimentFilter}
+              themeLabelFilter={viewModel.themeLabelFilter}
+              onSentimentClick={viewModel.updateSentimentFilter}
+              onClearSentiment={() => viewModel.updateSentimentFilter(null)}
+              onClearTheme={() => viewModel.updateThemeFilter(null)}
+              onClearAll={viewModel.clearAllFilters}
+            />
+          ) : null}
 
-          <FacultyReportComments
-            comments={viewModel.comments}
-            commentsMeta={viewModel.commentsMeta}
-            commentsPage={viewModel.commentsPage}
-            commentsLimit={viewModel.commentsLimit}
-            isLoading={viewModel.commentsQuery.isLoading}
-            isError={viewModel.commentsQuery.isError}
-            onRetry={viewModel.retryComments}
-            onPageChange={viewModel.updateCommentsPage}
-            onRowsPerPageChange={viewModel.updateCommentsLimit}
+          {showThemesSurface && themes.length > 0 ? (
+            <ThemeExplorerList
+              themes={themes}
+              expandedThemeLabel={viewModel.themeLabelFilter}
+              onToggleTheme={viewModel.updateThemeFilter}
+              facultyId={facultyId}
+              semesterId={viewModel.semesterId}
+              questionnaireTypeCode={viewModel.questionnaireTypeCode}
+              courseId={viewModel.courseId || undefined}
+              sentimentFilter={viewModel.sentimentFilter}
+              actions={actions}
+            />
+          ) : showThemesSurface && themes.length === 0 && viewModel.comments.length > 0 ? (
+            <section>
+              <div className="max-w-3xl">
+                <h2 className="font-playfair text-xl font-semibold tracking-tight text-foreground">
+                  Student comments
+                </h2>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  No themes clustered from this analysis. The raw comments are below.
+                </p>
+              </div>
+              <div className="mt-4">
+                <FacultyReportComments
+                  comments={viewModel.comments}
+                  commentsMeta={viewModel.commentsMeta}
+                  commentsPage={viewModel.commentsPage}
+                  commentsLimit={viewModel.commentsLimit}
+                  isLoading={viewModel.commentsQuery.isLoading}
+                  isError={viewModel.commentsQuery.isError}
+                  onRetry={viewModel.retryComments}
+                  onPageChange={viewModel.updateCommentsPage}
+                  onRowsPerPageChange={viewModel.updateCommentsLimit}
+                />
+              </div>
+            </section>
+          ) : showSentimentSurface ? (
+            <section className="rounded-2xl border border-dashed border-border bg-muted/30 px-6 py-10 text-center">
+              <p className="text-sm text-muted-foreground">
+                Sentiment analysis is ready. Themes and suggested actions will surface shortly.
+              </p>
+            </section>
+          ) : null}
+
+          <QuantitativeScoresSection
+            sections={viewModel.report.sections}
+            submissionCount={viewModel.report.submissionCount}
+            defaultOpen={false}
           />
         </>
       )}

--- a/features/faculty-analytics/components/quantitative-scores-section.tsx
+++ b/features/faculty-analytics/components/quantitative-scores-section.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+import { FacultyReportSectionPerformanceChart } from "@/features/faculty-analytics/components/faculty-report-section-performance-chart";
+import { FacultyReportSections } from "@/features/faculty-analytics/components/faculty-report-sections";
+import { cn } from "@/lib/utils";
+import type { FacultyReportSectionDto } from "@/features/faculty-analytics/types";
+
+type QuantitativeScoresSectionProps = {
+  sections: FacultyReportSectionDto[];
+  submissionCount: number;
+  defaultOpen?: boolean;
+};
+
+export function QuantitativeScoresSection({
+  sections,
+  submissionCount,
+  defaultOpen = false,
+}: QuantitativeScoresSectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  if (sections.length === 0) return null;
+
+  return (
+    <section className="rounded-2xl border border-border/70 bg-card">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-4 px-6 py-5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+      >
+        <div>
+          <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+            Numerical scores
+          </p>
+          <h2 className="mt-1 text-lg font-semibold tracking-tight text-foreground">
+            Per-section performance
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Weighted averages across {sections.length} section
+            {sections.length === 1 ? "" : "s"} from {submissionCount} submission
+            {submissionCount === 1 ? "" : "s"}.
+          </p>
+        </div>
+        <ChevronDown
+          className={cn(
+            "h-5 w-5 shrink-0 text-muted-foreground transition-transform duration-200",
+            open && "rotate-180"
+          )}
+          aria-hidden
+        />
+      </button>
+
+      <div
+        data-state={open ? "open" : "closed"}
+        aria-hidden={!open}
+        className="grid transition-[grid-template-rows] duration-300 ease-out data-[state=closed]:grid-rows-[0fr] data-[state=open]:grid-rows-[1fr]"
+      >
+        <div className="overflow-hidden">
+          <div className="space-y-6 border-t border-border/70 px-6 py-6">
+            <FacultyReportSectionPerformanceChart sections={sections} />
+            <FacultyReportSections sections={sections} />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/features/faculty-analytics/components/recommendations-card.tsx
+++ b/features/faculty-analytics/components/recommendations-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { ArrowUp } from "lucide-react";
 
 import {
   Accordion,
@@ -9,8 +10,10 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { recommendationAnchorId } from "@/features/faculty-analytics/lib/theme-anchor";
 import type {
   ActionPriority,
   RecommendationsResponse,
@@ -20,6 +23,7 @@ import type {
 
 type RecommendationsCardProps = {
   recommendations: RecommendationsResponse;
+  onViewTheme?: (topicLabel: string) => void;
 };
 
 const PRIORITY_VARIANT: Record<
@@ -31,14 +35,32 @@ const PRIORITY_VARIANT: Record<
   LOW: "outline",
 };
 
-function ActionItem({ action }: { action: RecommendedActionDto }) {
+function extractTopicLabel(action: RecommendedActionDto): string | null {
+  const topicSource = action.supportingEvidence?.sources.find(
+    (s): s is TopicSource => s.type === "topic"
+  );
+  return topicSource?.topicLabel ?? null;
+}
+
+function ActionItem({
+  action,
+  onViewTheme,
+}: {
+  action: RecommendedActionDto;
+  onViewTheme?: (topicLabel: string) => void;
+}) {
   const topicSources = action.supportingEvidence?.sources.filter(
     (s): s is TopicSource => s.type === "topic"
   );
   const evidenceKey = `evidence-${action.id}`;
+  const primaryTopicLabel = extractTopicLabel(action);
+  const anchorId = recommendationAnchorId(primaryTopicLabel ?? action.id);
 
   return (
-    <div className="rounded-xl border border-border/70 p-4">
+    <div
+      id={anchorId}
+      className="rounded-xl border border-border/70 p-4 data-[highlight=pulse]:animate-pulse data-[highlight=pulse]:bg-amber-100/60"
+    >
       <div className="flex items-start justify-between gap-3">
         <h3 className="font-playfair text-base font-semibold text-foreground">{action.headline}</h3>
         <Badge variant={PRIORITY_VARIANT[action.priority]}>{action.priority}</Badge>
@@ -48,6 +70,21 @@ function ActionItem({ action }: { action: RecommendedActionDto }) {
         <span className="font-medium">Plan: </span>
         {action.actionPlan}
       </p>
+
+      {primaryTopicLabel && onViewTheme ? (
+        <div className="mt-3">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 px-2 font-sans text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => onViewTheme(primaryTopicLabel)}
+          >
+            <ArrowUp className="mr-1 h-3 w-3" />
+            View theme
+          </Button>
+        </div>
+      ) : null}
 
       {topicSources && topicSources.length > 0 ? (
         <Accordion type="single" collapsible className="mt-3">
@@ -82,7 +119,7 @@ function ActionItem({ action }: { action: RecommendedActionDto }) {
   );
 }
 
-export function RecommendationsCard({ recommendations }: RecommendationsCardProps) {
+export function RecommendationsCard({ recommendations, onViewTheme }: RecommendationsCardProps) {
   const { strengths, improvements } = useMemo(() => {
     const strengths: RecommendedActionDto[] = [];
     const improvements: RecommendedActionDto[] = [];
@@ -100,10 +137,8 @@ export function RecommendationsCard({ recommendations }: RecommendationsCardProp
   return (
     <Card className="rounded-2xl border-border/70 shadow-sm">
       <CardHeader>
-        <CardTitle className="font-playfair text-xl">Recommendations</CardTitle>
-        <CardDescription>
-          Generated insights from faculty feedback, grouped by category.
-        </CardDescription>
+        <CardTitle className="font-playfair text-xl">Suggested Actions</CardTitle>
+        <CardDescription>Concrete actions informed by the feedback themes above.</CardDescription>
       </CardHeader>
       <CardContent>
         <Tabs defaultValue="improvements">
@@ -113,7 +148,7 @@ export function RecommendationsCard({ recommendations }: RecommendationsCardProp
           </TabsList>
           <TabsContent value="improvements" className="mt-4 space-y-3">
             {improvements.map((action) => (
-              <ActionItem key={action.id} action={action} />
+              <ActionItem key={action.id} action={action} onViewTheme={onViewTheme} />
             ))}
             {improvements.length === 0 ? (
               <p className="font-sans text-sm text-muted-foreground">
@@ -123,7 +158,7 @@ export function RecommendationsCard({ recommendations }: RecommendationsCardProp
           </TabsContent>
           <TabsContent value="strengths" className="mt-4 space-y-3">
             {strengths.map((action) => (
-              <ActionItem key={action.id} action={action} />
+              <ActionItem key={action.id} action={action} onViewTheme={onViewTheme} />
             ))}
             {strengths.length === 0 ? (
               <p className="font-sans text-sm text-muted-foreground">

--- a/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
+++ b/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
@@ -13,8 +13,29 @@ import { ThemesRankedList } from "@/features/faculty-analytics/components/themes
 import { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
 import { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
 import { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
-import { aggregateThemes } from "@/features/faculty-analytics/lib/pipeline-themes";
+import {
+  aggregateThemes,
+  type RankedTheme,
+} from "@/features/faculty-analytics/lib/pipeline-themes";
+import type { QualitativeThemeDto } from "@/features/faculty-analytics/types";
 import { useScopedAnalyticsDashboardViewModel } from "@/features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model";
+
+function rankedThemesToQualitativeThemes(themes: RankedTheme[]): QualitativeThemeDto[] {
+  return themes.map((theme, index) => {
+    const total = theme.commentCount || 0;
+    return {
+      themeId: `ranked-${index}-${theme.topicLabel}`,
+      label: theme.topicLabel,
+      count: total,
+      sentimentSplit: {
+        positive: Math.round(theme.sentimentBreakdown.positive * total),
+        neutral: Math.round(theme.sentimentBreakdown.neutral * total),
+        negative: Math.round(theme.sentimentBreakdown.negative * total),
+      },
+      sampleQuotes: theme.sampleQuotes,
+    };
+  });
+}
 
 export type ScopeLabel = "Campus" | "Department";
 
@@ -58,7 +79,10 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
   const liveStatus = pipelineStatusQuery.data?.status ?? latestPipeline?.status;
   const recommendationsQuery = usePipelineRecommendations(latestPipeline?.id ?? null, liveStatus);
   const themes = useMemo(
-    () => (recommendationsQuery.data ? aggregateThemes(recommendationsQuery.data.actions) : []),
+    () =>
+      recommendationsQuery.data
+        ? rankedThemesToQualitativeThemes(aggregateThemes(recommendationsQuery.data.actions))
+        : [],
     [recommendationsQuery.data]
   );
 

--- a/features/faculty-analytics/components/sentiment-stacked-bar.tsx
+++ b/features/faculty-analytics/components/sentiment-stacked-bar.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { SentimentDistributionDto, SentimentLabel } from "@/features/faculty-analytics/types";
+
+type SentimentStackedBarProps = {
+  distribution: SentimentDistributionDto;
+  activeSentiment: SentimentLabel | null;
+  onSegmentClick: (sentiment: SentimentLabel | null) => void;
+};
+
+const SEGMENT_STYLES: Record<
+  SentimentLabel,
+  { fill: string; ringActive: string; ringInactive: string; label: string }
+> = {
+  positive: {
+    fill: "bg-emerald-500",
+    ringActive: "ring-2 ring-emerald-600 ring-offset-1",
+    ringInactive: "hover:ring-2 hover:ring-emerald-400/60",
+    label: "Positive",
+  },
+  neutral: {
+    fill: "bg-muted-foreground/40",
+    ringActive: "ring-2 ring-muted-foreground ring-offset-1",
+    ringInactive: "hover:ring-2 hover:ring-muted-foreground/60",
+    label: "Neutral",
+  },
+  negative: {
+    fill: "bg-rose-500",
+    ringActive: "ring-2 ring-rose-600 ring-offset-1",
+    ringInactive: "hover:ring-2 hover:ring-rose-400/60",
+    label: "Negative",
+  },
+};
+
+const SEGMENT_ORDER: SentimentLabel[] = ["positive", "neutral", "negative"];
+
+export function SentimentStackedBar({
+  distribution,
+  activeSentiment,
+  onSegmentClick,
+}: SentimentStackedBarProps) {
+  const total = distribution.positive + distribution.neutral + distribution.negative;
+  const hasData = total > 0;
+
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl">Sentiment at a glance</CardTitle>
+        <CardDescription>
+          Click a segment to filter comments by sentiment. Click again to clear.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {!hasData ? (
+          <div
+            className="flex h-3 w-full overflow-hidden rounded-full bg-muted"
+            aria-label="No sentiment data yet"
+          />
+        ) : (
+          <div
+            className="flex h-5 w-full overflow-hidden rounded-full bg-muted"
+            role="group"
+            aria-label="Sentiment distribution"
+          >
+            {SEGMENT_ORDER.map((sentiment) => {
+              const count = distribution[sentiment];
+              if (count === 0) return null;
+              const widthPct = (count / total) * 100;
+              const style = SEGMENT_STYLES[sentiment];
+              const isActive = activeSentiment === sentiment;
+
+              return (
+                <button
+                  key={sentiment}
+                  type="button"
+                  onClick={() => onSegmentClick(isActive ? null : sentiment)}
+                  className={cn(
+                    "h-full transition-all",
+                    style.fill,
+                    isActive ? style.ringActive : style.ringInactive,
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                    "cursor-pointer"
+                  )}
+                  style={{ width: `${widthPct}%` }}
+                  aria-label={`Filter comments to ${style.label.toLowerCase()} sentiment, ${count} submissions`}
+                  aria-pressed={isActive}
+                />
+              );
+            })}
+          </div>
+        )}
+
+        <dl className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-1 font-sans text-xs tabular-nums text-muted-foreground">
+          {SEGMENT_ORDER.map((sentiment) => {
+            const style = SEGMENT_STYLES[sentiment];
+            return (
+              <div key={sentiment} className="flex items-center gap-2">
+                <span className={cn("inline-block h-2.5 w-2.5 rounded-full", style.fill)} />
+                <dt className="font-medium text-foreground">{style.label}</dt>
+                <dd>{distribution[sentiment]}</dd>
+              </div>
+            );
+          })}
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/faculty-analytics/components/theme-explorer-card.tsx
+++ b/features/faculty-analytics/components/theme-explorer-card.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { ChevronRight, Lightbulb, Quote } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { PaginationFooter } from "@/components/shared/pagination-footer";
+import { ScopedAnalyticsErrorState } from "@/features/faculty-analytics/components/scoped-analytics-error-state";
+import { ScopedAnalyticsLoadingState } from "@/features/faculty-analytics/components/scoped-analytics-loading-state";
+import { useFacultyReportComments } from "@/features/faculty-analytics/hooks/use-faculty-report-comments";
+import { themeRowAnchorId } from "@/features/faculty-analytics/lib/theme-anchor";
+import { cn } from "@/lib/utils";
+import { formatDateTime } from "@/lib/date";
+import type {
+  ActionPriority,
+  QualitativeThemeDto,
+  RecommendedActionDto,
+  SentimentLabel,
+} from "@/features/faculty-analytics/types";
+
+type ThemeExplorerCardProps = {
+  theme: QualitativeThemeDto;
+  rank: number;
+  isExpanded: boolean;
+  onToggle: () => void;
+  facultyId: string;
+  semesterId: string;
+  questionnaireTypeCode: string;
+  courseId?: string;
+  sentimentFilter: SentimentLabel | null;
+  matchingAction: RecommendedActionDto | null;
+};
+
+const DOMINANT_ACCENT: Record<SentimentLabel, string> = {
+  negative: "bg-rose-600",
+  neutral: "bg-muted-foreground/50",
+  positive: "bg-emerald-600",
+};
+
+const SEGMENT_COLOR: Record<SentimentLabel, string> = {
+  negative: "bg-rose-600",
+  neutral: "bg-muted-foreground/50",
+  positive: "bg-emerald-600",
+};
+
+const SENTIMENT_LABEL: Record<SentimentLabel, string> = {
+  positive: "Positive",
+  neutral: "Neutral",
+  negative: "Negative",
+};
+
+const SENTIMENT_COMMENT_BADGE: Record<SentimentLabel, string> = {
+  positive:
+    "border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-300",
+  neutral: "border-border bg-muted text-muted-foreground",
+  negative:
+    "border-rose-200 bg-rose-50 text-rose-900 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-300",
+};
+
+const PRIORITY_VARIANT: Record<
+  ActionPriority,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  HIGH: "destructive",
+  MEDIUM: "secondary",
+  LOW: "outline",
+};
+
+function dominantSentiment(theme: QualitativeThemeDto): SentimentLabel {
+  const { positive, neutral, negative } = theme.sentimentSplit;
+  if (negative >= positive && negative >= neutral) return "negative";
+  if (positive >= neutral) return "positive";
+  return "neutral";
+}
+
+export function ThemeExplorerCard({
+  theme,
+  rank,
+  isExpanded,
+  onToggle,
+  facultyId,
+  semesterId,
+  questionnaireTypeCode,
+  courseId,
+  sentimentFilter,
+  matchingAction,
+}: ThemeExplorerCardProps) {
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(5);
+  const [lastSentiment, setLastSentiment] = useState(sentimentFilter);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  if (lastSentiment !== sentimentFilter) {
+    setLastSentiment(sentimentFilter);
+    setPage(1);
+  }
+
+  const commentsQuery = useFacultyReportComments(
+    {
+      facultyId,
+      semesterId,
+      questionnaireTypeCode,
+      courseId,
+      themeId: theme.themeId,
+      sentiment: sentimentFilter ?? undefined,
+      page,
+      limit,
+    },
+    { enabled: isExpanded }
+  );
+
+  const dominant = dominantSentiment(theme);
+  const previewQuote = theme.sampleQuotes?.[0] ?? null;
+
+  const totalSplit =
+    theme.sentimentSplit.positive + theme.sentimentSplit.neutral + theme.sentimentSplit.negative;
+
+  const comments = commentsQuery.data?.items ?? [];
+  const meta = commentsQuery.data?.meta ?? null;
+
+  const segments = useMemo(
+    () =>
+      (["negative", "neutral", "positive"] as SentimentLabel[]).map((s) => ({
+        key: s,
+        count: theme.sentimentSplit[s],
+        widthPct: totalSplit > 0 ? (theme.sentimentSplit[s] / totalSplit) * 100 : 0,
+      })),
+    [theme.sentimentSplit, totalSplit]
+  );
+
+  return (
+    <article
+      id={themeRowAnchorId(theme.label)}
+      className={cn(
+        "group relative overflow-hidden rounded-2xl border bg-card transition-all",
+        "data-[highlight=pulse]:animate-pulse data-[highlight=pulse]:bg-accent",
+        isExpanded
+          ? "border-border shadow-md"
+          : "border-border/70 shadow-sm hover:border-border hover:shadow-md"
+      )}
+    >
+      {/* dominant-sentiment accent rail */}
+      <div
+        aria-hidden
+        className={cn("absolute left-0 top-0 h-full w-1", DOMINANT_ACCENT[dominant])}
+      />
+
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-start gap-5 px-6 pl-8 py-5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+        aria-expanded={isExpanded}
+        aria-controls={`theme-body-${theme.themeId}`}
+      >
+        {/* Rank numeral — the one place display font earns its keep */}
+        <span
+          aria-hidden
+          className="mt-0.5 font-playfair text-xl font-medium text-muted-foreground/50 tabular-nums"
+        >
+          {String(rank).padStart(2, "0")}
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+            <h3 className="text-lg font-semibold tracking-tight text-foreground">{theme.label}</h3>
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {theme.count} mention{theme.count === 1 ? "" : "s"}
+            </span>
+          </div>
+
+          {/* Inline sentiment split micro-bar */}
+          <div className="mt-3 flex items-center gap-3">
+            <div className="flex h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+              {segments.map((s) =>
+                s.count === 0 ? null : (
+                  <span
+                    key={s.key}
+                    className={cn("h-full", SEGMENT_COLOR[s.key])}
+                    style={{ width: `${s.widthPct}%` }}
+                    aria-label={`${SENTIMENT_LABEL[s.key]}: ${s.count}`}
+                  />
+                )
+              )}
+            </div>
+            <div className="flex gap-3 text-xs tabular-nums text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <span className={cn("h-1.5 w-1.5 rounded-full", SEGMENT_COLOR.negative)} />
+                {theme.sentimentSplit.negative}
+              </span>
+              <span className="flex items-center gap-1">
+                <span className={cn("h-1.5 w-1.5 rounded-full", SEGMENT_COLOR.neutral)} />
+                {theme.sentimentSplit.neutral}
+              </span>
+              <span className="flex items-center gap-1">
+                <span className={cn("h-1.5 w-1.5 rounded-full", SEGMENT_COLOR.positive)} />
+                {theme.sentimentSplit.positive}
+              </span>
+            </div>
+          </div>
+
+          {/* Pull-quote preview (readable sans, not serif) */}
+          {previewQuote && !isExpanded ? (
+            <blockquote className="mt-4 border-l-2 border-border pl-4 text-sm leading-relaxed text-muted-foreground">
+              &ldquo;{previewQuote}&rdquo;
+            </blockquote>
+          ) : null}
+        </div>
+
+        <span className="mt-1 flex items-center gap-1 text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground group-hover:text-foreground">
+          <span className="hidden sm:inline">{isExpanded ? "Collapse" : "Expand"}</span>
+          <ChevronRight
+            className={cn("h-4 w-4 transition-transform duration-200", isExpanded && "rotate-90")}
+          />
+        </span>
+      </button>
+
+      <div
+        id={`theme-body-${theme.themeId}`}
+        ref={bodyRef}
+        data-state={isExpanded ? "open" : "closed"}
+        aria-hidden={!isExpanded}
+        className="grid transition-[grid-template-rows] duration-300 ease-out data-[state=closed]:grid-rows-[0fr] data-[state=open]:grid-rows-[1fr]"
+      >
+        <div className="overflow-hidden">
+          <div className="border-t border-border/70 bg-muted/30 px-6 pl-8 pb-8 pt-6">
+            <div className="grid gap-10 lg:grid-cols-[1fr_minmax(0,320px)]">
+              {/* LEFT — sample quotes + comments */}
+              <div className="min-w-0 space-y-8">
+                {theme.sampleQuotes && theme.sampleQuotes.length > 0 ? (
+                  <section>
+                    <h4 className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                      What students say
+                    </h4>
+                    <ul className="mt-4 space-y-4">
+                      {theme.sampleQuotes.map((quote, idx) => (
+                        <li key={idx} className="relative border-l-2 border-foreground/20 pl-5">
+                          <Quote
+                            className="absolute -left-2 top-0 h-3.5 w-3.5 -translate-x-1/2 bg-muted px-0.5 text-muted-foreground"
+                            aria-hidden
+                          />
+                          <p className="text-sm leading-relaxed text-foreground">{quote}</p>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                ) : null}
+
+                <section>
+                  <div className="flex items-baseline justify-between gap-4">
+                    <h4 className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                      All comments in this theme
+                      {sentimentFilter ? (
+                        <span className="ml-2 normal-case tracking-normal text-muted-foreground/70">
+                          · filtered to {SENTIMENT_LABEL[sentimentFilter]}
+                        </span>
+                      ) : null}
+                    </h4>
+                    {meta ? (
+                      <span className="text-xs tabular-nums text-muted-foreground">
+                        {meta.totalItems} total
+                      </span>
+                    ) : null}
+                  </div>
+
+                  <div className="mt-4">
+                    {commentsQuery.isLoading ? (
+                      <ScopedAnalyticsLoadingState message="Loading comments..." />
+                    ) : commentsQuery.isError ? (
+                      <ScopedAnalyticsErrorState
+                        onRetry={() => void commentsQuery.refetch()}
+                        message="Unable to load comments for this theme."
+                      />
+                    ) : comments.length === 0 ? (
+                      <p className="rounded-xl border border-dashed border-border bg-background/60 px-4 py-6 text-center text-sm text-muted-foreground">
+                        No comments match the current filter in this theme.
+                      </p>
+                    ) : (
+                      <>
+                        <ul className="space-y-3">
+                          {comments.map((c, idx) => (
+                            <li
+                              key={`${c.submittedAt}-${idx}`}
+                              className="rounded-xl border border-border/70 bg-card px-4 py-3"
+                            >
+                              <div className="flex items-baseline justify-between gap-4">
+                                <div className="flex flex-wrap items-center gap-2">
+                                  {c.sentiment ? (
+                                    <Badge
+                                      variant="outline"
+                                      className={cn(
+                                        "rounded-full px-2 py-0.5 text-[0.65rem] uppercase tracking-wider",
+                                        SENTIMENT_COMMENT_BADGE[c.sentiment]
+                                      )}
+                                    >
+                                      {SENTIMENT_LABEL[c.sentiment]}
+                                    </Badge>
+                                  ) : null}
+                                </div>
+                                <span className="text-xs text-muted-foreground">
+                                  {formatDateTime(c.submittedAt)}
+                                </span>
+                              </div>
+                              <p className="mt-2 text-sm leading-relaxed text-foreground">
+                                {c.text}
+                              </p>
+                            </li>
+                          ))}
+                        </ul>
+                        {meta && meta.totalPages > 1 ? (
+                          <div className="mt-5">
+                            <PaginationFooter
+                              itemCount={meta.itemCount}
+                              totalItems={meta.totalItems}
+                              currentPage={meta.currentPage}
+                              totalPages={meta.totalPages}
+                              itemLabel="comments"
+                              rowsPerPage={limit}
+                              onRowsPerPageChange={(n) => {
+                                setLimit(n);
+                                setPage(1);
+                              }}
+                              onPageChange={setPage}
+                            />
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+                  </div>
+                </section>
+              </div>
+
+              {/* RIGHT — suggested action + meta */}
+              <aside className="space-y-6">
+                {matchingAction ? (
+                  <section className="rounded-2xl border border-border/70 bg-accent/40 p-5">
+                    <div className="flex items-center gap-2">
+                      <Lightbulb className="h-4 w-4 text-foreground/70" aria-hidden />
+                      <h4 className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                        Suggested action
+                      </h4>
+                    </div>
+                    <div className="mt-3 flex items-start justify-between gap-3">
+                      <h5 className="text-base font-semibold leading-tight text-foreground">
+                        {matchingAction.headline}
+                      </h5>
+                      <Badge variant={PRIORITY_VARIANT[matchingAction.priority]}>
+                        {matchingAction.priority}
+                      </Badge>
+                    </div>
+                    <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                      {matchingAction.description}
+                    </p>
+                    <div className="mt-4 rounded-xl border border-border/70 bg-card p-3">
+                      <p className="text-[0.65rem] uppercase tracking-[0.18em] text-muted-foreground">
+                        Plan
+                      </p>
+                      <p className="mt-1 text-sm leading-relaxed text-foreground">
+                        {matchingAction.actionPlan}
+                      </p>
+                    </div>
+                  </section>
+                ) : (
+                  <section className="rounded-2xl border border-dashed border-border bg-background/60 p-5">
+                    <h4 className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                      Suggested action
+                    </h4>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      No specific recommendation is tied to this theme yet.
+                    </p>
+                  </section>
+                )}
+
+                <section>
+                  <h4 className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                    Sentiment breakdown
+                  </h4>
+                  <dl className="mt-4 space-y-3 text-sm">
+                    {(["negative", "neutral", "positive"] as SentimentLabel[]).map((s) => {
+                      const count = theme.sentimentSplit[s];
+                      const pct = totalSplit > 0 ? Math.round((count / totalSplit) * 100) : 0;
+                      return (
+                        <div key={s} className="space-y-1">
+                          <div className="flex items-center justify-between text-muted-foreground">
+                            <span className="flex items-center gap-2">
+                              <span
+                                className={cn(
+                                  "inline-block h-2 w-2 rounded-full",
+                                  SEGMENT_COLOR[s]
+                                )}
+                              />
+                              {SENTIMENT_LABEL[s]}
+                            </span>
+                            <span className="tabular-nums">
+                              <span className="font-medium text-foreground">{count}</span>
+                              <span className="text-muted-foreground/70"> · {pct}%</span>
+                            </span>
+                          </div>
+                          <div className="h-1 overflow-hidden rounded-full bg-muted">
+                            <span
+                              className={cn("block h-full", SEGMENT_COLOR[s])}
+                              style={{ width: `${pct}%` }}
+                            />
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </dl>
+                </section>
+              </aside>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/features/faculty-analytics/components/theme-explorer-list.tsx
+++ b/features/faculty-analytics/components/theme-explorer-list.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useMemo } from "react";
+import { Lightbulb } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { ThemeExplorerCard } from "@/features/faculty-analytics/components/theme-explorer-card";
+import type {
+  ActionPriority,
+  QualitativeThemeDto,
+  RecommendedActionDto,
+  SentimentLabel,
+  TopicSource,
+} from "@/features/faculty-analytics/types";
+
+type ThemeExplorerListProps = {
+  themes: QualitativeThemeDto[];
+  expandedThemeLabel: string | null;
+  onToggleTheme: (themeLabel: string | null) => void;
+  facultyId: string;
+  semesterId: string;
+  questionnaireTypeCode: string;
+  courseId?: string;
+  sentimentFilter: SentimentLabel | null;
+  actions: RecommendedActionDto[];
+};
+
+const PRIORITY_VARIANT: Record<
+  ActionPriority,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  HIGH: "destructive",
+  MEDIUM: "secondary",
+  LOW: "outline",
+};
+
+function extractTopicLabel(action: RecommendedActionDto): string | null {
+  const topicSource = action.supportingEvidence?.sources.find(
+    (s): s is TopicSource => s.type === "topic"
+  );
+  return topicSource?.topicLabel ?? null;
+}
+
+export function ThemeExplorerList({
+  themes,
+  expandedThemeLabel,
+  onToggleTheme,
+  facultyId,
+  semesterId,
+  questionnaireTypeCode,
+  courseId,
+  sentimentFilter,
+  actions,
+}: ThemeExplorerListProps) {
+  const { actionByTheme, generalActions } = useMemo(() => {
+    const byLabel = new Map<string, RecommendedActionDto>();
+    const general: RecommendedActionDto[] = [];
+    for (const action of actions) {
+      const topicLabel = extractTopicLabel(action);
+      if (topicLabel && !byLabel.has(topicLabel)) {
+        byLabel.set(topicLabel, action);
+      } else if (!topicLabel) {
+        general.push(action);
+      }
+    }
+    return { actionByTheme: byLabel, generalActions: general };
+  }, [actions]);
+
+  if (themes.length === 0) {
+    return (
+      <section>
+        <SectionHeader eyebrow="Qualitative themes" heading="What students are saying" />
+        <div className="mt-6 rounded-2xl border border-dashed border-border bg-muted/30 px-6 py-10 text-center">
+          <p className="text-sm text-muted-foreground">
+            No themes have been identified for this analysis yet.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <div className="space-y-10">
+      <section>
+        <SectionHeader
+          eyebrow="Qualitative themes"
+          heading="What students are saying"
+          subheading={
+            <>
+              {themes.length} theme{themes.length === 1 ? "" : "s"} emerged from student comments,
+              ranked by volume. Expand any row to read student voice and the action tied to that
+              theme.
+            </>
+          }
+        />
+
+        <div className="mt-6 space-y-4">
+          {themes.map((theme, index) => (
+            <ThemeExplorerCard
+              key={theme.themeId}
+              theme={theme}
+              rank={index + 1}
+              isExpanded={expandedThemeLabel === theme.label}
+              onToggle={() =>
+                onToggleTheme(expandedThemeLabel === theme.label ? null : theme.label)
+              }
+              facultyId={facultyId}
+              semesterId={semesterId}
+              questionnaireTypeCode={questionnaireTypeCode}
+              courseId={courseId}
+              sentimentFilter={sentimentFilter}
+              matchingAction={actionByTheme.get(theme.label) ?? null}
+            />
+          ))}
+        </div>
+      </section>
+
+      {generalActions.length > 0 ? (
+        <section>
+          <SectionHeader
+            eyebrow="Cross-cutting"
+            heading="General guidance"
+            subheading="Recommendations drawn from the overall pattern of feedback, not bound to a single theme."
+          />
+
+          <ul className="mt-6 grid gap-4 md:grid-cols-2">
+            {generalActions.map((action) => (
+              <li
+                key={action.id}
+                className="rounded-2xl border border-border/70 bg-card p-6 shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <Lightbulb className="h-4 w-4 text-foreground/60" aria-hidden />
+                    <span className="text-[0.65rem] uppercase tracking-[0.18em] text-muted-foreground">
+                      {action.category === "STRENGTH" ? "Strength" : "Improvement"}
+                    </span>
+                  </div>
+                  <Badge variant={PRIORITY_VARIANT[action.priority]}>{action.priority}</Badge>
+                </div>
+                <h5 className="mt-3 text-lg font-semibold leading-tight tracking-tight text-foreground">
+                  {action.headline}
+                </h5>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  {action.description}
+                </p>
+                <div className="mt-4 rounded-xl border border-border/70 bg-muted/30 p-3">
+                  <p className="text-[0.65rem] uppercase tracking-[0.18em] text-muted-foreground">
+                    Plan
+                  </p>
+                  <p className="mt-1 text-sm leading-relaxed text-foreground">
+                    {action.actionPlan}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function SectionHeader({
+  eyebrow,
+  heading,
+  subheading,
+}: {
+  eyebrow: string;
+  heading: string;
+  subheading?: React.ReactNode;
+}) {
+  return (
+    <div className="max-w-3xl">
+      <p className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">{eyebrow}</p>
+      <h2 className="mt-2 text-xl font-semibold tracking-tight text-foreground">{heading}</h2>
+      {subheading ? (
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{subheading}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/features/faculty-analytics/components/theme-sentiment-matrix.tsx
+++ b/features/faculty-analytics/components/theme-sentiment-matrix.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { themeRowAnchorId } from "@/features/faculty-analytics/lib/theme-anchor";
+import type { QualitativeThemeDto, SentimentLabel } from "@/features/faculty-analytics/types";
+
+type ThemeSentimentMatrixProps = {
+  themes: QualitativeThemeDto[];
+  activeSentiment: SentimentLabel | null;
+  activeThemeLabel: string | null;
+  onCellClick: (themeLabel: string, sentiment: SentimentLabel | null) => void;
+  onRowLabelClick?: (themeLabel: string) => void;
+};
+
+const SENTIMENT_COLORS: Record<SentimentLabel, string> = {
+  negative: "bg-rose-500",
+  neutral: "bg-muted-foreground/40",
+  positive: "bg-emerald-500",
+};
+
+const CELL_HEADERS: { key: SentimentLabel; label: string }[] = [
+  { key: "negative", label: "Negative" },
+  { key: "neutral", label: "Neutral" },
+  { key: "positive", label: "Positive" },
+];
+
+function dominantKey(theme: QualitativeThemeDto): SentimentLabel {
+  const { positive, neutral, negative } = theme.sentimentSplit;
+  if (negative >= positive && negative >= neutral) return "negative";
+  if (positive >= neutral) return "positive";
+  return "neutral";
+}
+
+export function ThemeSentimentMatrix({
+  themes,
+  activeSentiment,
+  activeThemeLabel,
+  onCellClick,
+  onRowLabelClick,
+}: ThemeSentimentMatrixProps) {
+  if (themes.length === 0) {
+    return (
+      <Card className="rounded-2xl border-border/70 shadow-sm">
+        <CardHeader>
+          <CardTitle className="font-playfair text-xl">Themes × Sentiment</CardTitle>
+          <CardDescription>No themes detected in this analysis.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const maxCellCount = themes.reduce((max, theme) => {
+    const cellMax = Math.max(
+      theme.sentimentSplit.positive,
+      theme.sentimentSplit.neutral,
+      theme.sentimentSplit.negative
+    );
+    return Math.max(max, cellMax);
+  }, 0);
+
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl">Themes × Sentiment</CardTitle>
+        <CardDescription>
+          Click a cell to filter comments by theme and sentiment together.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        <table className="w-full border-collapse font-sans text-sm">
+          <thead>
+            <tr className="border-b border-border/70 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="py-2 pr-3 font-medium">Theme</th>
+              {CELL_HEADERS.map((h) => (
+                <th key={h.key} className="w-[18%] px-3 py-2 text-center font-medium">
+                  {h.label}
+                </th>
+              ))}
+              <th className="w-[10%] px-3 py-2 text-right font-medium">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {themes.map((theme) => {
+              const dominant = dominantKey(theme);
+              const isActiveRow = activeThemeLabel === theme.label;
+              return (
+                <tr
+                  key={theme.themeId}
+                  id={themeRowAnchorId(theme.label)}
+                  data-theme-label={theme.label}
+                  className={cn(
+                    "border-b border-border/40 transition-colors",
+                    isActiveRow ? "bg-muted/30" : "hover:bg-muted/20",
+                    "data-[highlight=pulse]:animate-pulse data-[highlight=pulse]:bg-amber-100/60"
+                  )}
+                >
+                  <td className="py-2 pr-3 align-middle">
+                    <button
+                      type="button"
+                      onClick={() => onRowLabelClick?.(theme.label)}
+                      className={cn(
+                        "font-medium text-foreground hover:underline",
+                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+                      )}
+                      aria-label={`Jump to recommendation for ${theme.label}`}
+                    >
+                      {theme.label}
+                    </button>
+                  </td>
+                  {CELL_HEADERS.map(({ key, label: cellLabel }) => {
+                    const count = theme.sentimentSplit[key];
+                    const isActiveCell =
+                      activeThemeLabel === theme.label && activeSentiment === key;
+                    const width = maxCellCount > 0 ? (count / maxCellCount) * 100 : 0;
+                    return (
+                      <td
+                        key={key}
+                        className={cn(
+                          "px-2 py-2 align-middle",
+                          dominant === key ? "bg-muted/10" : ""
+                        )}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => onCellClick(theme.label, isActiveCell ? null : key)}
+                          className={cn(
+                            "flex w-full flex-col items-center gap-1 rounded-md px-2 py-1 text-center transition-colors",
+                            "hover:bg-muted/40",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                            isActiveCell ? "ring-2 ring-primary/70 bg-muted/40" : ""
+                          )}
+                          aria-label={`Filter comments to ${theme.label} theme, ${cellLabel} sentiment, ${count} submissions`}
+                          aria-pressed={isActiveCell}
+                        >
+                          <span className="tabular-nums font-medium text-foreground">{count}</span>
+                          <span
+                            aria-hidden="true"
+                            className={cn(
+                              "h-1.5 w-full rounded-full",
+                              count > 0 ? SENTIMENT_COLORS[key] : "bg-muted"
+                            )}
+                            style={{ width: count > 0 ? `${Math.max(10, width)}%` : "100%" }}
+                          />
+                        </button>
+                      </td>
+                    );
+                  })}
+                  <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                    {theme.count}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/faculty-analytics/components/themes-ranked-list.tsx
+++ b/features/faculty-analytics/components/themes-ranked-list.tsx
@@ -1,17 +1,12 @@
 "use client";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import type { RankedTheme } from "@/features/faculty-analytics/lib/pipeline-themes";
+import type { QualitativeThemeDto } from "@/features/faculty-analytics/types";
 
 type ThemesRankedListProps = {
-  themes: RankedTheme[];
+  themes: QualitativeThemeDto[];
   maxVisible?: number;
 };
-
-function clamp01(n: number) {
-  if (!Number.isFinite(n)) return 0;
-  return Math.min(1, Math.max(0, n));
-}
 
 export function ThemesRankedList({ themes, maxVisible = 10 }: ThemesRankedListProps) {
   if (themes.length === 0) return null;
@@ -27,17 +22,18 @@ export function ThemesRankedList({ themes, maxVisible = 10 }: ThemesRankedListPr
       <CardContent>
         <ul className="space-y-3">
           {visible.map((theme) => {
-            const pos = clamp01(theme.sentimentBreakdown.positive) * 100;
-            const neu = clamp01(theme.sentimentBreakdown.neutral) * 100;
-            const neg = clamp01(theme.sentimentBreakdown.negative) * 100;
+            const { positive, neutral, negative } = theme.sentimentSplit;
+            const pos = theme.count > 0 ? (positive / theme.count) * 100 : 0;
+            const neu = theme.count > 0 ? (neutral / theme.count) * 100 : 0;
+            const neg = theme.count > 0 ? (negative / theme.count) * 100 : 0;
             return (
-              <li key={theme.topicLabel} className="space-y-1.5">
+              <li key={theme.themeId} className="space-y-1.5">
                 <div className="flex items-center justify-between gap-4">
                   <span className="font-sans text-sm font-medium text-foreground">
-                    {theme.topicLabel}
+                    {theme.label}
                   </span>
                   <span className="font-sans text-xs text-muted-foreground">
-                    {theme.commentCount} mention{theme.commentCount === 1 ? "" : "s"}
+                    {theme.count} mention{theme.count === 1 ? "" : "s"}
                   </span>
                 </div>
                 <div className="flex h-2 overflow-hidden rounded-full bg-muted">

--- a/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
+++ b/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
 
 import {
   buildFacultyReportHref,
@@ -13,11 +14,22 @@ import {
 import { useFacultyEnrollments } from "@/features/faculty-analytics/hooks/use-faculty-enrollments";
 import { useFacultyReportComments } from "@/features/faculty-analytics/hooks/use-faculty-report-comments";
 import { useFacultyReport } from "@/features/faculty-analytics/hooks/use-faculty-report";
-import type { FacultyReportCourseOption } from "@/features/faculty-analytics/types";
+import { useQualitativeSummary } from "@/features/faculty-analytics/hooks/use-qualitative-summary";
+import type { FacultyReportCourseOption, SentimentLabel } from "@/features/faculty-analytics/types";
 import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
 import { resolvePageSizeOption } from "@/lib/pagination";
 import { useActiveRole } from "@/features/auth/hooks/use-active-role";
 import { getRoleConfig } from "@/features/auth/lib/role-route";
+
+const VALID_SENTIMENTS: ReadonlySet<SentimentLabel> = new Set<SentimentLabel>([
+  "positive",
+  "neutral",
+  "negative",
+]);
+
+function isSentimentLabel(value: string | null): value is SentimentLabel {
+  return Boolean(value) && VALID_SENTIMENTS.has(value as SentimentLabel);
+}
 
 type UseFacultyReportDetailViewModelParams = {
   facultyId: string;
@@ -44,6 +56,11 @@ export function useFacultyReportDetailViewModel({
   );
   const commentsPage = resolvePositiveIntegerParam(searchParams.get("page"), 1);
   const commentsLimit = resolvePageSizeOption(searchParams.get("limit"), [5, 10, 20]);
+  const rawSentiment = searchParams.get("sentiment");
+  const sentimentFilter: SentimentLabel | null = isSentimentLabel(rawSentiment)
+    ? rawSentiment
+    : null;
+  const themeLabelFilter = searchParams.get("themeLabel");
 
   const questionnaireTypesQuery = useQuestionnaireTypes();
   const questionnaireTypes = useMemo(
@@ -101,6 +118,26 @@ export function useFacultyReportDetailViewModel({
           ),
         }
       : null);
+  const qualitativeSummaryQuery = useQualitativeSummary(
+    {
+      facultyId,
+      semesterId,
+      questionnaireTypeCode,
+      courseId: courseId || undefined,
+    },
+    { enabled: Boolean(semesterId && questionnaireTypeCode) }
+  );
+
+  const labelToId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const theme of qualitativeSummaryQuery.data?.themes ?? []) {
+      map.set(theme.label, theme.themeId);
+    }
+    return map;
+  }, [qualitativeSummaryQuery.data]);
+
+  const resolvedThemeId = themeLabelFilter ? (labelToId.get(themeLabelFilter) ?? null) : null;
+
   const commentsQuery = useFacultyReportComments(
     {
       facultyId,
@@ -109,6 +146,8 @@ export function useFacultyReportDetailViewModel({
       courseId: courseId || undefined,
       page: commentsPage,
       limit: commentsLimit,
+      sentiment: sentimentFilter ?? undefined,
+      themeId: resolvedThemeId ?? undefined,
     },
     { enabled: Boolean(semesterId) }
   );
@@ -157,10 +196,49 @@ export function useFacultyReportDetailViewModel({
     router,
   ]);
 
-  const updateSearchParams = (updates: Record<string, string | null>) => {
-    const nextHref = buildFacultyReportHref(pathname, currentSearchParams, updates);
-    router.replace(nextHref, { scroll: false });
-  };
+  const updateSearchParams = useCallback(
+    (updates: Record<string, string | null>) => {
+      const nextHref = buildFacultyReportHref(pathname, currentSearchParams, updates);
+      router.replace(nextHref, { scroll: false });
+    },
+    [currentSearchParams, pathname, router]
+  );
+
+  const updateSentimentFilter = useCallback(
+    (next: SentimentLabel | null) => {
+      updateSearchParams({ sentiment: next, page: null });
+    },
+    [updateSearchParams]
+  );
+
+  const updateThemeFilter = useCallback(
+    (next: string | null) => {
+      updateSearchParams({ themeLabel: next, page: null });
+    },
+    [updateSearchParams]
+  );
+
+  const clearAllFilters = useCallback(() => {
+    updateSearchParams({ sentiment: null, themeLabel: null, page: null });
+  }, [updateSearchParams]);
+
+  // F4: Silently strip unknown sentiment values from the URL before any API call.
+  useEffect(() => {
+    if (rawSentiment && !isSentimentLabel(rawSentiment)) {
+      updateSentimentFilter(null);
+    }
+  }, [rawSentiment, updateSentimentFilter]);
+
+  // Theme-label decay: clear when no match exists in the latest pipeline's themes.
+  useEffect(() => {
+    if (!themeLabelFilter || !qualitativeSummaryQuery.isSuccess) {
+      return;
+    }
+    if (!labelToId.has(themeLabelFilter)) {
+      updateThemeFilter(null);
+      toast.info("Theme not found in current analysis");
+    }
+  }, [themeLabelFilter, qualitativeSummaryQuery.isSuccess, labelToId, updateThemeFilter]);
 
   const report = reportQuery.data ?? null;
   const reportTitle = report?.faculty.name || facultyNameParam || "Faculty report";
@@ -180,6 +258,7 @@ export function useFacultyReportDetailViewModel({
     void questionnaireTypesQuery.refetch();
     void reportQuery.refetch();
     void commentsQuery.refetch();
+    void qualitativeSummaryQuery.refetch();
   };
 
   const { activeRole } = useActiveRole();
@@ -206,8 +285,15 @@ export function useFacultyReportDetailViewModel({
     commentsCount,
     reportQuery,
     commentsQuery,
+    qualitativeSummaryQuery,
     questionnaireTypesQuery,
     facultyEnrollmentsQuery,
+    sentimentFilter,
+    themeLabelFilter,
+    resolvedThemeId,
+    updateSentimentFilter,
+    updateThemeFilter,
+    clearAllFilters,
     isQuestionnaireTypeLoading: questionnaireTypesQuery.isLoading,
     isCourseLoading: facultyEnrollmentsQuery.isLoading,
     hasSemesterContext: Boolean(semesterId),

--- a/features/faculty-analytics/hooks/use-qualitative-summary.ts
+++ b/features/faculty-analytics/hooks/use-qualitative-summary.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchQualitativeSummary } from "@/features/faculty-analytics/api/faculty-analytics.requests";
+import type { QualitativeSummaryQuery } from "@/features/faculty-analytics/types";
+import { useAuthStore } from "@/stores/auth-store";
+
+type UseQualitativeSummaryOptions = {
+  enabled?: boolean;
+};
+
+export function useQualitativeSummary(
+  params: QualitativeSummaryQuery,
+  options?: UseQualitativeSummaryOptions
+) {
+  const token = useAuthStore((state) => state.token);
+  const isEnabled = options?.enabled ?? true;
+
+  return useQuery({
+    queryKey: [
+      "faculty-analytics",
+      "qualitative-summary",
+      params.facultyId,
+      params.semesterId,
+      params.questionnaireTypeCode,
+      params.courseId ?? "all",
+      token,
+    ],
+    enabled:
+      Boolean(token) &&
+      Boolean(params.facultyId) &&
+      Boolean(params.semesterId) &&
+      Boolean(params.questionnaireTypeCode) &&
+      isEnabled,
+    refetchOnWindowFocus: false,
+    queryFn: () => fetchQualitativeSummary(params),
+  });
+}

--- a/features/faculty-analytics/lib/theme-anchor.ts
+++ b/features/faculty-analytics/lib/theme-anchor.ts
@@ -1,0 +1,16 @@
+export function slugifyThemeLabel(label: string): string {
+  return label
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function themeRowAnchorId(label: string): string {
+  return `theme-row-${slugifyThemeLabel(label)}`;
+}
+
+export function recommendationAnchorId(label: string): string {
+  return `rec-action-${slugifyThemeLabel(label)}`;
+}

--- a/features/faculty-analytics/types/index.ts
+++ b/features/faculty-analytics/types/index.ts
@@ -222,9 +222,13 @@ export type FacultyReportQuery = {
   courseId?: string;
 };
 
+export type SentimentLabel = "positive" | "neutral" | "negative";
+
 export type FacultyReportCommentsQuery = FacultyReportQuery & {
   page?: number;
   limit?: number;
+  sentiment?: SentimentLabel;
+  themeId?: string;
 };
 
 export type FacultyReportFacultyDto = {
@@ -283,11 +287,43 @@ export type FacultyReportResponseDto = {
 export type FacultyReportCommentDto = {
   text: string;
   submittedAt: string;
+  sentiment?: SentimentLabel;
+  themeIds?: string[];
 };
 
 export type FacultyReportCommentsResponseDto = {
   items: FacultyReportCommentDto[];
   meta: PaginationMetaDto;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Qualitative Summary (FAC-134)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type SentimentDistributionDto = {
+  positive: number;
+  neutral: number;
+  negative: number;
+};
+
+export type QualitativeThemeDto = {
+  themeId: string;
+  label: string;
+  count: number;
+  sentimentSplit: SentimentDistributionDto;
+  sampleQuotes?: string[];
+};
+
+export type QualitativeSummaryResponseDto = {
+  sentimentDistribution: SentimentDistributionDto;
+  themes: QualitativeThemeDto[];
+};
+
+export type QualitativeSummaryQuery = {
+  facultyId: string;
+  semesterId: string;
+  questionnaireTypeCode: string;
+  courseId?: string;
 };
 
 export type FacultyReportCourseOption = {
@@ -334,6 +370,7 @@ export type PipelineScopeIds = {
   campusId?: string;
   courseId?: string;
   questionnaireVersionId?: string;
+  questionnaireTypeCode?: string;
 };
 
 // IDs + display values paired — shape of pipeline.status response's `scope`

--- a/network/endpoints.ts
+++ b/network/endpoints.ts
@@ -48,6 +48,7 @@ export enum Endpoints {
   analyticsAttention = "/api/v1/analytics/attention",
   analyticsFacultyReport = "/api/v1/analytics/faculty/:facultyId/report",
   analyticsFacultyReportComments = "/api/v1/analytics/faculty/:facultyId/report/comments",
+  analyticsFacultyQualitativeSummary = "/api/v1/analytics/faculty/:facultyId/qualitative-summary",
   reportsGenerate = "/api/v1/reports/generate",
   reportsGenerateBatch = "/api/v1/reports/generate/batch",
   reportsStatus = "/api/v1/reports/status/:jobId",


### PR DESCRIPTION
Closes #80

## Summary

Frontend for [api.faculytics FAC-134](https://github.com/CtrlAltElite-Devs/api.faculytics/pull/347). Re-architects the faculty analysis view around a theme-first qualitative surface, matching the established dashboard / faculty-list layout pattern.

- **Hero stats row** — dashboard-style 4-card layout (overall rating, interpretation, submissions, positive sentiment rate)
- **Sentiment distribution strip** with clickable segments for filtering
- **Theme explorer** — expandable ranked cards with pull-quote preview, per-theme paginated comments, inline suggested action, animated expand/collapse
- **General guidance** 2-column grid for non-theme-tied recommendations
- **Quantitative scores** (collapsed by default) wraps the existing section chart + sections table in an animated collapsible
- **Pipeline trigger card** surfaced inline (was previously hidden in a collapsible; now matches dashboard pattern)
- URL-synced `sentiment` + `themeLabel` filters with decay handling (invalid sentiment silently stripped; missing theme auto-cleared with toast)

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [ ] Manual verification on all three role routes: `/dean/faculties/:id/analysis`, `/campus-head/faculties/:id/analysis`, `/chairperson/faculties/:id/analysis` — same view renders identically
- [ ] Trigger a pipeline from the page, confirm status polling transitions sentiment strip → theme explorer as stages complete
- [ ] Click sentiment bar segment → URL reflects `?sentiment=negative`, theme-card comments filter correctly
- [ ] Expand a theme → per-theme comments load lazily; collapse → animation smooth
- [ ] Active filter chips (tethered in hero) clear individually and \"clear all\" works
- [ ] Reload with `?sentiment=invalid&themeLabel=NonexistentTheme` — invalid sentiment silently stripped, theme-label toast appears
- [ ] Dark mode sanity check
- [ ] Per-section table fits without horizontal scroll on wide screens (previous issue fixed by removing `max-w-6xl` centering)

## Related

- Frontend issue: #80
- Backend PR: https://github.com/CtrlAltElite-Devs/api.faculytics/pull/347
- Follow-up tickets filed on api.faculytics for companion work: FAC-135 (low-volume handling), FAC-136 (pipeline identity), FAC-137 (decouple recommendations), FAC-138 (prompt redesign), FAC-139 (multi-scope recs), FAC-140 (all-comments browser), FAC-141 (dimension radar)