### PR TITLE
[FEAT][FAC-WEB-32] add chairperson analytics dashboard parity

### DIFF
--- a/app/(dashboard)/chairperson/dashboard/page.tsx
+++ b/app/(dashboard)/chairperson/dashboard/page.tsx
@@ -1,10 +1,5 @@
+import { ScopedAnalyticsDashboardScreen } from "@/features/faculty-analytics";
+
 export default function ChairpersonDashboardPage() {
-  return (
-    <section className="md:p-8">
-      <h1 className="text-2xl font-semibold">Chairperson dashboard</h1>
-      <p className="mt-2 text-sm text-muted-foreground">
-        Chairperson analytics and summary views will appear here.
-      </p>
-    </section>
-  );
+  return <ScopedAnalyticsDashboardScreen scopeLabel="Program" />;
 }

--- a/features/auth/types/index.ts
+++ b/features/auth/types/index.ts
@@ -31,6 +31,18 @@ export type Campus = {
   code: string;
 };
 
+export type Department = {
+  id: string;
+  name?: string;
+  code: string;
+};
+
+export type Program = {
+  id: string;
+  name?: string;
+  code: string;
+};
+
 export type MeResponse = {
   id: string;
   userName: string;
@@ -41,4 +53,6 @@ export type MeResponse = {
   fullName: string;
   roles: string[];
   campus?: Campus;
+  program?: Program;
+  department?: Department;
 };

--- a/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
+++ b/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
@@ -10,6 +10,7 @@ import { ScopedMetricsGrid } from "@/features/faculty-analytics/components/scope
 import { PipelineTriggerCard } from "@/features/faculty-analytics/components/pipeline-trigger-card";
 import { RecommendationsCard } from "@/features/faculty-analytics/components/recommendations-card";
 import { ThemesRankedList } from "@/features/faculty-analytics/components/themes-ranked-list";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
 import { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
 import { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
@@ -37,7 +38,62 @@ function rankedThemesToQualitativeThemes(themes: RankedTheme[]): QualitativeThem
   });
 }
 
-export type ScopeLabel = "Campus" | "Department";
+export type ScopeLabel = "Campus" | "Department" | "Program";
+
+const SCOPE_METADATA: Record<
+  ScopeLabel,
+  {
+    scopeLower: string;
+    facultiesHref: string;
+  }
+> = {
+  Campus: {
+    scopeLower: "campus",
+    facultiesHref: "/campus-head/faculties",
+  },
+  Department: {
+    scopeLower: "department",
+    facultiesHref: "/dean/faculties",
+  },
+  Program: {
+    scopeLower: "program",
+    facultiesHref: "/chairperson/faculties",
+  },
+};
+
+function EmptyInsightsPlaceholder() {
+  return (
+    <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+      <Card className="rounded-2xl border-border/70 shadow-sm">
+        <CardHeader>
+          <CardTitle className="font-playfair text-xl">Top Themes</CardTitle>
+          <CardDescription>Ranked by comment volume with sentiment breakdown.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
+            <p className="max-w-sm font-sans text-sm text-muted-foreground">
+              Run analysis to surface the strongest feedback themes for this scope.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-2xl border-border/70 shadow-sm">
+        <CardHeader>
+          <CardTitle className="font-playfair text-xl">Suggested Actions</CardTitle>
+          <CardDescription>Concrete actions informed by the feedback themes above.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
+            <p className="max-w-sm font-sans text-sm text-muted-foreground">
+              Suggested actions will appear here after a completed analysis run.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
 
 export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: ScopeLabel }) {
   const {
@@ -85,9 +141,10 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
         : [],
     [recommendationsQuery.data]
   );
+  const showRecommendationPanels = liveStatus === "COMPLETED" && themes.length > 0;
+  const showEmptyInsightsPlaceholder = Boolean(selectedSemesterId) && !showRecommendationPanels;
 
-  const scopeLower = scopeLabel.toLowerCase();
-  const facultiesHref = scopeLabel === "Campus" ? "/campus-head/faculties" : "/dean/faculties";
+  const { scopeLower, facultiesHref } = SCOPE_METADATA[scopeLabel];
   const emptyStateDescription =
     semesters.length === 0
       ? "Semester options will appear here once academic terms are available."
@@ -143,7 +200,7 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
               />
             </div>
 
-            {liveStatus === "COMPLETED" && themes.length > 0 ? (
+            {showRecommendationPanels ? (
               <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
                 <ThemesRankedList themes={themes} />
                 {recommendationsQuery.data ? (
@@ -151,6 +208,8 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
                 ) : null}
               </div>
             ) : null}
+
+            {showEmptyInsightsPlaceholder ? <EmptyInsightsPlaceholder /> : null}
           </>
         )}
       </section>

--- a/features/faculty-analytics/components/scoped-attention-card.tsx
+++ b/features/faculty-analytics/components/scoped-attention-card.tsx
@@ -13,9 +13,21 @@ type ScopedAttentionCardProps = {
   items: AttentionItemDto[];
   isLoading?: boolean;
   hasAnalyticsData: boolean;
-  scopeLabel: "Campus" | "Department";
+  scopeLabel: "Campus" | "Department" | "Program";
   facultiesHref: string;
 };
+
+function getAttentionScopeCopy(scopeLabel: ScopedAttentionCardProps["scopeLabel"]) {
+  switch (scopeLabel) {
+    case "Campus":
+      return "Faculty in your campus flagged for review in the selected semester.";
+    case "Program":
+      return "Faculty in your assigned program scope flagged for review in the selected semester.";
+    case "Department":
+    default:
+      return "Faculty in your department flagged for review in the selected semester.";
+  }
+}
 
 const FLAG_STYLES: Record<
   AttentionFlagDto["type"],
@@ -83,7 +95,6 @@ export function ScopedAttentionCard({
   facultiesHref,
 }: ScopedAttentionCardProps) {
   const topItems = items.slice(0, 5);
-  const scopeLower = scopeLabel.toLowerCase();
 
   return (
     <Card className="rounded-2xl border-border/70 shadow-sm">
@@ -92,7 +103,7 @@ export function ScopedAttentionCard({
           Faculty Requiring Attention
         </CardTitle>
         <p className="font-sans text-sm text-muted-foreground">
-          Faculty in your {scopeLower} flagged for review in the selected semester.
+          {getAttentionScopeCopy(scopeLabel)}
         </p>
       </CardHeader>
       <CardContent>

--- a/features/faculty-analytics/components/scoped-dashboard-header.tsx
+++ b/features/faculty-analytics/components/scoped-dashboard-header.tsx
@@ -26,8 +26,20 @@ type ScopedDashboardHeaderProps = {
   selectedProgramLabel: string;
   onProgramChange: (value: string) => void;
   lastUpdatedLabel: string;
-  scopeLabel: "Campus" | "Department";
+  scopeLabel: "Campus" | "Department" | "Program";
 };
+
+function getScopeDescription(scopeLabel: ScopedDashboardHeaderProps["scopeLabel"]) {
+  switch (scopeLabel) {
+    case "Campus":
+      return "Monitor response volume and campus-level sentiment for the selected semester.";
+    case "Program":
+      return "Monitor response volume and program-level sentiment for your assigned scope in the selected semester.";
+    case "Department":
+    default:
+      return "Monitor response volume and department-level sentiment for the selected semester.";
+  }
+}
 
 export function ScopedDashboardHeader({
   semesters,
@@ -41,7 +53,6 @@ export function ScopedDashboardHeader({
   lastUpdatedLabel,
   scopeLabel,
 }: ScopedDashboardHeaderProps) {
-  const scopeLower = scopeLabel.toLowerCase();
   return (
     <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
       <div className="min-w-0">
@@ -49,7 +60,7 @@ export function ScopedDashboardHeader({
           {scopeLabel} Analytics Overview
         </h1>
         <p className="mt-4 max-w-3xl font-sans text-sm text-muted-foreground sm:mt-5">
-          Monitor response volume and {scopeLower}-level sentiment for the selected semester.
+          {getScopeDescription(scopeLabel)}
         </p>
       </div>
       <div className="w-full md:w-auto md:text-right">

--- a/features/faculty-analytics/components/scoped-faculty-analysis-table.tsx
+++ b/features/faculty-analytics/components/scoped-faculty-analysis-table.tsx
@@ -24,7 +24,7 @@ type ScopedFacultyAnalysisTableProps = {
   selectedSemesterLabel: string;
   onPageChange: (page: number) => void;
   onRowsPerPageChange: (value: number) => void;
-  scopeLabel: "Campus" | "Department";
+  scopeLabel: "Campus" | "Department" | "Program";
 };
 
 function getFacultyInitials(name: string) {

--- a/features/faculty-analytics/lib/faculty-analysis-routes.ts
+++ b/features/faculty-analytics/lib/faculty-analysis-routes.ts
@@ -6,7 +6,7 @@ type BuildScopedFacultyAnalysisHrefOptions = {
   semesterId: string;
   semesterLabel: string;
   questionnaireTypeCode?: string;
-  scopeLabel: "Campus" | "Department";
+  scopeLabel: "Campus" | "Department" | "Program";
 };
 
 export function buildScopedFacultyAnalysisHref({
@@ -24,6 +24,11 @@ export function buildScopedFacultyAnalysisHref({
     questionnaireTypeCode,
   });
 
-  const basePath = scopeLabel === "Campus" ? "/campus-head/faculties" : "/dean/faculties";
+  const basePath =
+    scopeLabel === "Campus"
+      ? "/campus-head/faculties"
+      : scopeLabel === "Program"
+        ? "/chairperson/faculties"
+        : "/dean/faculties";
   return `${basePath}/${facultyId}/analysis?${params.toString()}`;
 }

--- a/features/faculty-analytics/lib/scoped-analytics-view-model.ts
+++ b/features/faculty-analytics/lib/scoped-analytics-view-model.ts
@@ -57,14 +57,13 @@ export function mapSemesterOptionsToViewModel(
 }
 
 export function mapProgramOptionsToViewModel(programs: ProgramOptionDto[]): ScopedProgramOption[] {
-  return [
-    { id: null, code: null, label: ALL_PROGRAMS_LABEL },
-    ...programs.map((program) => ({
-      id: program.id,
-      code: program.code,
-      label: program.name?.trim() ? `${program.code} • ${program.name}` : program.code,
-    })),
-  ];
+  const mappedPrograms = programs.map((program) => ({
+    id: program.id,
+    code: program.code,
+    label: program.name?.trim() ? `${program.code} • ${program.name}` : program.code,
+  }));
+
+  return [{ id: null, code: null, label: ALL_PROGRAMS_LABEL }, ...mappedPrograms];
 }
 
 export function mapDepartmentOverviewToDashboardViewModel({


### PR DESCRIPTION
## Summary

- Replace the chairperson dashboard placeholder with the shared analytics dashboard screen
- Add program-scoped dashboard copy and route handling while keeping dean and campus-head behavior intact
- Align shared analytics helpers and auth typing to support chairperson dashboard parity
- Show empty placeholder panels for top themes and suggested actions before a completed analysis run

## Test Plan

- [x] `bun run typecheck`
- [x] `bun run lint 'features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx' 'features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model.ts' 'features/faculty-analytics/lib/scoped-analytics-view-model.ts' --quiet`
- [x] Manually verify `/chairperson/dashboard` renders the shared analytics dashboard instead of placeholder content
- [ ] Manually verify chairperson dashboard copy reads as program-scoped, not department-scoped
- [ ] Manually verify the program filter includes `All Programs` and remains scoped by backend authorization
- [ ] Manually verify pre-run placeholder cards for `Top Themes` and `Suggested Actions` appear before a completed pipeline run
- [ ] Manually verify dean `/dean/dashboard` behavior remains unchanged

Closes #83