### PR TITLE
[FEAT][FAC-WEB-33] add chairperson faculties list

### DIFF
--- a/app/(dashboard)/chairperson/faculties/[facultyId]/analysis/page.tsx
+++ b/app/(dashboard)/chairperson/faculties/[facultyId]/analysis/page.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+type ChairpersonFacultyAnalysisPlaceholderPageProps = {
+  params: Promise<{
+    facultyId: string;
+  }>;
+  searchParams: Promise<{
+    facultyName?: string;
+    semesterLabel?: string;
+  }>;
+};
+
+export default async function ChairpersonFacultyAnalysisPlaceholderPage({
+  params,
+  searchParams,
+}: ChairpersonFacultyAnalysisPlaceholderPageProps) {
+  const { facultyId } = await params;
+  const { facultyName, semesterLabel } = await searchParams;
+
+  return (
+    <section className="space-y-6 px-1 pb-4 md:p-8">
+      <div className="space-y-2">
+        <h1 className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl">
+          Faculty Analysis
+        </h1>
+        <p className="font-sans text-sm text-muted-foreground">
+          This chairperson faculty analysis page is a placeholder for now.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-border/70 bg-card p-5 shadow-sm">
+        <dl className="space-y-3 font-sans text-sm">
+          <div>
+            <dt className="text-muted-foreground">Faculty</dt>
+            <dd className="font-medium text-foreground">{facultyName ?? "Unknown faculty"}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Faculty ID</dt>
+            <dd className="font-medium text-foreground">{facultyId}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Semester</dt>
+            <dd className="font-medium text-foreground">{semesterLabel ?? "Not provided"}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <Button asChild variant="outline">
+        <Link href="/chairperson/faculties">Back to Faculties</Link>
+      </Button>
+    </section>
+  );
+}

--- a/app/(dashboard)/chairperson/faculties/page.tsx
+++ b/app/(dashboard)/chairperson/faculties/page.tsx
@@ -1,10 +1,5 @@
+import { ScopedFacultyListScreen } from "@/features/faculty-analytics";
+
 export default function ChairpersonFacultiesPage() {
-  return (
-    <section className="md:p-8">
-      <h1 className="text-2xl font-semibold">Chairperson Faculties</h1>
-      <p className="mt-2 text-sm text-muted-foreground">
-        Placeholder page for chairperson-scoped faculty views.
-      </p>
-    </section>
-  );
+  return <ScopedFacultyListScreen scopeLabel="Program" allowAllPrograms={false} />;
 }

--- a/features/faculty-analytics/components/scoped-faculty-analysis-table.tsx
+++ b/features/faculty-analytics/components/scoped-faculty-analysis-table.tsx
@@ -54,10 +54,10 @@ export function ScopedFacultyAnalysisTable({
               <TableHead className="data-table-head w-[28%] px-2 text-[11px] md:px-3 md:text-xs lg:px-5">
                 Faculty
               </TableHead>
-              <TableHead className="data-table-head w-[54%] px-2 text-[11px] md:px-3 md:text-xs lg:px-5">
+              <TableHead className="data-table-head w-[52%] px-2 text-[11px] md:w-[54%] md:px-3 md:text-xs lg:px-5">
                 Subjects
               </TableHead>
-              <TableHead className="data-table-head w-[18%] px-2 text-right text-[11px] md:px-3 md:text-xs lg:px-5">
+              <TableHead className="data-table-head w-[20%] px-2 text-right text-[11px] md:w-[18%] md:px-3 md:text-xs lg:px-5">
                 Action
               </TableHead>
             </TableRow>
@@ -67,7 +67,7 @@ export function ScopedFacultyAnalysisTable({
               <TableRow key={faculty.id} className="data-table-row w-full">
                 <TableCell className="data-table-cell px-2 md:px-3 lg:px-5">
                   <div className="flex min-w-0 items-center gap-3">
-                    <Avatar size="default" className="hidden border border-border/70 xl:flex">
+                    <Avatar size="default" className="border border-border/70">
                       {faculty.profilePicture ? (
                         <AvatarImage src={faculty.profilePicture} alt={faculty.fullName} />
                       ) : null}
@@ -90,7 +90,7 @@ export function ScopedFacultyAnalysisTable({
                     asChild
                     variant="secondary"
                     size="sm"
-                    className="h-auto max-w-full whitespace-normal px-3 py-2 text-center font-sans leading-tight"
+                    className="h-auto px-2 py-2 text-center font-sans text-xs leading-none md:px-3 md:text-sm"
                   >
                     <Link
                       href={buildScopedFacultyAnalysisHref({
@@ -100,9 +100,10 @@ export function ScopedFacultyAnalysisTable({
                         semesterLabel: selectedSemesterLabel,
                         scopeLabel,
                       })}
-                      className="block whitespace-normal text-center leading-tight"
+                      className="text-center leading-none"
                     >
-                      View Analysis
+                      <span className="sm:hidden">View</span>
+                      <span className="hidden sm:inline">View Analysis</span>
                     </Link>
                   </Button>
                 </TableCell>

--- a/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
+++ b/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
@@ -21,7 +21,15 @@ import {
 import { Input } from "@/components/ui/input";
 import type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-analytics-dashboard-screen";
 
-export function ScopedFacultyListScreen({ scopeLabel }: { scopeLabel: ScopeLabel }) {
+type ScopedFacultyListScreenProps = {
+  scopeLabel: ScopeLabel;
+  allowAllPrograms?: boolean;
+};
+
+export function ScopedFacultyListScreen({
+  scopeLabel,
+  allowAllPrograms = true,
+}: ScopedFacultyListScreenProps) {
   const [isBatchExportDialogOpen, setIsBatchExportDialogOpen] = useState(false);
   const {
     semesters,
@@ -41,7 +49,8 @@ export function ScopedFacultyListScreen({ scopeLabel }: { scopeLabel: ScopeLabel
     setSearchValue,
     setCurrentPage,
     setRowsPerPage,
-  } = useScopedFacultyAnalyticsListViewModel();
+  } = useScopedFacultyAnalyticsListViewModel({ allowAllPrograms });
+  const selectedProgramValue = selectedProgramId ?? (allowAllPrograms ? ALL_PROGRAMS_VALUE : "");
 
   return (
     <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
@@ -91,7 +100,7 @@ export function ScopedFacultyListScreen({ scopeLabel }: { scopeLabel: ScopeLabel
                 className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
               >
                 <DropdownMenuRadioGroup
-                  value={selectedProgramId ?? ALL_PROGRAMS_VALUE}
+                  value={selectedProgramValue}
                   onValueChange={setSelectedProgramId}
                 >
                   {programs.map((program) => (

--- a/features/faculty-analytics/hooks/use-scoped-faculty-analytics-list-view-model.ts
+++ b/features/faculty-analytics/hooks/use-scoped-faculty-analytics-list-view-model.ts
@@ -16,12 +16,19 @@ import {
 import { useProgramOptions } from "@/features/faculty-analytics/hooks/use-program-options";
 import { useSemesterOptions } from "@/features/faculty-analytics/hooks/use-semester-options";
 
-export function useScopedFacultyAnalyticsListViewModel() {
+type UseScopedFacultyAnalyticsListViewModelOptions = {
+  allowAllPrograms?: boolean;
+};
+
+export function useScopedFacultyAnalyticsListViewModel(
+  options?: UseScopedFacultyAnalyticsListViewModelOptions
+) {
   const [selectedSemesterIdState, setSelectedSemesterId] = useState<string | null>(null);
   const [selectedProgramIdState, setSelectedProgramId] = useState<string | null>(null);
   const [searchValue, setSearchValue] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState<number>(DEFAULT_PAGE_SIZE);
+  const allowAllPrograms = options?.allowAllPrograms ?? true;
 
   const deferredSearchValue = useDeferredValue(searchValue.trim());
   const meQuery = useMe();
@@ -45,8 +52,8 @@ export function useScopedFacultyAnalyticsListViewModel() {
     { enabled: Boolean(selectedSemesterId) }
   );
   const programs = useMemo(
-    () => mapProgramOptionsToViewModel(programOptionsQuery.data?.data ?? []),
-    [programOptionsQuery.data]
+    () => mapProgramOptionsToViewModel(programOptionsQuery.data?.data ?? [], allowAllPrograms),
+    [allowAllPrograms, programOptionsQuery.data]
   );
   const selectedProgram =
     programs.find((program) => program.id === selectedProgramIdState) ?? programs[0] ?? null;
@@ -60,7 +67,7 @@ export function useScopedFacultyAnalyticsListViewModel() {
       page: currentPage,
       limit: rowsPerPage,
     },
-    { enabled: Boolean(selectedSemesterId) }
+    { enabled: Boolean(selectedSemesterId) && (allowAllPrograms || Boolean(selectedProgramId)) }
   );
 
   const selectedSemester =
@@ -72,7 +79,8 @@ export function useScopedFacultyAnalyticsListViewModel() {
     selectedSemesterId,
     selectedSemesterLabel: selectedSemester?.label ?? "Select semester",
     selectedProgramId,
-    selectedProgramLabel: selectedProgram?.label ?? ALL_PROGRAMS_LABEL,
+    selectedProgramLabel:
+      selectedProgram?.label ?? (allowAllPrograms ? ALL_PROGRAMS_LABEL : "Select program"),
     facultyList: facultyListQuery.data?.data ?? [],
     pagination: facultyListQuery.data?.meta ?? {
       totalItems: 0,
@@ -113,7 +121,7 @@ export function useScopedFacultyAnalyticsListViewModel() {
       setCurrentPage(1);
     },
     setSelectedProgramId: (value: string) => {
-      setSelectedProgramId(value === ALL_PROGRAMS_VALUE ? null : value);
+      setSelectedProgramId(value === ALL_PROGRAMS_VALUE && allowAllPrograms ? null : value);
       setCurrentPage(1);
     },
     setSearchValue: (value: string) => {

--- a/features/faculty-analytics/lib/scoped-analytics-view-model.ts
+++ b/features/faculty-analytics/lib/scoped-analytics-view-model.ts
@@ -56,12 +56,19 @@ export function mapSemesterOptionsToViewModel(
   }));
 }
 
-export function mapProgramOptionsToViewModel(programs: ProgramOptionDto[]): ScopedProgramOption[] {
+export function mapProgramOptionsToViewModel(
+  programs: ProgramOptionDto[],
+  allowAllPrograms = true
+): ScopedProgramOption[] {
   const mappedPrograms = programs.map((program) => ({
     id: program.id,
     code: program.code,
     label: program.name?.trim() ? `${program.code} • ${program.name}` : program.code,
   }));
+
+  if (!allowAllPrograms) {
+    return mappedPrograms;
+  }
 
   return [{ id: null, code: null, label: ALL_PROGRAMS_LABEL }, ...mappedPrograms];
 }


### PR DESCRIPTION
## Summary
- replace the chairperson faculties placeholder with the shared scoped faculty list screen
- restrict chairperson faculties to explicit authorized program selection by removing the `All Programs` option
- add a temporary chairperson faculty analysis placeholder route and wire the list action to it

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] Open `/chairperson/faculties` and confirm the placeholder is gone
- [x] Confirm the chairperson program filter only shows authorized programs
- [x] Confirm the chairperson faculties list remains scoped to the selected program
- [x] Confirm the chairperson `View Analysis` action opens the placeholder route
- [x] Confirm dean and campus-head faculties pages still behave as before

Closes #85