### PR TITLE
FAC-WEB release: chairperson analytics + faculty tri-view with self-view redactions

### DIFF
--- a/app/(dashboard)/chairperson/dashboard/page.tsx
+++ b/app/(dashboard)/chairperson/dashboard/page.tsx
@@ -1,10 +1,5 @@
+import { ScopedAnalyticsDashboardScreen } from "@/features/faculty-analytics";
+
 export default function ChairpersonDashboardPage() {
-  return (
-    <section className="md:p-8">
-      <h1 className="text-2xl font-semibold">Chairperson dashboard</h1>
-      <p className="mt-2 text-sm text-muted-foreground">
-        Chairperson analytics and summary views will appear here.
-      </p>
-    </section>
-  );
+  return <ScopedAnalyticsDashboardScreen scopeLabel="Program" />;
 }

--- a/app/(dashboard)/chairperson/faculties/[facultyId]/analysis/page.tsx
+++ b/app/(dashboard)/chairperson/faculties/[facultyId]/analysis/page.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+type ChairpersonFacultyAnalysisPlaceholderPageProps = {
+  params: Promise<{
+    facultyId: string;
+  }>;
+  searchParams: Promise<{
+    facultyName?: string;
+    semesterLabel?: string;
+  }>;
+};
+
+export default async function ChairpersonFacultyAnalysisPlaceholderPage({
+  params,
+  searchParams,
+}: ChairpersonFacultyAnalysisPlaceholderPageProps) {
+  const { facultyId } = await params;
+  const { facultyName, semesterLabel } = await searchParams;
+
+  return (
+    <section className="space-y-6 px-1 pb-4 md:p-8">
+      <div className="space-y-2">
+        <h1 className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl">
+          Faculty Analysis
+        </h1>
+        <p className="font-sans text-sm text-muted-foreground">
+          This chairperson faculty analysis page is a placeholder for now.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-border/70 bg-card p-5 shadow-sm">
+        <dl className="space-y-3 font-sans text-sm">
+          <div>
+            <dt className="text-muted-foreground">Faculty</dt>
+            <dd className="font-medium text-foreground">{facultyName ?? "Unknown faculty"}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Faculty ID</dt>
+            <dd className="font-medium text-foreground">{facultyId}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Semester</dt>
+            <dd className="font-medium text-foreground">{semesterLabel ?? "Not provided"}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <Button asChild variant="outline">
+        <Link href="/chairperson/faculties">Back to Faculties</Link>
+      </Button>
+    </section>
+  );
+}

--- a/app/(dashboard)/chairperson/faculties/page.tsx
+++ b/app/(dashboard)/chairperson/faculties/page.tsx
@@ -1,10 +1,5 @@
+import { ScopedFacultyListScreen } from "@/features/faculty-analytics";
+
 export default function ChairpersonFacultiesPage() {
-  return (
-    <section className="md:p-8">
-      <h1 className="text-2xl font-semibold">Chairperson Faculties</h1>
-      <p className="mt-2 text-sm text-muted-foreground">
-        Placeholder page for chairperson-scoped faculty views.
-      </p>
-    </section>
-  );
+  return <ScopedFacultyListScreen scopeLabel="Program" allowAllPrograms={false} />;
 }

--- a/app/(dashboard)/faculty/analytics/page.tsx
+++ b/app/(dashboard)/faculty/analytics/page.tsx
@@ -1,8 +1,92 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { useMe } from "@/features/auth/hooks/use-me";
+import { FacultyReportScreen } from "@/features/faculty-analytics/components/faculty-report-screen";
+import { ScopedAnalyticsErrorState } from "@/features/faculty-analytics/components/scoped-analytics-error-state";
+import { ScopedAnalyticsLoadingState } from "@/features/faculty-analytics/components/scoped-analytics-loading-state";
+import { useSemesterOptions } from "@/features/faculty-analytics/hooks/use-semester-options";
+import { mapSemesterOptionsToViewModel } from "@/features/faculty-analytics/lib/scoped-analytics-view-model";
+
+// FAC-135 Phase D (Task D1): Faculty self-view entry point.
+//
+// Accessor choice: `me.data.id` is the canonical Faculty profile id used by
+// the API's AnalysisAccessService as the redaction pivot — see
+// `api.faculytics/src/modules/analysis/services/analysis-access.service.ts`
+// comment: "user.id === pipeline.faculty.id is the canonical matching
+// precedent". MeResponse does NOT carry a separate `facultyId` field; the
+// backend treats the auth user's id and the Faculty profile id as
+// equivalent for Faculty-role users.
 export default function FacultyAnalyticsPage() {
-  return (
-    <section className="md:p-8">
-      <h1 className="text-2xl font-semibold">Faculty Analytics</h1>
-      <p className="mt-2 text-sm text-muted-foreground">Placeholder page for faculty analytics.</p>
-    </section>
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const meQuery = useMe();
+
+  const campusId = meQuery.data?.campus?.id;
+  const semestersQuery = useSemesterOptions(campusId ? { campusId } : undefined, {
+    enabled: Boolean(campusId),
+  });
+
+  const semesters = useMemo(
+    () => mapSemesterOptionsToViewModel(semestersQuery.data?.data ?? []),
+    [semestersQuery.data]
   );
+
+  const urlSemesterId = searchParams.get("semesterId");
+
+  // Auto-resolve: when no semesterId is present in the URL (faculty landed
+  // directly on /faculty/analytics), pick the first available semester and
+  // inject it into the URL so the downstream view-model has context.
+  useEffect(() => {
+    if (urlSemesterId || semesters.length === 0) return;
+    const first = semesters[0];
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("semesterId", first.id);
+    params.set("semesterLabel", first.label);
+    router.replace(`${pathname}?${params.toString()}`);
+  }, [urlSemesterId, semesters, searchParams, pathname, router]);
+
+  if (meQuery.isLoading || (Boolean(campusId) && semestersQuery.isLoading)) {
+    return (
+      <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
+        <ScopedAnalyticsLoadingState message="Loading your analytics..." />
+      </section>
+    );
+  }
+
+  if (meQuery.isError || !meQuery.data) {
+    return (
+      <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
+        <ScopedAnalyticsErrorState
+          onRetry={() => void meQuery.refetch()}
+          message="Unable to load your profile. Please try again."
+        />
+      </section>
+    );
+  }
+
+  if (semesters.length === 0 && semestersQuery.isSuccess) {
+    return (
+      <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
+        <ScopedAnalyticsErrorState
+          onRetry={() => void semestersQuery.refetch()}
+          message="No semesters available for your campus yet."
+        />
+      </section>
+    );
+  }
+
+  // Wait for the redirect effect to inject semesterId into the URL.
+  if (!urlSemesterId) {
+    return (
+      <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
+        <ScopedAnalyticsLoadingState message="Loading your analytics..." />
+      </section>
+    );
+  }
+
+  return <FacultyReportScreen facultyId={meQuery.data.id} />;
 }

--- a/features/auth/types/index.ts
+++ b/features/auth/types/index.ts
@@ -31,6 +31,18 @@ export type Campus = {
   code: string;
 };
 
+export type Department = {
+  id: string;
+  name?: string;
+  code: string;
+};
+
+export type Program = {
+  id: string;
+  name?: string;
+  code: string;
+};
+
 export type MeResponse = {
   id: string;
   userName: string;
@@ -41,4 +53,6 @@ export type MeResponse = {
   fullName: string;
   roles: string[];
   campus?: Campus;
+  program?: Program;
+  department?: Department;
 };

--- a/features/faculty-analytics/api/faculty-analytics.requests.ts
+++ b/features/faculty-analytics/api/faculty-analytics.requests.ts
@@ -24,6 +24,8 @@ import type {
   QualitativeSummaryResponseDto,
   ReportStatusResponseDto,
   SemesterListResponseDto,
+  FacultyQuestionnaireTypesQuery,
+  FacultyQuestionnaireTypesResponseDto,
 } from "@/features/faculty-analytics/types";
 import type { MyEnrollmentsResponseDto } from "@/features/enrollments/types";
 
@@ -102,6 +104,18 @@ export async function fetchFacultyReportComments({
 export async function fetchQualitativeSummary({ facultyId, ...params }: QualitativeSummaryQuery) {
   const response = await apiClient.get<QualitativeSummaryResponseDto>(
     Endpoints.analyticsFacultyQualitativeSummary.replace(":facultyId", facultyId),
+    { params }
+  );
+
+  return response.data;
+}
+
+export async function getFacultyQuestionnaireTypes({
+  facultyId,
+  ...params
+}: FacultyQuestionnaireTypesQuery) {
+  const response = await apiClient.get<FacultyQuestionnaireTypesResponseDto>(
+    Endpoints.analyticsFacultyQuestionnaireTypes.replace(":facultyId", facultyId),
     { params }
   );
 

--- a/features/faculty-analytics/components/auto-correction-notice.tsx
+++ b/features/faculty-analytics/components/auto-correction-notice.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+type AutoCorrectionNoticeProps = {
+  requested: string;
+  actual: string;
+  paramLabel: string;
+  onDismiss?: () => void;
+};
+
+export function AutoCorrectionNotice({
+  requested,
+  actual,
+  paramLabel,
+  onDismiss,
+}: AutoCorrectionNoticeProps) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    onDismiss?.();
+  };
+
+  return (
+    <div
+      role="status"
+      className="flex items-start justify-between gap-3 rounded-lg border border-amber-300/70 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-700/70 dark:bg-amber-950/30 dark:text-amber-100"
+    >
+      <p className="font-sans leading-snug">
+        The <span className="font-medium">{requested}</span> {paramLabel} is not available for this
+        scope; showing <span className="font-medium">{actual}</span> instead.
+      </p>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="Dismiss notice"
+        onClick={handleDismiss}
+        className="-my-1 size-7 shrink-0 text-amber-900/70 hover:bg-amber-100/60 dark:text-amber-100/70"
+      >
+        <X className="size-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/features/faculty-analytics/components/faculty-report-header.tsx
+++ b/features/faculty-analytics/components/faculty-report-header.tsx
@@ -14,36 +14,23 @@ import {
 
 type FacultyReportHeaderProps = {
   backHref: string;
-  questionnaireTypeLabel: string;
-  questionnaireTypeCode: string;
   courseId: string;
   courseLabel: string;
-  availableQuestionnaireTypes: Array<{
-    code: string;
-    label: string;
-  }>;
   availableCourses: Array<{
     id: string;
     label: string;
   }>;
-  isQuestionnaireTypeLoading: boolean;
   isCourseLoading: boolean;
-  onQuestionnaireTypeChange: (value: string) => void;
   onCourseChange: (value: string) => void;
   onExport: () => void;
 };
 
 export function FacultyReportHeader({
   backHref,
-  questionnaireTypeLabel,
-  questionnaireTypeCode,
   courseId,
   courseLabel,
-  availableQuestionnaireTypes,
   availableCourses,
-  isQuestionnaireTypeLoading,
   isCourseLoading,
-  onQuestionnaireTypeChange,
   onCourseChange,
   onExport,
 }: FacultyReportHeaderProps) {
@@ -62,39 +49,6 @@ export function FacultyReportHeader({
       </Button>
 
       <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full min-w-0 justify-between border-stone-200 bg-white px-3 py-2 font-sans text-xs sm:w-56"
-              disabled={isQuestionnaireTypeLoading || availableQuestionnaireTypes.length === 0}
-            >
-              <span className="truncate text-stone-700">{questionnaireTypeLabel}</span>
-              <ChevronDown className="size-3.5 text-stone-400" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="end"
-            className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
-          >
-            <DropdownMenuRadioGroup
-              value={questionnaireTypeCode}
-              onValueChange={onQuestionnaireTypeChange}
-            >
-              {availableQuestionnaireTypes.map((type) => (
-                <DropdownMenuRadioItem
-                  key={type.code}
-                  value={type.code}
-                  className="font-sans text-sm"
-                >
-                  {type.label}
-                </DropdownMenuRadioItem>
-              ))}
-            </DropdownMenuRadioGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
-
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button

--- a/features/faculty-analytics/components/faculty-report-screen.tsx
+++ b/features/faculty-analytics/components/faculty-report-screen.tsx
@@ -4,22 +4,28 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
-import { FacultyAnalysisSentimentStrip } from "@/features/faculty-analytics/components/faculty-analysis-sentiment-strip";
-import { FacultyAnalysisStats } from "@/features/faculty-analytics/components/faculty-analysis-stats";
-import { FacultyReportComments } from "@/features/faculty-analytics/components/faculty-report-comments";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { AutoCorrectionNotice } from "@/features/faculty-analytics/components/auto-correction-notice";
+import { FeedbackTab } from "@/features/faculty-analytics/components/feedback-tab";
+import { HeadlineMetricsStrip } from "@/features/faculty-analytics/components/headline-metrics-strip";
+import { InsightsTab } from "@/features/faculty-analytics/components/insights-tab";
 import { PipelineTriggerCard } from "@/features/faculty-analytics/components/pipeline-trigger-card";
-import { QuantitativeScoresSection } from "@/features/faculty-analytics/components/quantitative-scores-section";
+import { ReportExportDialog } from "@/features/faculty-analytics/components/report-export-dialog";
 import { ScopedAnalyticsEmptyState } from "@/features/faculty-analytics/components/scoped-analytics-empty-state";
 import { ScopedAnalyticsErrorState } from "@/features/faculty-analytics/components/scoped-analytics-error-state";
 import { ScopedAnalyticsLoadingState } from "@/features/faculty-analytics/components/scoped-analytics-loading-state";
-import { ReportExportDialog } from "@/features/faculty-analytics/components/report-export-dialog";
-import { ThemeExplorerList } from "@/features/faculty-analytics/components/theme-explorer-list";
+import { ScoresTab } from "@/features/faculty-analytics/components/scores-tab";
 import { useFacultyReportDetailViewModel } from "@/features/faculty-analytics/hooks/use-faculty-report-detail-view-model";
 import { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
 import { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
 import { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
 import { hasFacultyReportAnalyticsData } from "@/features/faculty-analytics/lib/faculty-report-detail";
-import type { PipelineStatus } from "@/features/faculty-analytics/types";
+import {
+  REPORT_VIEW_LABELS,
+  REPORT_VIEW_ORDER,
+  type PipelineStatus,
+  type ReportView,
+} from "@/features/faculty-analytics/types";
 
 import { FacultyReportHeader } from "./faculty-report-header";
 
@@ -41,14 +47,13 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
   const pipelineScope = useMemo(
     () => ({
       semesterId: viewModel.semesterId ?? "",
-      facultyId,
-      questionnaireTypeCode: viewModel.questionnaireTypeCode || undefined,
-      courseId: viewModel.courseId || undefined,
+      scopeType: "FACULTY" as const,
+      scopeId: facultyId,
     }),
-    [viewModel.semesterId, viewModel.questionnaireTypeCode, viewModel.courseId, facultyId]
+    [viewModel.semesterId, facultyId]
   );
   const { latestPipeline } = useLatestPipelineForScope(pipelineScope, {
-    enabled: Boolean(viewModel.semesterId && viewModel.questionnaireTypeCode),
+    enabled: Boolean(viewModel.semesterId),
   });
   const pipelineStatusQuery = usePipelineStatus(latestPipeline?.id ?? null, {
     enabled: Boolean(latestPipeline?.id),
@@ -60,13 +65,15 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
   );
 
   const qualitativeSummary = viewModel.qualitativeSummaryQuery.data;
-  const themes = qualitativeSummary?.themes ?? [];
-  const actions = recommendationsQuery.data?.actions ?? [];
 
   const showSentimentSurface = livePipelineStatus
     ? SENTIMENT_READY_STATUSES.has(livePipelineStatus)
     : false;
   const showThemesSurface = livePipelineStatus === "COMPLETED";
+
+  // Stable disabled derivation: keyed on latestPipeline (not the polling
+  // status), so chips don't flicker mid-click.
+  const filtersDisabled = latestPipeline?.status !== "COMPLETED";
 
   const announcement = useMemo(() => {
     const parts: string[] = [];
@@ -86,7 +93,7 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
       <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
         <div className="flex justify-end">
           <Button asChild variant="outline" className="font-sans">
-            <Link href={viewModel.backHref}>Back to Faculties</Link>
+            <Link href={viewModel.backHref}>{viewModel.backLabel}</Link>
           </Button>
         </div>
         <ScopedAnalyticsErrorState
@@ -110,7 +117,7 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
       <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
         <div className="flex justify-end">
           <Button asChild variant="outline" className="font-sans">
-            <Link href={viewModel.backHref}>Back to Faculties</Link>
+            <Link href={viewModel.backHref}>{viewModel.backLabel}</Link>
           </Button>
         </div>
         <ScopedAnalyticsErrorState
@@ -139,107 +146,162 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
 
         <FacultyReportHeader
           backHref={viewModel.backHref}
-          questionnaireTypeLabel={viewModel.questionnaireTypeLabel}
-          questionnaireTypeCode={viewModel.questionnaireTypeCode}
           courseId={viewModel.courseId}
           courseLabel={viewModel.selectedCourseLabel}
-          availableQuestionnaireTypes={viewModel.availableQuestionnaireTypes}
           availableCourses={viewModel.availableCourses}
-          isQuestionnaireTypeLoading={viewModel.isQuestionnaireTypeLoading}
           isCourseLoading={viewModel.isCourseLoading}
-          onQuestionnaireTypeChange={viewModel.updateQuestionnaireType}
           onCourseChange={viewModel.updateCourse}
           onExport={() => setIsExportDialogOpen(true)}
         />
       </div>
 
+      <HeadlineMetricsStrip
+        overallRating={viewModel.report.overallRating}
+        overallInterpretation={viewModel.report.overallInterpretation}
+        responseCount={viewModel.report.submissionCount}
+        sentimentDistribution={
+          showSentimentSurface && qualitativeSummary
+            ? qualitativeSummary.sentimentDistribution
+            : null
+        }
+      />
+
       <div role="status" aria-live="polite" className="sr-only">
         {announcement}
       </div>
+
+      {viewModel.viewAutoCorrection ? (
+        <AutoCorrectionNotice
+          requested={viewModel.viewAutoCorrection.requested}
+          actual={viewModel.viewAutoCorrection.actual}
+          paramLabel="view"
+          onDismiss={viewModel.dismissViewAutoCorrection}
+        />
+      ) : null}
 
       {!hasAnalyticsData ? (
         <ScopedAnalyticsEmptyState description="No evaluation analytics are available for this faculty in the selected filters." />
       ) : (
         <>
-          {/* Analysis pipeline status — surfaced prominently, same pattern as
-              dashboard. Not hidden in a collapsible. */}
-          {viewModel.semesterId && viewModel.questionnaireTypeCode ? (
+          {viewModel.semesterId ? (
             <PipelineTriggerCard scope={pipelineScope} pipeline={latestPipeline} />
           ) : null}
 
-          <FacultyAnalysisStats
-            submissionCount={viewModel.report.submissionCount}
-            overallRating={viewModel.report.overallRating}
-            overallInterpretation={viewModel.report.overallInterpretation}
-            commentsCount={viewModel.commentsCount}
-            sentimentDistribution={
-              showSentimentSurface && qualitativeSummary
-                ? qualitativeSummary.sentimentDistribution
-                : null
+          <Tabs
+            value={
+              viewModel.isFacultySelfView && viewModel.selectedView === "feedback"
+                ? "insights"
+                : viewModel.selectedView
             }
-          />
+            onValueChange={(value) => viewModel.selectView(value as ReportView)}
+            className="w-full"
+          >
+            <TabsList variant="line" className="w-full gap-0 border-b border-border/40">
+              {REPORT_VIEW_ORDER.filter(
+                (view) => !(viewModel.isFacultySelfView && view === "feedback")
+              ).map((view) => (
+                <TabsTrigger
+                  key={view}
+                  value={view}
+                  className="px-4 py-2.5 font-sans text-sm tracking-tight after:bg-brand-blue data-[state=active]:text-brand-blue sm:px-5 dark:data-[state=active]:text-brand-blue"
+                >
+                  {REPORT_VIEW_LABELS[view]}
+                </TabsTrigger>
+              ))}
+            </TabsList>
 
-          {showSentimentSurface && qualitativeSummary ? (
-            <FacultyAnalysisSentimentStrip
-              distribution={qualitativeSummary.sentimentDistribution}
-              sentimentFilter={viewModel.sentimentFilter}
-              themeLabelFilter={viewModel.themeLabelFilter}
-              onSentimentClick={viewModel.updateSentimentFilter}
-              onClearSentiment={() => viewModel.updateSentimentFilter(null)}
-              onClearTheme={() => viewModel.updateThemeFilter(null)}
-              onClearAll={viewModel.clearAllFilters}
-            />
-          ) : null}
+            <TabsContent value="insights" className="mt-6">
+              <InsightsTab
+                facultyId={facultyId}
+                semesterId={viewModel.semesterId}
+                questionnaireTypeCode={viewModel.questionnaireTypeCode}
+                qualitativeSummary={qualitativeSummary}
+                recommendations={recommendationsQuery.data}
+                livePipelineStatus={livePipelineStatus}
+                showSentimentSurface={showSentimentSurface}
+                showThemesSurface={showThemesSurface}
+                sentimentFilter={viewModel.sentimentFilter}
+                themeLabelFilter={viewModel.themeLabelFilter}
+                onSentimentClick={viewModel.updateSentimentFilter}
+                onThemeClick={viewModel.updateThemeFilter}
+                onClearAllFilters={viewModel.clearAllFilters}
+                comments={viewModel.comments}
+                commentsMeta={viewModel.commentsMeta}
+                commentsPage={viewModel.commentsPage}
+                commentsLimit={viewModel.commentsLimit}
+                isCommentsLoading={viewModel.commentsQuery.isLoading}
+                isCommentsError={viewModel.commentsQuery.isError}
+                onCommentsRetry={viewModel.retryComments}
+                onCommentsPageChange={viewModel.updateCommentsPage}
+                onCommentsRowsPerPageChange={viewModel.updateCommentsLimit}
+                themeLabelAutoCorrection={viewModel.themeLabelAutoCorrection}
+                onDismissThemeLabelAutoCorrection={viewModel.dismissThemeLabelAutoCorrection}
+                redactComments={viewModel.isFacultySelfView}
+              />
+            </TabsContent>
 
-          {showThemesSurface && themes.length > 0 ? (
-            <ThemeExplorerList
-              themes={themes}
-              expandedThemeLabel={viewModel.themeLabelFilter}
-              onToggleTheme={viewModel.updateThemeFilter}
-              facultyId={facultyId}
-              semesterId={viewModel.semesterId}
-              questionnaireTypeCode={viewModel.questionnaireTypeCode}
-              courseId={viewModel.courseId || undefined}
-              sentimentFilter={viewModel.sentimentFilter}
-              actions={actions}
-            />
-          ) : showThemesSurface && themes.length === 0 && viewModel.comments.length > 0 ? (
-            <section>
-              <div className="max-w-3xl">
-                <h2 className="font-playfair text-xl font-semibold tracking-tight text-foreground">
-                  Student comments
-                </h2>
-                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                  No themes clustered from this analysis. The raw comments are below.
-                </p>
-              </div>
-              <div className="mt-4">
-                <FacultyReportComments
+            <TabsContent value="scores" className="mt-6">
+              <ScoresTab
+                report={viewModel.report}
+                semesterLabel={viewModel.semesterLabel}
+                questionnaireTypeLabel={viewModel.questionnaireTypeLabel}
+                availableQuestionnaireTypes={viewModel.availableQuestionnaireTypes}
+                selectedQuestionnaireTypeCode={viewModel.questionnaireTypeCode}
+                isQuestionnaireTypesLoading={viewModel.isQuestionnaireTypeLoading}
+                onQuestionnaireTypeSelect={viewModel.selectQuestionnaireType}
+                qualitativeSummary={qualitativeSummary}
+                showSentimentSurface={showSentimentSurface}
+                commentsCount={viewModel.commentsCount}
+                questionnaireTypeCodeAutoCorrection={viewModel.questionnaireTypeCodeAutoCorrection}
+                onDismissQuestionnaireTypeCodeAutoCorrection={
+                  viewModel.dismissQuestionnaireTypeCodeAutoCorrection
+                }
+                renderHeadlineStats={false}
+              />
+            </TabsContent>
+
+            {!viewModel.isFacultySelfView ? (
+              <TabsContent value="feedback" className="mt-6">
+                <FeedbackTab
+                  report={viewModel.report}
+                  semesterLabel={viewModel.semesterLabel}
+                  questionnaireTypeLabel={viewModel.questionnaireTypeLabel}
+                  availableQuestionnaireTypes={viewModel.availableQuestionnaireTypes}
+                  selectedQuestionnaireTypeCode={viewModel.questionnaireTypeCode}
+                  isQuestionnaireTypesLoading={viewModel.isQuestionnaireTypeLoading}
+                  onQuestionnaireTypeSelect={viewModel.selectQuestionnaireType}
+                  qualitativeSummary={qualitativeSummary}
+                  filtersDisabled={filtersDisabled}
+                  filtersDisabledReason={
+                    filtersDisabled
+                      ? "Run qualitative analysis to enable sentiment and topic filters."
+                      : undefined
+                  }
+                  sentimentFilter={viewModel.sentimentFilter}
+                  resolvedThemeId={viewModel.resolvedThemeId}
+                  onSentimentChange={viewModel.updateSentimentFilter}
+                  onThemeChange={viewModel.updateThemeFilter}
                   comments={viewModel.comments}
                   commentsMeta={viewModel.commentsMeta}
                   commentsPage={viewModel.commentsPage}
                   commentsLimit={viewModel.commentsLimit}
-                  isLoading={viewModel.commentsQuery.isLoading}
-                  isError={viewModel.commentsQuery.isError}
-                  onRetry={viewModel.retryComments}
-                  onPageChange={viewModel.updateCommentsPage}
-                  onRowsPerPageChange={viewModel.updateCommentsLimit}
+                  isCommentsLoading={viewModel.commentsQuery.isLoading}
+                  isCommentsError={viewModel.commentsQuery.isError}
+                  onCommentsRetry={viewModel.retryComments}
+                  onCommentsPageChange={viewModel.updateCommentsPage}
+                  onCommentsRowsPerPageChange={viewModel.updateCommentsLimit}
+                  questionnaireTypeCodeAutoCorrection={
+                    viewModel.questionnaireTypeCodeAutoCorrection
+                  }
+                  onDismissQuestionnaireTypeCodeAutoCorrection={
+                    viewModel.dismissQuestionnaireTypeCodeAutoCorrection
+                  }
+                  themeLabelAutoCorrection={viewModel.themeLabelAutoCorrection}
+                  onDismissThemeLabelAutoCorrection={viewModel.dismissThemeLabelAutoCorrection}
                 />
-              </div>
-            </section>
-          ) : showSentimentSurface ? (
-            <section className="rounded-2xl border border-dashed border-border bg-muted/30 px-6 py-10 text-center">
-              <p className="text-sm text-muted-foreground">
-                Sentiment analysis is ready. Themes and suggested actions will surface shortly.
-              </p>
-            </section>
-          ) : null}
-
-          <QuantitativeScoresSection
-            sections={viewModel.report.sections}
-            submissionCount={viewModel.report.submissionCount}
-            defaultOpen={false}
-          />
+              </TabsContent>
+            ) : null}
+          </Tabs>
         </>
       )}
 
@@ -250,7 +312,7 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
         facultyName={viewModel.report.faculty.name}
         semesterId={viewModel.semesterId}
         semesterLabel={viewModel.semesterLabel}
-        questionnaireTypeCode={viewModel.questionnaireTypeCode}
+        questionnaireTypeCode={viewModel.questionnaireTypeCode ?? ""}
         questionnaireTypeLabel={viewModel.questionnaireTypeLabel}
       />
     </section>

--- a/features/faculty-analytics/components/feedback-filter-bar.tsx
+++ b/features/faculty-analytics/components/feedback-filter-bar.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import type { QualitativeThemeDto, SentimentLabel } from "@/features/faculty-analytics/types";
+
+type FeedbackFilterBarProps = {
+  themes: QualitativeThemeDto[];
+  sentimentFilter: SentimentLabel | null;
+  resolvedThemeId: string | null;
+  onSentimentChange: (next: SentimentLabel | null) => void;
+  onThemeChange: (label: string | null) => void;
+  disabled?: boolean;
+  disabledReason?: string;
+};
+
+const SENTIMENT_OPTIONS: { value: SentimentLabel; label: string; chipClass: string }[] = [
+  {
+    value: "positive",
+    label: "Positive",
+    chipClass:
+      "data-[active=true]:bg-emerald-100 data-[active=true]:text-emerald-800 data-[active=true]:border-emerald-300",
+  },
+  {
+    value: "neutral",
+    label: "Neutral",
+    chipClass:
+      "data-[active=true]:bg-muted data-[active=true]:text-foreground data-[active=true]:border-border",
+  },
+  {
+    value: "negative",
+    label: "Negative",
+    chipClass:
+      "data-[active=true]:bg-rose-100 data-[active=true]:text-rose-800 data-[active=true]:border-rose-300",
+  },
+];
+
+export function FeedbackFilterBar({
+  themes,
+  sentimentFilter,
+  resolvedThemeId,
+  onSentimentChange,
+  onThemeChange,
+  disabled = false,
+  disabledReason,
+}: FeedbackFilterBarProps) {
+  const hasActiveFilters = sentimentFilter !== null || resolvedThemeId !== null;
+  const selectedTheme = themes.find((t) => t.themeId === resolvedThemeId) ?? null;
+
+  const handleSentimentClick = (next: SentimentLabel) => {
+    if (disabled) return;
+    onSentimentChange(sentimentFilter === next ? null : next);
+  };
+
+  const handleThemeChange = (themeId: string) => {
+    if (disabled) return;
+    if (themeId === "ALL") {
+      onThemeChange(null);
+      return;
+    }
+    const match = themes.find((t) => t.themeId === themeId);
+    onThemeChange(match?.label ?? null);
+  };
+
+  const handleClearAll = () => {
+    if (disabled) return;
+    onSentimentChange(null);
+    onThemeChange(null);
+  };
+
+  return (
+    <div className={cn("space-y-2", disabled && "opacity-60")}>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-sans text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+          Sentiment
+        </span>
+        {SENTIMENT_OPTIONS.map((option) => {
+          const isActive = sentimentFilter === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              data-active={isActive}
+              disabled={disabled}
+              onClick={() => handleSentimentClick(option.value)}
+              className={cn(
+                "rounded-full border border-border bg-background px-3 py-1 font-sans text-xs transition-colors",
+                "hover:bg-muted disabled:cursor-not-allowed disabled:hover:bg-background",
+                option.chipClass
+              )}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+
+        <span className="ml-2 font-sans text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+          Topic
+        </span>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="min-w-44 justify-between font-sans text-xs"
+              disabled={disabled || themes.length === 0}
+            >
+              <span className="truncate">{selectedTheme ? selectedTheme.label : "All topics"}</span>
+              <ChevronDown className="size-3.5 text-muted-foreground" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="max-h-72 w-64 overflow-auto">
+            <DropdownMenuRadioGroup
+              value={resolvedThemeId ?? "ALL"}
+              onValueChange={handleThemeChange}
+            >
+              <DropdownMenuRadioItem value="ALL" className="font-sans text-sm">
+                All topics
+              </DropdownMenuRadioItem>
+              {themes.map((theme) => (
+                <DropdownMenuRadioItem
+                  key={theme.themeId}
+                  value={theme.themeId}
+                  className="font-sans text-sm"
+                >
+                  {theme.label}
+                  <span className="ml-2 text-[10px] tabular-nums text-muted-foreground">
+                    · {theme.count}
+                  </span>
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {hasActiveFilters ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="ml-auto font-sans text-xs"
+            onClick={handleClearAll}
+            disabled={disabled}
+          >
+            Clear filters
+          </Button>
+        ) : null}
+      </div>
+
+      {disabled && disabledReason ? (
+        <p
+          role="status"
+          className="rounded-md border border-dashed border-border bg-muted/40 px-3 py-2 font-sans text-xs text-muted-foreground"
+        >
+          {disabledReason}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/features/faculty-analytics/components/feedback-tab.tsx
+++ b/features/faculty-analytics/components/feedback-tab.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { AutoCorrectionNotice } from "@/features/faculty-analytics/components/auto-correction-notice";
+import { FacultyReportComments } from "@/features/faculty-analytics/components/faculty-report-comments";
+import { FeedbackFilterBar } from "@/features/faculty-analytics/components/feedback-filter-bar";
+import { QuestionnaireTypeTabs } from "@/features/faculty-analytics/components/questionnaire-type-tabs";
+import { ScopedAnalyticsEmptyState } from "@/features/faculty-analytics/components/scoped-analytics-empty-state";
+import type {
+  FacultyQuestionnaireTypeOptionDto,
+  FacultyReportCommentDto,
+  FacultyReportResponseDto,
+  PaginationMetaDto,
+  QualitativeSummaryResponseDto,
+  SentimentLabel,
+} from "@/features/faculty-analytics/types";
+import type { ParamAutoCorrection } from "@/features/faculty-analytics/hooks/use-faculty-report-detail-view-model";
+
+type FeedbackTabProps = {
+  report: FacultyReportResponseDto | null;
+  semesterLabel: string;
+  questionnaireTypeLabel: string;
+  availableQuestionnaireTypes: FacultyQuestionnaireTypeOptionDto[];
+  selectedQuestionnaireTypeCode: string | null;
+  isQuestionnaireTypesLoading: boolean;
+  onQuestionnaireTypeSelect: (code: string) => void;
+  qualitativeSummary: QualitativeSummaryResponseDto | undefined;
+  /** Stable: derived from latestPipeline?.status, NOT the polling status. */
+  filtersDisabled: boolean;
+  filtersDisabledReason?: string;
+  sentimentFilter: SentimentLabel | null;
+  resolvedThemeId: string | null;
+  onSentimentChange: (next: SentimentLabel | null) => void;
+  onThemeChange: (label: string | null) => void;
+  comments: FacultyReportCommentDto[];
+  commentsMeta: PaginationMetaDto | null;
+  commentsPage: number;
+  commentsLimit: number;
+  isCommentsLoading: boolean;
+  isCommentsError: boolean;
+  onCommentsRetry: () => void;
+  onCommentsPageChange: (page: number) => void;
+  onCommentsRowsPerPageChange: (value: number) => void;
+  questionnaireTypeCodeAutoCorrection: ParamAutoCorrection | null;
+  onDismissQuestionnaireTypeCodeAutoCorrection: () => void;
+  themeLabelAutoCorrection: ParamAutoCorrection | null;
+  onDismissThemeLabelAutoCorrection: () => void;
+};
+
+export function FeedbackTab({
+  report,
+  semesterLabel,
+  questionnaireTypeLabel,
+  availableQuestionnaireTypes,
+  selectedQuestionnaireTypeCode,
+  isQuestionnaireTypesLoading,
+  onQuestionnaireTypeSelect,
+  qualitativeSummary,
+  filtersDisabled,
+  filtersDisabledReason,
+  sentimentFilter,
+  resolvedThemeId,
+  onSentimentChange,
+  onThemeChange,
+  comments,
+  commentsMeta,
+  commentsPage,
+  commentsLimit,
+  isCommentsLoading,
+  isCommentsError,
+  onCommentsRetry,
+  onCommentsPageChange,
+  onCommentsRowsPerPageChange,
+  questionnaireTypeCodeAutoCorrection,
+  onDismissQuestionnaireTypeCodeAutoCorrection,
+  themeLabelAutoCorrection,
+  onDismissThemeLabelAutoCorrection,
+}: FeedbackTabProps) {
+  const submissionCount = report?.submissionCount ?? 0;
+  const showEmpty = report !== null && submissionCount === 0;
+
+  return (
+    <div className="space-y-6">
+      {questionnaireTypeCodeAutoCorrection ? (
+        <AutoCorrectionNotice
+          requested={questionnaireTypeCodeAutoCorrection.requested}
+          actual={questionnaireTypeCodeAutoCorrection.actual}
+          paramLabel="questionnaire"
+          onDismiss={onDismissQuestionnaireTypeCodeAutoCorrection}
+        />
+      ) : null}
+
+      {themeLabelAutoCorrection ? (
+        <AutoCorrectionNotice
+          requested={themeLabelAutoCorrection.requested}
+          actual={themeLabelAutoCorrection.actual}
+          paramLabel="topic"
+          onDismiss={onDismissThemeLabelAutoCorrection}
+        />
+      ) : null}
+
+      <QuestionnaireTypeTabs
+        types={availableQuestionnaireTypes}
+        selectedCode={selectedQuestionnaireTypeCode}
+        onSelect={onQuestionnaireTypeSelect}
+        isLoading={isQuestionnaireTypesLoading}
+      />
+
+      {showEmpty ? (
+        <ScopedAnalyticsEmptyState
+          description={`No submissions for ${semesterLabel} · ${questionnaireTypeLabel}.`}
+        />
+      ) : (
+        <>
+          <FeedbackFilterBar
+            themes={qualitativeSummary?.themes ?? []}
+            sentimentFilter={sentimentFilter}
+            resolvedThemeId={resolvedThemeId}
+            onSentimentChange={onSentimentChange}
+            onThemeChange={onThemeChange}
+            disabled={filtersDisabled}
+            disabledReason={filtersDisabledReason}
+          />
+          <FacultyReportComments
+            comments={comments}
+            commentsMeta={commentsMeta}
+            commentsPage={commentsPage}
+            commentsLimit={commentsLimit}
+            isLoading={isCommentsLoading}
+            isError={isCommentsError}
+            onRetry={onCommentsRetry}
+            onPageChange={onCommentsPageChange}
+            onRowsPerPageChange={onCommentsRowsPerPageChange}
+            themes={qualitativeSummary?.themes}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/features/faculty-analytics/components/headline-metrics-strip.tsx
+++ b/features/faculty-analytics/components/headline-metrics-strip.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { AnimatedNumber } from "@/components/animated-number";
+import { getFacultyReportInterpretationTextClass } from "@/features/faculty-analytics/lib/faculty-report-detail";
+import { cn } from "@/lib/utils";
+import type { SentimentDistributionDto } from "@/features/faculty-analytics/types";
+
+type HeadlineMetricsStripProps = {
+  overallRating: number | null;
+  overallInterpretation: string | null;
+  responseCount: number | null;
+  sentimentDistribution: SentimentDistributionDto | null;
+};
+
+function SentimentMiniBar({ distribution }: { distribution: SentimentDistributionDto }) {
+  const total = distribution.positive + distribution.neutral + distribution.negative;
+  if (total === 0) return null;
+
+  const pct = (n: number) => `${(n / total) * 100}%`;
+
+  return (
+    <div
+      role="img"
+      aria-label={`${distribution.positive} positive, ${distribution.neutral} neutral, ${distribution.negative} negative`}
+      className="flex h-2 w-full max-w-xs overflow-hidden rounded-full bg-muted"
+    >
+      <span className="block bg-emerald-400" style={{ width: pct(distribution.positive) }} />
+      <span className="block bg-amber-300" style={{ width: pct(distribution.neutral) }} />
+      <span className="block bg-rose-400" style={{ width: pct(distribution.negative) }} />
+    </div>
+  );
+}
+
+export function HeadlineMetricsStrip({
+  overallRating,
+  overallInterpretation,
+  responseCount,
+  sentimentDistribution,
+}: HeadlineMetricsStripProps) {
+  const ratingCell = overallRating !== null;
+  const responseCell = responseCount !== null;
+  const sentimentCell =
+    sentimentDistribution !== null &&
+    sentimentDistribution.positive +
+      sentimentDistribution.neutral +
+      sentimentDistribution.negative >
+      0;
+
+  if (!ratingCell && !responseCell && !sentimentCell) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-8 gap-y-3 rounded-2xl border border-border/70 bg-card px-5 py-4">
+      {ratingCell ? (
+        <div className="min-w-0">
+          <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+            Overall rating
+          </p>
+          <div className="mt-1 flex items-baseline gap-2">
+            <span className="font-playfair text-2xl font-semibold tabular-nums text-foreground">
+              <AnimatedNumber value={overallRating!} decimals={2} />
+            </span>
+            {overallInterpretation ? (
+              <span
+                className={cn(
+                  "text-xs font-medium",
+                  getFacultyReportInterpretationTextClass(overallInterpretation)
+                )}
+              >
+                {overallInterpretation}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      {sentimentCell ? (
+        <div className="min-w-[180px]">
+          <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">Sentiment</p>
+          <div className="mt-2">
+            <SentimentMiniBar distribution={sentimentDistribution!} />
+          </div>
+        </div>
+      ) : null}
+
+      {responseCell ? (
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">Responses</p>
+          <p className="mt-1 font-playfair text-2xl font-semibold tabular-nums text-foreground">
+            <AnimatedNumber value={responseCount!} />
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/features/faculty-analytics/components/insights-tab.tsx
+++ b/features/faculty-analytics/components/insights-tab.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { AutoCorrectionNotice } from "@/features/faculty-analytics/components/auto-correction-notice";
+import { FacultyAnalysisSentimentStrip } from "@/features/faculty-analytics/components/faculty-analysis-sentiment-strip";
+import { FacultyReportComments } from "@/features/faculty-analytics/components/faculty-report-comments";
+import { RecommendationsCard } from "@/features/faculty-analytics/components/recommendations-card";
+import { ScopedAnalyticsEmptyState } from "@/features/faculty-analytics/components/scoped-analytics-empty-state";
+import { ThemeExplorerList } from "@/features/faculty-analytics/components/theme-explorer-list";
+import type {
+  FacultyReportCommentDto,
+  PaginationMetaDto,
+  PipelineStatus,
+  QualitativeSummaryResponseDto,
+  RecommendationsResponse,
+  SentimentLabel,
+} from "@/features/faculty-analytics/types";
+import type { ParamAutoCorrection } from "@/features/faculty-analytics/hooks/use-faculty-report-detail-view-model";
+
+type InsightsTabProps = {
+  facultyId: string;
+  semesterId: string;
+  questionnaireTypeCode: string | null;
+  qualitativeSummary: QualitativeSummaryResponseDto | undefined;
+  recommendations: RecommendationsResponse | undefined;
+  livePipelineStatus: PipelineStatus | undefined;
+  showSentimentSurface: boolean;
+  showThemesSurface: boolean;
+  sentimentFilter: SentimentLabel | null;
+  themeLabelFilter: string | null;
+  onSentimentClick: (next: SentimentLabel | null) => void;
+  onThemeClick: (label: string | null) => void;
+  onClearAllFilters: () => void;
+  comments: FacultyReportCommentDto[];
+  commentsMeta: PaginationMetaDto | null;
+  commentsPage: number;
+  commentsLimit: number;
+  isCommentsLoading: boolean;
+  isCommentsError: boolean;
+  onCommentsRetry: () => void;
+  onCommentsPageChange: (page: number) => void;
+  onCommentsRowsPerPageChange: (value: number) => void;
+  themeLabelAutoCorrection: ParamAutoCorrection | null;
+  onDismissThemeLabelAutoCorrection: () => void;
+  redactComments?: boolean;
+};
+
+export function InsightsTab({
+  facultyId,
+  semesterId,
+  questionnaireTypeCode,
+  qualitativeSummary,
+  recommendations,
+  livePipelineStatus,
+  showSentimentSurface,
+  showThemesSurface,
+  sentimentFilter,
+  themeLabelFilter,
+  onSentimentClick,
+  onThemeClick,
+  onClearAllFilters,
+  comments,
+  commentsMeta,
+  commentsPage,
+  commentsLimit,
+  isCommentsLoading,
+  isCommentsError,
+  onCommentsRetry,
+  onCommentsPageChange,
+  onCommentsRowsPerPageChange,
+  themeLabelAutoCorrection,
+  onDismissThemeLabelAutoCorrection,
+  redactComments,
+}: InsightsTabProps) {
+  const themes = useMemo(() => qualitativeSummary?.themes ?? [], [qualitativeSummary?.themes]);
+  const actions = useMemo(() => recommendations?.actions ?? [], [recommendations?.actions]);
+
+  const pipelineNotRun = !livePipelineStatus;
+
+  return (
+    <div className="space-y-6">
+      {themeLabelAutoCorrection ? (
+        <AutoCorrectionNotice
+          requested={themeLabelAutoCorrection.requested}
+          actual={themeLabelAutoCorrection.actual}
+          paramLabel="topic"
+          onDismiss={onDismissThemeLabelAutoCorrection}
+        />
+      ) : null}
+
+      {showSentimentSurface && qualitativeSummary ? (
+        <FacultyAnalysisSentimentStrip
+          distribution={qualitativeSummary.sentimentDistribution}
+          sentimentFilter={sentimentFilter}
+          themeLabelFilter={themeLabelFilter}
+          onSentimentClick={onSentimentClick}
+          onClearSentiment={() => onSentimentClick(null)}
+          onClearTheme={() => onThemeClick(null)}
+          onClearAll={onClearAllFilters}
+        />
+      ) : null}
+
+      {showThemesSurface && themes.length > 0 ? (
+        <section className="space-y-6">
+          <p className="max-w-3xl text-xs text-muted-foreground">
+            Themes and feedback are analyzed across all your courses to ensure reliable patterns.
+            Per-course breakdowns show quantitative ratings only.
+          </p>
+          <ThemeExplorerList
+            themes={themes}
+            expandedThemeLabel={themeLabelFilter}
+            onToggleTheme={onThemeClick}
+            facultyId={facultyId}
+            semesterId={semesterId}
+            questionnaireTypeCode={questionnaireTypeCode ?? ""}
+            sentimentFilter={sentimentFilter}
+            actions={actions}
+            redactComments={redactComments}
+          />
+          {recommendations ? <RecommendationsCard recommendations={recommendations} /> : null}
+        </section>
+      ) : showThemesSurface && themes.length === 0 && comments.length > 0 && !redactComments ? (
+        <section>
+          <div className="max-w-3xl">
+            <h2 className="font-playfair text-xl font-semibold tracking-tight text-foreground">
+              Student comments
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+              No themes clustered from this analysis. The raw comments are below.
+            </p>
+          </div>
+          <div className="mt-4">
+            <FacultyReportComments
+              comments={comments}
+              commentsMeta={commentsMeta}
+              commentsPage={commentsPage}
+              commentsLimit={commentsLimit}
+              isLoading={isCommentsLoading}
+              isError={isCommentsError}
+              onRetry={onCommentsRetry}
+              onPageChange={onCommentsPageChange}
+              onRowsPerPageChange={onCommentsRowsPerPageChange}
+            />
+          </div>
+        </section>
+      ) : showSentimentSurface ? (
+        <section className="rounded-2xl border border-dashed border-border bg-muted/30 px-6 py-10 text-center">
+          <p className="text-sm text-muted-foreground">
+            Sentiment analysis is ready. Themes and suggested actions will surface shortly.
+          </p>
+        </section>
+      ) : pipelineNotRun ? (
+        <ScopedAnalyticsEmptyState description="Run qualitative analysis to surface sentiment, themes, and recommended actions for this faculty member." />
+      ) : null}
+    </div>
+  );
+}

--- a/features/faculty-analytics/components/pipeline-confirm-dialog.tsx
+++ b/features/faculty-analytics/components/pipeline-confirm-dialog.tsx
@@ -11,7 +11,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import type { PipelineSummary } from "@/features/faculty-analytics/types";
+import { formatFacetLabel } from "@/features/faculty-analytics/lib/facet-filter";
+import type { Facet, PipelineSummary, VoiceBreakdown } from "@/features/faculty-analytics/types";
 
 type PipelineConfirmDialogProps = {
   open: boolean;
@@ -21,7 +22,28 @@ type PipelineConfirmDialogProps = {
   onCancel: () => void;
   isConfirming: boolean;
   isCancelling: boolean;
+  // FAC-135 Phase C (Task C9): optional composition row derived from
+  // coverage.voiceBreakdown. Hidden gracefully if absent.
+  voiceBreakdown?: VoiceBreakdown | null;
 };
+
+// Keys on VoiceBreakdown (deliberately narrower than Facet — excludes
+// `overall`, which is a UI-only aggregate label that has no coverage slice
+// on its own).
+type VoiceBreakdownKey = keyof VoiceBreakdown;
+
+const COMPOSITION_KEYS: readonly VoiceBreakdownKey[] = [
+  "facultyFeedback",
+  "inClassroom",
+  "outOfClassroom",
+  "other",
+];
+
+function compositionLabel(key: VoiceBreakdownKey): string {
+  if (key === "other") return "Other";
+  // All non-`other` keys are valid Facet values (overall excluded by design).
+  return formatFacetLabel(key as Facet);
+}
 
 function formatPercent(n: number): string {
   if (!Number.isFinite(n)) return "—";
@@ -36,12 +58,14 @@ export function PipelineConfirmDialog({
   onCancel,
   isConfirming,
   isCancelling,
+  voiceBreakdown,
 }: PipelineConfirmDialogProps) {
   if (!pipeline) return null;
 
   const coverage = pipeline.coverage;
   const warnings = pipeline.warnings ?? [];
   const busy = isConfirming || isCancelling;
+  const breakdown = voiceBreakdown ?? coverage.voiceBreakdown ?? null;
 
   return (
     <Dialog open={open} onOpenChange={busy ? undefined : onOpenChange}>
@@ -95,6 +119,25 @@ export function PipelineConfirmDialog({
             </p>
           </div>
         </div>
+
+        {breakdown ? (
+          <div className="rounded-xl border border-border/70 bg-muted/10 p-3">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+              Voice composition
+            </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {COMPOSITION_KEYS.map((key) => (
+                <span
+                  key={key}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-background px-2.5 py-1 font-sans text-[11px] text-muted-foreground"
+                >
+                  <span className="font-medium text-foreground">{compositionLabel(key)}</span>
+                  <span className="tabular-nums">{breakdown[key].submissionCount}</span>
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
 
         {warnings.length > 0 ? (
           <div className="rounded-xl border border-amber-500/40 bg-amber-50/70 p-4 dark:bg-amber-950/20">

--- a/features/faculty-analytics/components/pipeline-trigger-card.tsx
+++ b/features/faculty-analytics/components/pipeline-trigger-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   ActivityIcon,
@@ -51,6 +51,29 @@ const TRIGGER_ROLES: ReadonlySet<AppRole> = new Set<AppRole>([
   APP_ROLES.SUPER_ADMIN,
 ]);
 
+// FAC-135 Phase C (Task C10): auto-schedule banner formatter.
+// Uses Intl.DateTimeFormat (no new deps). When `iso` is nullish, returns
+// null — caller renders the generic fallback copy.
+function formatNextScheduled(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function AutoScheduleBanner({ iso }: { iso: string | null | undefined }) {
+  const formatted = formatNextScheduled(iso);
+  const copy = formatted ? `Next scheduled refresh: ${formatted}` : "Refreshes weekly on Mondays.";
+  return (
+    <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+      {copy}
+    </p>
+  );
+}
+
 function extractErrorMessage(err: unknown): string {
   if (
     typeof err === "object" &&
@@ -80,15 +103,31 @@ export function PipelineTriggerCard({ scope, pipeline, onStatusChange }: Pipelin
     if (liveStatus) onStatusChange?.(liveStatus);
   }, [liveStatus, onStatusChange]);
 
-  // Reactivity fix: when polling detects a terminal transition, refresh the
-  // list-pipelines-for-scope cache so `latestPipeline.status` in the parent
-  // screen becomes COMPLETED/FAILED/CANCELLED — which in turn unlocks the
-  // recommendations query gate so themes + recs render without refresh.
+  const previousStatusRef = useRef<PipelineStatus | undefined>(undefined);
+
+  // Transition-only invalidation: fire when liveStatus actually transitions
+  // into a terminal state (not on every mount where it is already terminal).
+  // Qualitative-summary refetch is narrowed to COMPLETED because FAILED /
+  // CANCELLED produce no new themes — refetching would clobber the
+  // previously-good cache for no benefit. See tech-spec Step C.
   useEffect(() => {
-    if (liveStatus && TERMINAL_STATUSES.has(liveStatus)) {
+    const previous = previousStatusRef.current;
+    previousStatusRef.current = liveStatus;
+
+    if (
+      liveStatus &&
+      TERMINAL_STATUSES.has(liveStatus) &&
+      previous !== undefined &&
+      previous !== liveStatus
+    ) {
       queryClient.invalidateQueries({
         queryKey: ["analysis", "list-pipelines-for-scope"],
       });
+      if (liveStatus === "COMPLETED") {
+        queryClient.invalidateQueries({
+          queryKey: ["faculty-analytics", "qualitative-summary"],
+        });
+      }
     }
   }, [liveStatus, queryClient]);
 
@@ -150,24 +189,42 @@ export function PipelineTriggerCard({ scope, pipeline, onStatusChange }: Pipelin
     });
   };
 
+  const nextScheduledRunAt = statusQuery.data?.nextScheduledRunAt ?? null;
+
   // ─── Faculty view ───────────────────────────────────────────────────────
   if (!canTrigger) {
-    if (!pipeline || !liveStatus) return null;
-    return (
-      <section className="flex items-center gap-3 rounded-2xl border border-border/70 bg-card px-5 py-4 shadow-sm">
-        <ActivityIcon className="size-4 text-muted-foreground" />
-        <div className="flex-1">
+    if (!pipeline || !liveStatus) {
+      // Still show the auto-schedule hint even when no pipeline exists yet.
+      return (
+        <section className="flex flex-col gap-1 rounded-2xl border border-border/70 bg-card px-5 py-4 shadow-sm">
           <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
             Analysis
           </p>
-          <p className="font-sans text-sm">
-            Last updated{" "}
-            <span className="font-mono tabular-nums">
-              {new Date(pipeline.updatedAt).toLocaleString()}
-            </span>
+          <p className="font-sans text-sm text-muted-foreground">
+            Your analysis will run automatically once student feedback is available.
           </p>
+          <AutoScheduleBanner iso={nextScheduledRunAt} />
+        </section>
+      );
+    }
+    return (
+      <section className="flex flex-col gap-3 rounded-2xl border border-border/70 bg-card px-5 py-4 shadow-sm">
+        <div className="flex items-center gap-3">
+          <ActivityIcon className="size-4 text-muted-foreground" />
+          <div className="flex-1">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+              Analysis
+            </p>
+            <p className="font-sans text-sm">
+              Last updated{" "}
+              <span className="font-mono tabular-nums">
+                {new Date(pipeline.updatedAt).toLocaleString()}
+              </span>
+            </p>
+          </div>
+          <PipelineStatusBadge status={liveStatus} />
         </div>
-        <PipelineStatusBadge status={liveStatus} />
+        <AutoScheduleBanner iso={nextScheduledRunAt} />
       </section>
     );
   }
@@ -314,11 +371,14 @@ export function PipelineTriggerCard({ scope, pipeline, onStatusChange }: Pipelin
         ) : null}
 
         <div className="flex flex-wrap items-center justify-between gap-3 px-6 pb-5 pt-5">
-          <p className="font-mono text-[11px] tabular-nums text-muted-foreground">
-            {pipeline
-              ? `Last updated ${new Date(pipeline.updatedAt).toLocaleString()}`
-              : "No previous run"}
-          </p>
+          <div className="flex flex-col gap-0.5">
+            <p className="font-mono text-[11px] tabular-nums text-muted-foreground">
+              {pipeline
+                ? `Last updated ${new Date(pipeline.updatedAt).toLocaleString()}`
+                : "No previous run"}
+            </p>
+            <AutoScheduleBanner iso={nextScheduledRunAt} />
+          </div>
           <div className="flex flex-wrap items-center gap-2">
             {/* Status dialog entry — available whenever a pipeline exists
                 (running OR terminal). Muted ghost style so it doesn't
@@ -383,6 +443,7 @@ export function PipelineTriggerCard({ scope, pipeline, onStatusChange }: Pipelin
         onCancel={handleCancelFromConfirm}
         isConfirming={confirmMutation.isPending}
         isCancelling={cancelMutation.isPending}
+        voiceBreakdown={statusQuery.data?.coverage.voiceBreakdown ?? null}
       />
 
       <PipelineStatusDialog

--- a/features/faculty-analytics/components/quantitative-scores-section.tsx
+++ b/features/faculty-analytics/components/quantitative-scores-section.tsx
@@ -12,16 +12,47 @@ type QuantitativeScoresSectionProps = {
   sections: FacultyReportSectionDto[];
   submissionCount: number;
   defaultOpen?: boolean;
+  /**
+   * When false, render chart + sections directly without the disclosure
+   * chrome. Used inside the Scores tab where the panel is already
+   * tab-scoped and collapse adds no value.
+   */
+  collapsible?: boolean;
 };
 
 export function QuantitativeScoresSection({
   sections,
   submissionCount,
   defaultOpen = false,
+  collapsible = true,
 }: QuantitativeScoresSectionProps) {
   const [open, setOpen] = useState(defaultOpen);
 
   if (sections.length === 0) return null;
+
+  if (!collapsible) {
+    return (
+      <section className="rounded-2xl border border-border/70 bg-card">
+        <div className="px-6 py-5">
+          <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+            Numerical scores
+          </p>
+          <h2 className="mt-1 text-lg font-semibold tracking-tight text-foreground">
+            Per-section performance
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Weighted averages across {sections.length} section
+            {sections.length === 1 ? "" : "s"} from {submissionCount} submission
+            {submissionCount === 1 ? "" : "s"}.
+          </p>
+        </div>
+        <div className="space-y-6 border-t border-border/70 px-6 py-6">
+          <FacultyReportSectionPerformanceChart sections={sections} />
+          <FacultyReportSections sections={sections} />
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="rounded-2xl border border-border/70 bg-card">

--- a/features/faculty-analytics/components/questionnaire-type-tabs.tsx
+++ b/features/faculty-analytics/components/questionnaire-type-tabs.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { FacultyQuestionnaireTypeOptionDto } from "@/features/faculty-analytics/types";
+
+type QuestionnaireTypeTabsProps = {
+  types: FacultyQuestionnaireTypeOptionDto[];
+  selectedCode: string | null;
+  onSelect: (code: string) => void;
+  isLoading?: boolean;
+};
+
+export function QuestionnaireTypeTabs({
+  types,
+  selectedCode,
+  onSelect,
+  isLoading,
+}: QuestionnaireTypeTabsProps) {
+  if (isLoading) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-8 w-24" />
+      </div>
+    );
+  }
+
+  if (types.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No questionnaire types with submissions for this scope.
+      </p>
+    );
+  }
+
+  const value = selectedCode ?? types[0].code;
+
+  return (
+    <Tabs value={value} onValueChange={(next) => onSelect(next)} className="w-full sm:w-auto">
+      <TabsList className="flex h-auto w-full flex-wrap gap-1 sm:w-auto">
+        {types.map((type) => (
+          <TabsTrigger
+            key={type.code}
+            value={type.code}
+            className="font-sans text-xs data-[state=active]:bg-brand-blue/10 data-[state=active]:text-brand-blue dark:data-[state=active]:bg-brand-blue/15 dark:data-[state=active]:text-brand-blue"
+          >
+            {type.name}
+            <span className="ml-1.5 text-[10px] tabular-nums text-muted-foreground">
+              · {type.submissionCount}
+            </span>
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/features/faculty-analytics/components/recommendations-card.tsx
+++ b/features/faculty-analytics/components/recommendations-card.tsx
@@ -130,9 +130,7 @@ export function RecommendationsCard({ recommendations, onViewTheme }: Recommenda
     return { strengths, improvements };
   }, [recommendations.actions]);
 
-  if (recommendations.actions.length === 0) {
-    return null;
-  }
+  if (recommendations.actions.length === 0) return null;
 
   return (
     <Card className="rounded-2xl border-border/70 shadow-sm">

--- a/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
+++ b/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
@@ -10,6 +10,7 @@ import { ScopedMetricsGrid } from "@/features/faculty-analytics/components/scope
 import { PipelineTriggerCard } from "@/features/faculty-analytics/components/pipeline-trigger-card";
 import { RecommendationsCard } from "@/features/faculty-analytics/components/recommendations-card";
 import { ThemesRankedList } from "@/features/faculty-analytics/components/themes-ranked-list";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
 import { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
 import { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
@@ -37,7 +38,62 @@ function rankedThemesToQualitativeThemes(themes: RankedTheme[]): QualitativeThem
   });
 }
 
-export type ScopeLabel = "Campus" | "Department";
+export type ScopeLabel = "Campus" | "Department" | "Program";
+
+const SCOPE_METADATA: Record<
+  ScopeLabel,
+  {
+    scopeLower: string;
+    facultiesHref: string;
+  }
+> = {
+  Campus: {
+    scopeLower: "campus",
+    facultiesHref: "/campus-head/faculties",
+  },
+  Department: {
+    scopeLower: "department",
+    facultiesHref: "/dean/faculties",
+  },
+  Program: {
+    scopeLower: "program",
+    facultiesHref: "/chairperson/faculties",
+  },
+};
+
+function EmptyInsightsPlaceholder() {
+  return (
+    <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+      <Card className="rounded-2xl border-border/70 shadow-sm">
+        <CardHeader>
+          <CardTitle className="font-playfair text-xl">Top Themes</CardTitle>
+          <CardDescription>Ranked by comment volume with sentiment breakdown.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
+            <p className="max-w-sm font-sans text-sm text-muted-foreground">
+              Run analysis to surface the strongest feedback themes for this scope.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-2xl border-border/70 shadow-sm">
+        <CardHeader>
+          <CardTitle className="font-playfair text-xl">Suggested Actions</CardTitle>
+          <CardDescription>Concrete actions informed by the feedback themes above.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
+            <p className="max-w-sm font-sans text-sm text-muted-foreground">
+              Suggested actions will appear here after a completed analysis run.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
 
 export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: ScopeLabel }) {
   const {
@@ -85,9 +141,10 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
         : [],
     [recommendationsQuery.data]
   );
+  const showRecommendationPanels = liveStatus === "COMPLETED" && themes.length > 0;
+  const showEmptyInsightsPlaceholder = Boolean(selectedSemesterId) && !showRecommendationPanels;
 
-  const scopeLower = scopeLabel.toLowerCase();
-  const facultiesHref = scopeLabel === "Campus" ? "/campus-head/faculties" : "/dean/faculties";
+  const { scopeLower, facultiesHref } = SCOPE_METADATA[scopeLabel];
   const emptyStateDescription =
     semesters.length === 0
       ? "Semester options will appear here once academic terms are available."
@@ -143,7 +200,7 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
               />
             </div>
 
-            {liveStatus === "COMPLETED" && themes.length > 0 ? (
+            {showRecommendationPanels ? (
               <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
                 <ThemesRankedList themes={themes} />
                 {recommendationsQuery.data ? (
@@ -151,6 +208,8 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
                 ) : null}
               </div>
             ) : null}
+
+            {showEmptyInsightsPlaceholder ? <EmptyInsightsPlaceholder /> : null}
           </>
         )}
       </section>

--- a/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
+++ b/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 
+import { useMe } from "@/features/auth/hooks/use-me";
 import { ScopedDashboardHeader } from "@/features/faculty-analytics/components/scoped-dashboard-header";
 import { ScopedAttentionCard } from "@/features/faculty-analytics/components/scoped-attention-card";
 import { ScopedOverallSentimentBarChart } from "@/features/faculty-analytics/components/scoped-charts";
@@ -14,6 +15,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
 import { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
 import { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
+import type { PipelineScopeIds } from "@/features/faculty-analytics/types";
 import {
   aggregateThemes,
   type RankedTheme,
@@ -116,8 +118,12 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
     retry,
   } = useScopedAnalyticsDashboardViewModel();
 
-  // No departmentId needed — the backend fills the DEAN/CAMPUS_HEAD's
-  // resolved scope per FAC-132 TD-2 List rules.
+  // FAC-135 Phase C: for LIST queries, scopeType/scopeId are optional — the
+  // backend resolves the DEAN/CAMPUS_HEAD's scope automatically. For CREATE
+  // we need an explicit scope (see `campusPipelineScope` below).
+  const meQuery = useMe();
+  const campusId = meQuery.data?.campus?.id ?? null;
+
   const pipelineQuery = useMemo(
     () => ({ semesterId: selectedSemesterId ?? "" }),
     [selectedSemesterId]
@@ -125,6 +131,20 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
   const { latestPipeline } = useLatestPipelineForScope(pipelineQuery, {
     enabled: Boolean(selectedSemesterId),
   });
+
+  // FAC-135 Phase C (Task C11): on Campus Head dashboards only, provide a
+  // CAMPUS scope for the trigger card so "Run campus-wide themes" posts the
+  // correct canonical shape. Dean dashboard suppresses the trigger card —
+  // AC26 ("Dean-on-/dean/dashboard must NOT see this button").
+  const campusPipelineScope: PipelineScopeIds | null = useMemo(() => {
+    if (scopeLabel !== "Campus") return null;
+    if (!selectedSemesterId || !campusId) return null;
+    return {
+      semesterId: selectedSemesterId,
+      scopeType: "CAMPUS",
+      scopeId: campusId,
+    };
+  }, [scopeLabel, selectedSemesterId, campusId]);
   // Poll status at the screen level so themes/recs gating reacts to the
   // live terminal transition — without this, `latestPipeline.status` comes
   // from the stale list cache and the completed-state UI doesn't appear
@@ -172,11 +192,12 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
           lastUpdatedLabel={lastUpdatedLabel}
         />
 
-        {selectedSemesterId ? (
-          <PipelineTriggerCard
-            scope={{ semesterId: selectedSemesterId }}
-            pipeline={latestPipeline}
-          />
+        {/* FAC-135 Phase C (Task C11 / AC26): campus-wide trigger only on
+            Campus Head dashboard. Dean dashboard intentionally omits this —
+            Dean-level pipelines are not supported under the current scope
+            tiers and trying to trigger one would 400 on the new DTO. */}
+        {campusPipelineScope ? (
+          <PipelineTriggerCard scope={campusPipelineScope} pipeline={latestPipeline} />
         ) : null}
 
         {semesters.length === 0 ? (

--- a/features/faculty-analytics/components/scoped-attention-card.tsx
+++ b/features/faculty-analytics/components/scoped-attention-card.tsx
@@ -13,9 +13,21 @@ type ScopedAttentionCardProps = {
   items: AttentionItemDto[];
   isLoading?: boolean;
   hasAnalyticsData: boolean;
-  scopeLabel: "Campus" | "Department";
+  scopeLabel: "Campus" | "Department" | "Program";
   facultiesHref: string;
 };
+
+function getAttentionScopeCopy(scopeLabel: ScopedAttentionCardProps["scopeLabel"]) {
+  switch (scopeLabel) {
+    case "Campus":
+      return "Faculty in your campus flagged for review in the selected semester.";
+    case "Program":
+      return "Faculty in your assigned program scope flagged for review in the selected semester.";
+    case "Department":
+    default:
+      return "Faculty in your department flagged for review in the selected semester.";
+  }
+}
 
 const FLAG_STYLES: Record<
   AttentionFlagDto["type"],
@@ -83,7 +95,6 @@ export function ScopedAttentionCard({
   facultiesHref,
 }: ScopedAttentionCardProps) {
   const topItems = items.slice(0, 5);
-  const scopeLower = scopeLabel.toLowerCase();
 
   return (
     <Card className="rounded-2xl border-border/70 shadow-sm">
@@ -92,7 +103,7 @@ export function ScopedAttentionCard({
           Faculty Requiring Attention
         </CardTitle>
         <p className="font-sans text-sm text-muted-foreground">
-          Faculty in your {scopeLower} flagged for review in the selected semester.
+          {getAttentionScopeCopy(scopeLabel)}
         </p>
       </CardHeader>
       <CardContent>

--- a/features/faculty-analytics/components/scoped-dashboard-header.tsx
+++ b/features/faculty-analytics/components/scoped-dashboard-header.tsx
@@ -26,8 +26,20 @@ type ScopedDashboardHeaderProps = {
   selectedProgramLabel: string;
   onProgramChange: (value: string) => void;
   lastUpdatedLabel: string;
-  scopeLabel: "Campus" | "Department";
+  scopeLabel: "Campus" | "Department" | "Program";
 };
+
+function getScopeDescription(scopeLabel: ScopedDashboardHeaderProps["scopeLabel"]) {
+  switch (scopeLabel) {
+    case "Campus":
+      return "Monitor response volume and campus-level sentiment for the selected semester.";
+    case "Program":
+      return "Monitor response volume and program-level sentiment for your assigned scope in the selected semester.";
+    case "Department":
+    default:
+      return "Monitor response volume and department-level sentiment for the selected semester.";
+  }
+}
 
 export function ScopedDashboardHeader({
   semesters,
@@ -41,7 +53,6 @@ export function ScopedDashboardHeader({
   lastUpdatedLabel,
   scopeLabel,
 }: ScopedDashboardHeaderProps) {
-  const scopeLower = scopeLabel.toLowerCase();
   return (
     <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
       <div className="min-w-0">
@@ -49,7 +60,7 @@ export function ScopedDashboardHeader({
           {scopeLabel} Analytics Overview
         </h1>
         <p className="mt-4 max-w-3xl font-sans text-sm text-muted-foreground sm:mt-5">
-          Monitor response volume and {scopeLower}-level sentiment for the selected semester.
+          {getScopeDescription(scopeLabel)}
         </p>
       </div>
       <div className="w-full md:w-auto md:text-right">

--- a/features/faculty-analytics/components/scoped-faculty-analysis-table.tsx
+++ b/features/faculty-analytics/components/scoped-faculty-analysis-table.tsx
@@ -24,7 +24,7 @@ type ScopedFacultyAnalysisTableProps = {
   selectedSemesterLabel: string;
   onPageChange: (page: number) => void;
   onRowsPerPageChange: (value: number) => void;
-  scopeLabel: "Campus" | "Department";
+  scopeLabel: "Campus" | "Department" | "Program";
 };
 
 function getFacultyInitials(name: string) {

--- a/features/faculty-analytics/components/scoped-faculty-analysis-table.tsx
+++ b/features/faculty-analytics/components/scoped-faculty-analysis-table.tsx
@@ -54,10 +54,10 @@ export function ScopedFacultyAnalysisTable({
               <TableHead className="data-table-head w-[28%] px-2 text-[11px] md:px-3 md:text-xs lg:px-5">
                 Faculty
               </TableHead>
-              <TableHead className="data-table-head w-[54%] px-2 text-[11px] md:px-3 md:text-xs lg:px-5">
+              <TableHead className="data-table-head w-[52%] px-2 text-[11px] md:w-[54%] md:px-3 md:text-xs lg:px-5">
                 Subjects
               </TableHead>
-              <TableHead className="data-table-head w-[18%] px-2 text-right text-[11px] md:px-3 md:text-xs lg:px-5">
+              <TableHead className="data-table-head w-[20%] px-2 text-right text-[11px] md:w-[18%] md:px-3 md:text-xs lg:px-5">
                 Action
               </TableHead>
             </TableRow>
@@ -67,7 +67,7 @@ export function ScopedFacultyAnalysisTable({
               <TableRow key={faculty.id} className="data-table-row w-full">
                 <TableCell className="data-table-cell px-2 md:px-3 lg:px-5">
                   <div className="flex min-w-0 items-center gap-3">
-                    <Avatar size="default" className="hidden border border-border/70 xl:flex">
+                    <Avatar size="default" className="border border-border/70">
                       {faculty.profilePicture ? (
                         <AvatarImage src={faculty.profilePicture} alt={faculty.fullName} />
                       ) : null}
@@ -90,7 +90,7 @@ export function ScopedFacultyAnalysisTable({
                     asChild
                     variant="secondary"
                     size="sm"
-                    className="h-auto max-w-full whitespace-normal px-3 py-2 text-center font-sans leading-tight"
+                    className="h-auto px-2 py-2 text-center font-sans text-xs leading-none md:px-3 md:text-sm"
                   >
                     <Link
                       href={buildScopedFacultyAnalysisHref({
@@ -100,9 +100,10 @@ export function ScopedFacultyAnalysisTable({
                         semesterLabel: selectedSemesterLabel,
                         scopeLabel,
                       })}
-                      className="block whitespace-normal text-center leading-tight"
+                      className="text-center leading-none"
                     >
-                      View Analysis
+                      <span className="sm:hidden">View</span>
+                      <span className="hidden sm:inline">View Analysis</span>
                     </Link>
                   </Button>
                 </TableCell>

--- a/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
+++ b/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
@@ -21,7 +21,15 @@ import {
 import { Input } from "@/components/ui/input";
 import type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-analytics-dashboard-screen";
 
-export function ScopedFacultyListScreen({ scopeLabel }: { scopeLabel: ScopeLabel }) {
+type ScopedFacultyListScreenProps = {
+  scopeLabel: ScopeLabel;
+  allowAllPrograms?: boolean;
+};
+
+export function ScopedFacultyListScreen({
+  scopeLabel,
+  allowAllPrograms = true,
+}: ScopedFacultyListScreenProps) {
   const [isBatchExportDialogOpen, setIsBatchExportDialogOpen] = useState(false);
   const {
     semesters,
@@ -41,7 +49,8 @@ export function ScopedFacultyListScreen({ scopeLabel }: { scopeLabel: ScopeLabel
     setSearchValue,
     setCurrentPage,
     setRowsPerPage,
-  } = useScopedFacultyAnalyticsListViewModel();
+  } = useScopedFacultyAnalyticsListViewModel({ allowAllPrograms });
+  const selectedProgramValue = selectedProgramId ?? (allowAllPrograms ? ALL_PROGRAMS_VALUE : "");
 
   return (
     <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
@@ -91,7 +100,7 @@ export function ScopedFacultyListScreen({ scopeLabel }: { scopeLabel: ScopeLabel
                 className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
               >
                 <DropdownMenuRadioGroup
-                  value={selectedProgramId ?? ALL_PROGRAMS_VALUE}
+                  value={selectedProgramValue}
                   onValueChange={setSelectedProgramId}
                 >
                   {programs.map((program) => (

--- a/features/faculty-analytics/components/scores-tab.tsx
+++ b/features/faculty-analytics/components/scores-tab.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { AutoCorrectionNotice } from "@/features/faculty-analytics/components/auto-correction-notice";
+import { FacultyAnalysisStats } from "@/features/faculty-analytics/components/faculty-analysis-stats";
+import { QuantitativeScoresSection } from "@/features/faculty-analytics/components/quantitative-scores-section";
+import { QuestionnaireTypeTabs } from "@/features/faculty-analytics/components/questionnaire-type-tabs";
+import { ScopedAnalyticsEmptyState } from "@/features/faculty-analytics/components/scoped-analytics-empty-state";
+import type {
+  FacultyQuestionnaireTypeOptionDto,
+  FacultyReportResponseDto,
+  QualitativeSummaryResponseDto,
+} from "@/features/faculty-analytics/types";
+import type { ParamAutoCorrection } from "@/features/faculty-analytics/hooks/use-faculty-report-detail-view-model";
+
+type ScoresTabProps = {
+  report: FacultyReportResponseDto | null;
+  semesterLabel: string;
+  questionnaireTypeLabel: string;
+  availableQuestionnaireTypes: FacultyQuestionnaireTypeOptionDto[];
+  selectedQuestionnaireTypeCode: string | null;
+  isQuestionnaireTypesLoading: boolean;
+  onQuestionnaireTypeSelect: (code: string) => void;
+  qualitativeSummary: QualitativeSummaryResponseDto | undefined;
+  showSentimentSurface: boolean;
+  commentsCount: number;
+  questionnaireTypeCodeAutoCorrection: ParamAutoCorrection | null;
+  onDismissQuestionnaireTypeCodeAutoCorrection: () => void;
+  /** When true, render FacultyAnalysisStats here (Phase A). When false, the
+   *  HeadlineMetricsStrip in the screen header carries headline metrics
+   *  (Phase B). */
+  renderHeadlineStats?: boolean;
+};
+
+export function ScoresTab({
+  report,
+  semesterLabel,
+  questionnaireTypeLabel,
+  availableQuestionnaireTypes,
+  selectedQuestionnaireTypeCode,
+  isQuestionnaireTypesLoading,
+  onQuestionnaireTypeSelect,
+  qualitativeSummary,
+  showSentimentSurface,
+  commentsCount,
+  questionnaireTypeCodeAutoCorrection,
+  onDismissQuestionnaireTypeCodeAutoCorrection,
+  renderHeadlineStats = true,
+}: ScoresTabProps) {
+  const submissionCount = report?.submissionCount ?? 0;
+  const showEmpty = report !== null && submissionCount === 0;
+
+  return (
+    <div className="space-y-6">
+      {questionnaireTypeCodeAutoCorrection ? (
+        <AutoCorrectionNotice
+          requested={questionnaireTypeCodeAutoCorrection.requested}
+          actual={questionnaireTypeCodeAutoCorrection.actual}
+          paramLabel="questionnaire"
+          onDismiss={onDismissQuestionnaireTypeCodeAutoCorrection}
+        />
+      ) : null}
+
+      <QuestionnaireTypeTabs
+        types={availableQuestionnaireTypes}
+        selectedCode={selectedQuestionnaireTypeCode}
+        onSelect={onQuestionnaireTypeSelect}
+        isLoading={isQuestionnaireTypesLoading}
+      />
+
+      {showEmpty ? (
+        <ScopedAnalyticsEmptyState
+          description={`No submissions for ${semesterLabel} · ${questionnaireTypeLabel}.`}
+        />
+      ) : report ? (
+        <>
+          {renderHeadlineStats ? (
+            <FacultyAnalysisStats
+              submissionCount={submissionCount}
+              overallRating={report.overallRating}
+              overallInterpretation={report.overallInterpretation}
+              commentsCount={commentsCount}
+              sentimentDistribution={
+                showSentimentSurface && qualitativeSummary
+                  ? qualitativeSummary.sentimentDistribution
+                  : null
+              }
+            />
+          ) : null}
+
+          <QuantitativeScoresSection
+            sections={report.sections}
+            submissionCount={submissionCount}
+            collapsible={false}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/features/faculty-analytics/components/theme-explorer-card.tsx
+++ b/features/faculty-analytics/components/theme-explorer-card.tsx
@@ -26,9 +26,9 @@ type ThemeExplorerCardProps = {
   facultyId: string;
   semesterId: string;
   questionnaireTypeCode: string;
-  courseId?: string;
   sentimentFilter: SentimentLabel | null;
   matchingAction: RecommendedActionDto | null;
+  redactComments?: boolean;
 };
 
 const DOMINANT_ACCENT: Record<SentimentLabel, string> = {
@@ -81,9 +81,9 @@ export function ThemeExplorerCard({
   facultyId,
   semesterId,
   questionnaireTypeCode,
-  courseId,
   sentimentFilter,
   matchingAction,
+  redactComments,
 }: ThemeExplorerCardProps) {
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(5);
@@ -100,17 +100,21 @@ export function ThemeExplorerCard({
       facultyId,
       semesterId,
       questionnaireTypeCode,
-      courseId,
       themeId: theme.themeId,
       sentiment: sentimentFilter ?? undefined,
       page,
       limit,
     },
-    { enabled: isExpanded }
+    { enabled: isExpanded && !redactComments }
   );
 
   const dominant = dominantSentiment(theme);
-  const previewQuote = theme.sampleQuotes?.[0] ?? null;
+  // FAC-135 Phase C (Task C12): when `sampleQuotes` is empty (server-side
+  // redaction in Faculty self-view, or no quotes available) we don't render
+  // a preview and surface a subtle note in the expanded body. Server is the
+  // canonical gate; this is cosmetic handling of the empty shape.
+  const hasSampleQuotes = (theme.sampleQuotes?.length ?? 0) > 0;
+  const previewQuote = hasSampleQuotes ? theme.sampleQuotes![0] : null;
 
   const totalSplit =
     theme.sentimentSplit.positive + theme.sentimentSplit.neutral + theme.sentimentSplit.negative;
@@ -199,7 +203,7 @@ export function ThemeExplorerCard({
           </div>
 
           {/* Pull-quote preview (readable sans, not serif) */}
-          {previewQuote && !isExpanded ? (
+          {previewQuote && !isExpanded && !redactComments ? (
             <blockquote className="mt-4 border-l-2 border-border pl-4 text-sm leading-relaxed text-muted-foreground">
               &ldquo;{previewQuote}&rdquo;
             </blockquote>
@@ -223,111 +227,123 @@ export function ThemeExplorerCard({
       >
         <div className="overflow-hidden">
           <div className="border-t border-border/70 bg-muted/30 px-6 pl-8 pb-8 pt-6">
-            <div className="grid gap-10 lg:grid-cols-[1fr_minmax(0,320px)]">
-              {/* LEFT — sample quotes + comments */}
-              <div className="min-w-0 space-y-8">
-                {theme.sampleQuotes && theme.sampleQuotes.length > 0 ? (
-                  <section>
-                    <h4 className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
-                      What students say
-                    </h4>
-                    <ul className="mt-4 space-y-4">
-                      {theme.sampleQuotes.map((quote, idx) => (
-                        <li key={idx} className="relative border-l-2 border-foreground/20 pl-5">
-                          <Quote
-                            className="absolute -left-2 top-0 h-3.5 w-3.5 -translate-x-1/2 bg-muted px-0.5 text-muted-foreground"
-                            aria-hidden
-                          />
-                          <p className="text-sm leading-relaxed text-foreground">{quote}</p>
-                        </li>
-                      ))}
-                    </ul>
-                  </section>
-                ) : null}
+            <div
+              className={cn(
+                "grid gap-10",
+                redactComments ? "lg:grid-cols-1" : "lg:grid-cols-[1fr_minmax(0,320px)]"
+              )}
+            >
+              {/* LEFT — sample quotes + comments (hidden for faculty self-view) */}
+              {!redactComments ? (
+                <div className="min-w-0 space-y-8">
+                  {hasSampleQuotes ? (
+                    <section>
+                      <h4 className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                        What students say
+                      </h4>
+                      <ul className="mt-4 space-y-4">
+                        {theme.sampleQuotes!.map((quote, idx) => (
+                          <li key={idx} className="relative border-l-2 border-foreground/20 pl-5">
+                            <Quote
+                              className="absolute -left-2 top-0 h-3.5 w-3.5 -translate-x-1/2 bg-muted px-0.5 text-muted-foreground"
+                              aria-hidden
+                            />
+                            <p className="text-sm leading-relaxed text-foreground">{quote}</p>
+                          </li>
+                        ))}
+                      </ul>
+                    </section>
+                  ) : (
+                    // FAC-135 Phase C (Task C12): redacted / no-quotes path.
+                    <p className="text-xs italic text-muted-foreground">
+                      Individual comments are not available in your view.
+                    </p>
+                  )}
 
-                <section>
-                  <div className="flex items-baseline justify-between gap-4">
-                    <h4 className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
-                      All comments in this theme
-                      {sentimentFilter ? (
-                        <span className="ml-2 normal-case tracking-normal text-muted-foreground/70">
-                          · filtered to {SENTIMENT_LABEL[sentimentFilter]}
+                  <section>
+                    <div className="flex items-baseline justify-between gap-4">
+                      <h4 className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                        All comments in this theme
+                        {sentimentFilter ? (
+                          <span className="ml-2 normal-case tracking-normal text-muted-foreground/70">
+                            · filtered to {SENTIMENT_LABEL[sentimentFilter]}
+                          </span>
+                        ) : null}
+                      </h4>
+                      {meta ? (
+                        <span className="text-xs tabular-nums text-muted-foreground">
+                          {meta.totalItems} total
                         </span>
                       ) : null}
-                    </h4>
-                    {meta ? (
-                      <span className="text-xs tabular-nums text-muted-foreground">
-                        {meta.totalItems} total
-                      </span>
-                    ) : null}
-                  </div>
+                    </div>
 
-                  <div className="mt-4">
-                    {commentsQuery.isLoading ? (
-                      <ScopedAnalyticsLoadingState message="Loading comments..." />
-                    ) : commentsQuery.isError ? (
-                      <ScopedAnalyticsErrorState
-                        onRetry={() => void commentsQuery.refetch()}
-                        message="Unable to load comments for this theme."
-                      />
-                    ) : comments.length === 0 ? (
-                      <p className="rounded-xl border border-dashed border-border bg-background/60 px-4 py-6 text-center text-sm text-muted-foreground">
-                        No comments match the current filter in this theme.
-                      </p>
-                    ) : (
-                      <>
-                        <ul className="space-y-3">
-                          {comments.map((c, idx) => (
-                            <li
-                              key={`${c.submittedAt}-${idx}`}
-                              className="rounded-xl border border-border/70 bg-card px-4 py-3"
-                            >
-                              <div className="flex items-baseline justify-between gap-4">
-                                <div className="flex flex-wrap items-center gap-2">
-                                  {c.sentiment ? (
-                                    <Badge
-                                      variant="outline"
-                                      className={cn(
-                                        "rounded-full px-2 py-0.5 text-[0.65rem] uppercase tracking-wider",
-                                        SENTIMENT_COMMENT_BADGE[c.sentiment]
-                                      )}
-                                    >
-                                      {SENTIMENT_LABEL[c.sentiment]}
-                                    </Badge>
-                                  ) : null}
+                    <div className="mt-4">
+                      {commentsQuery.isLoading ? (
+                        <ScopedAnalyticsLoadingState message="Loading comments..." />
+                      ) : commentsQuery.isError ? (
+                        <ScopedAnalyticsErrorState
+                          onRetry={() => void commentsQuery.refetch()}
+                          message="Unable to load comments for this theme."
+                        />
+                      ) : comments.length === 0 ? (
+                        <p className="rounded-xl border border-dashed border-border bg-background/60 px-4 py-6 text-center text-sm text-muted-foreground">
+                          No comments match the current filter in this theme.
+                        </p>
+                      ) : (
+                        <>
+                          <ul className="space-y-3">
+                            {comments.map((c, idx) => (
+                              <li
+                                key={`${c.submittedAt}-${idx}`}
+                                className="rounded-xl border border-border/70 bg-card px-4 py-3"
+                              >
+                                <div className="flex items-baseline justify-between gap-4">
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    {c.sentiment ? (
+                                      <Badge
+                                        variant="outline"
+                                        className={cn(
+                                          "rounded-full px-2 py-0.5 text-[0.65rem] uppercase tracking-wider",
+                                          SENTIMENT_COMMENT_BADGE[c.sentiment]
+                                        )}
+                                      >
+                                        {SENTIMENT_LABEL[c.sentiment]}
+                                      </Badge>
+                                    ) : null}
+                                  </div>
+                                  <span className="text-xs text-muted-foreground">
+                                    {formatDateTime(c.submittedAt)}
+                                  </span>
                                 </div>
-                                <span className="text-xs text-muted-foreground">
-                                  {formatDateTime(c.submittedAt)}
-                                </span>
-                              </div>
-                              <p className="mt-2 text-sm leading-relaxed text-foreground">
-                                {c.text}
-                              </p>
-                            </li>
-                          ))}
-                        </ul>
-                        {meta && meta.totalPages > 1 ? (
-                          <div className="mt-5">
-                            <PaginationFooter
-                              itemCount={meta.itemCount}
-                              totalItems={meta.totalItems}
-                              currentPage={meta.currentPage}
-                              totalPages={meta.totalPages}
-                              itemLabel="comments"
-                              rowsPerPage={limit}
-                              onRowsPerPageChange={(n) => {
-                                setLimit(n);
-                                setPage(1);
-                              }}
-                              onPageChange={setPage}
-                            />
-                          </div>
-                        ) : null}
-                      </>
-                    )}
-                  </div>
-                </section>
-              </div>
+                                <p className="mt-2 text-sm leading-relaxed text-foreground">
+                                  {c.text}
+                                </p>
+                              </li>
+                            ))}
+                          </ul>
+                          {meta && meta.totalPages > 1 ? (
+                            <div className="mt-5">
+                              <PaginationFooter
+                                itemCount={meta.itemCount}
+                                totalItems={meta.totalItems}
+                                currentPage={meta.currentPage}
+                                totalPages={meta.totalPages}
+                                itemLabel="comments"
+                                rowsPerPage={limit}
+                                onRowsPerPageChange={(n) => {
+                                  setLimit(n);
+                                  setPage(1);
+                                }}
+                                onPageChange={setPage}
+                              />
+                            </div>
+                          ) : null}
+                        </>
+                      )}
+                    </div>
+                  </section>
+                </div>
+              ) : null}
 
               {/* RIGHT — suggested action + meta */}
               <aside className="space-y-6">
@@ -370,42 +386,44 @@ export function ThemeExplorerCard({
                   </section>
                 )}
 
-                <section>
-                  <h4 className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
-                    Sentiment breakdown
-                  </h4>
-                  <dl className="mt-4 space-y-3 text-sm">
-                    {(["negative", "neutral", "positive"] as SentimentLabel[]).map((s) => {
-                      const count = theme.sentimentSplit[s];
-                      const pct = totalSplit > 0 ? Math.round((count / totalSplit) * 100) : 0;
-                      return (
-                        <div key={s} className="space-y-1">
-                          <div className="flex items-center justify-between text-muted-foreground">
-                            <span className="flex items-center gap-2">
+                {!redactComments ? (
+                  <section>
+                    <h4 className="text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                      Sentiment breakdown
+                    </h4>
+                    <dl className="mt-4 space-y-3 text-sm">
+                      {(["negative", "neutral", "positive"] as SentimentLabel[]).map((s) => {
+                        const count = theme.sentimentSplit[s];
+                        const pct = totalSplit > 0 ? Math.round((count / totalSplit) * 100) : 0;
+                        return (
+                          <div key={s} className="space-y-1">
+                            <div className="flex items-center justify-between text-muted-foreground">
+                              <span className="flex items-center gap-2">
+                                <span
+                                  className={cn(
+                                    "inline-block h-2 w-2 rounded-full",
+                                    SEGMENT_COLOR[s]
+                                  )}
+                                />
+                                {SENTIMENT_LABEL[s]}
+                              </span>
+                              <span className="tabular-nums">
+                                <span className="font-medium text-foreground">{count}</span>
+                                <span className="text-muted-foreground/70"> · {pct}%</span>
+                              </span>
+                            </div>
+                            <div className="h-1 overflow-hidden rounded-full bg-muted">
                               <span
-                                className={cn(
-                                  "inline-block h-2 w-2 rounded-full",
-                                  SEGMENT_COLOR[s]
-                                )}
+                                className={cn("block h-full", SEGMENT_COLOR[s])}
+                                style={{ width: `${pct}%` }}
                               />
-                              {SENTIMENT_LABEL[s]}
-                            </span>
-                            <span className="tabular-nums">
-                              <span className="font-medium text-foreground">{count}</span>
-                              <span className="text-muted-foreground/70"> · {pct}%</span>
-                            </span>
+                            </div>
                           </div>
-                          <div className="h-1 overflow-hidden rounded-full bg-muted">
-                            <span
-                              className={cn("block h-full", SEGMENT_COLOR[s])}
-                              style={{ width: `${pct}%` }}
-                            />
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </dl>
-                </section>
+                        );
+                      })}
+                    </dl>
+                  </section>
+                ) : null}
               </aside>
             </div>
           </div>

--- a/features/faculty-analytics/components/theme-explorer-list.tsx
+++ b/features/faculty-analytics/components/theme-explorer-list.tsx
@@ -20,9 +20,9 @@ type ThemeExplorerListProps = {
   facultyId: string;
   semesterId: string;
   questionnaireTypeCode: string;
-  courseId?: string;
   sentimentFilter: SentimentLabel | null;
   actions: RecommendedActionDto[];
+  redactComments?: boolean;
 };
 
 const PRIORITY_VARIANT: Record<
@@ -48,9 +48,9 @@ export function ThemeExplorerList({
   facultyId,
   semesterId,
   questionnaireTypeCode,
-  courseId,
   sentimentFilter,
   actions,
+  redactComments,
 }: ThemeExplorerListProps) {
   const { actionByTheme, generalActions } = useMemo(() => {
     const byLabel = new Map<string, RecommendedActionDto>();
@@ -107,9 +107,9 @@ export function ThemeExplorerList({
               facultyId={facultyId}
               semesterId={semesterId}
               questionnaireTypeCode={questionnaireTypeCode}
-              courseId={courseId}
               sentimentFilter={sentimentFilter}
               matchingAction={actionByTheme.get(theme.label) ?? null}
+              redactComments={redactComments}
             />
           ))}
         </div>

--- a/features/faculty-analytics/hooks/use-faculty-questionnaire-types.ts
+++ b/features/faculty-analytics/hooks/use-faculty-questionnaire-types.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getFacultyQuestionnaireTypes } from "@/features/faculty-analytics/api/faculty-analytics.requests";
+import type {
+  FacultyQuestionnaireTypesQuery,
+  FacultyQuestionnaireTypesResponseDto,
+} from "@/features/faculty-analytics/types";
+import { useAuthStore } from "@/stores/auth-store";
+
+type UseFacultyQuestionnaireTypesOptions = {
+  enabled?: boolean;
+};
+
+export function useFacultyQuestionnaireTypes(
+  params: FacultyQuestionnaireTypesQuery,
+  options?: UseFacultyQuestionnaireTypesOptions
+) {
+  const token = useAuthStore((state) => state.token);
+  const isEnabled = options?.enabled ?? true;
+
+  return useQuery<FacultyQuestionnaireTypesResponseDto>({
+    queryKey: ["faculty-analytics", "faculty-questionnaire-types", params, token],
+    enabled: Boolean(token) && Boolean(params.facultyId) && Boolean(params.semesterId) && isEnabled,
+    queryFn: () => getFacultyQuestionnaireTypes(params),
+  });
+}

--- a/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
+++ b/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
@@ -1,25 +1,34 @@
 "use client";
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { toast } from "sonner";
 
 import {
   buildFacultyReportHref,
   formatFacultyReportCourseLabel,
+  isInvalidViewParam,
   resolveFacultyReportQuestionnaireTypeCode,
   resolveFacultyReportQuestionnaireTypeLabel,
   resolvePositiveIntegerParam,
+  resolveView,
 } from "@/features/faculty-analytics/lib/faculty-report-detail";
 import { useFacultyEnrollments } from "@/features/faculty-analytics/hooks/use-faculty-enrollments";
 import { useFacultyReportComments } from "@/features/faculty-analytics/hooks/use-faculty-report-comments";
 import { useFacultyReport } from "@/features/faculty-analytics/hooks/use-faculty-report";
+import { useFacultyQuestionnaireTypes } from "@/features/faculty-analytics/hooks/use-faculty-questionnaire-types";
 import { useQualitativeSummary } from "@/features/faculty-analytics/hooks/use-qualitative-summary";
-import type { FacultyReportCourseOption, SentimentLabel } from "@/features/faculty-analytics/types";
+import {
+  DEFAULT_REPORT_VIEW,
+  type FacultyQuestionnaireTypeOptionDto,
+  type FacultyReportCourseOption,
+  type ReportView,
+  type SentimentLabel,
+} from "@/features/faculty-analytics/types";
 import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
 import { resolvePageSizeOption } from "@/lib/pagination";
 import { useActiveRole } from "@/features/auth/hooks/use-active-role";
 import { getRoleConfig } from "@/features/auth/lib/role-route";
+import { APP_ROLES } from "@/constants/roles";
 
 const VALID_SENTIMENTS: ReadonlySet<SentimentLabel> = new Set<SentimentLabel>([
   "positive",
@@ -30,6 +39,11 @@ const VALID_SENTIMENTS: ReadonlySet<SentimentLabel> = new Set<SentimentLabel>([
 function isSentimentLabel(value: string | null): value is SentimentLabel {
   return Boolean(value) && VALID_SENTIMENTS.has(value as SentimentLabel);
 }
+
+export type ParamAutoCorrection = {
+  requested: string;
+  actual: string;
+};
 
 type UseFacultyReportDetailViewModelParams = {
   facultyId: string;
@@ -51,9 +65,9 @@ export function useFacultyReportDetailViewModel({
   const semesterId = searchParams.get("semesterId") ?? "";
   const semesterLabelParam = searchParams.get("semesterLabel") ?? "Selected semester";
   const courseId = searchParams.get("courseId") ?? "";
-  const questionnaireTypeCode = resolveFacultyReportQuestionnaireTypeCode(
-    searchParams.get("questionnaireTypeCode")
-  );
+  const rawQuestionnaireTypeCode = searchParams.get("questionnaireTypeCode");
+  const rawViewParam = searchParams.get("view");
+  const selectedView: ReportView = resolveView(rawViewParam);
   const commentsPage = resolvePositiveIntegerParam(searchParams.get("page"), 1);
   const commentsLimit = resolvePageSizeOption(searchParams.get("limit"), [5, 10, 20]);
   const rawSentiment = searchParams.get("sentiment");
@@ -61,18 +75,52 @@ export function useFacultyReportDetailViewModel({
     ? rawSentiment
     : null;
   const themeLabelFilter = searchParams.get("themeLabel");
+  const rawFacetParam = searchParams.get("facet");
 
-  const questionnaireTypesQuery = useQuestionnaireTypes();
-  const questionnaireTypes = useMemo(
-    () => questionnaireTypesQuery.data ?? [],
-    [questionnaireTypesQuery.data]
+  const globalQuestionnaireTypesQuery = useQuestionnaireTypes();
+  const globalQuestionnaireTypes = useMemo(
+    () => globalQuestionnaireTypesQuery.data ?? [],
+    [globalQuestionnaireTypesQuery.data]
   );
+
+  // Per-faculty per-semester counts (Task 4 hook). Distinct from the global
+  // registry above — this drives the questionnaire-type secondary tabs.
+  const availableQuestionnaireTypesQuery = useFacultyQuestionnaireTypes(
+    { facultyId, semesterId },
+    { enabled: Boolean(semesterId) }
+  );
+  const availableQuestionnaireTypes = useMemo<FacultyQuestionnaireTypeOptionDto[]>(
+    () => availableQuestionnaireTypesQuery.data?.items ?? [],
+    [availableQuestionnaireTypesQuery.data]
+  );
+
+  // Derive the active questionnaire type from URL ⊕ default. `fromUrl` is
+  // always a non-empty string (resolveFacultyReportQuestionnaireTypeCode
+  // falls back to DEFAULT_QUESTIONNAIRE_TYPE when the URL param is missing).
+  // We return `fromUrl` both while the available-types query is still loading
+  // AND when the URL's code simply isn't in the faculty's list — the outer
+  // `queriesReady` gate prevents premature fetches during loading, and
+  // returning `fromUrl` instead of `null` guarantees `params.questionnaireTypeCode`
+  // is NEVER the empty string at the hook site, which is the load-bearing
+  // invariant that keeps downstream queries from shipping `questionnaireTypeCode=`
+  // to the backend under any invalidation/refetch bypass of the `enabled` guard.
+  const questionnaireTypeCode = useMemo<string>(() => {
+    const fromUrl = resolveFacultyReportQuestionnaireTypeCode(rawQuestionnaireTypeCode);
+    const stillValid = availableQuestionnaireTypes.some((option) => option.code === fromUrl);
+    if (stillValid) return fromUrl;
+    return availableQuestionnaireTypes[0]?.code ?? fromUrl;
+  }, [rawQuestionnaireTypeCode, availableQuestionnaireTypes]);
+
+  const isQuestionnaireTypesResolving =
+    Boolean(semesterId) && availableQuestionnaireTypesQuery.isLoading;
+  const queriesReady =
+    Boolean(semesterId) && Boolean(questionnaireTypeCode) && !isQuestionnaireTypesResolving;
+
   const selectedQuestionnaireType =
-    questionnaireTypes.find((type) => type.code === questionnaireTypeCode) ?? null;
-  const availableQuestionnaireTypes = questionnaireTypes.map((type) => ({
-    code: type.code,
-    label: resolveFacultyReportQuestionnaireTypeLabel(type.code, type.name),
-  }));
+    availableQuestionnaireTypes.find((type) => type.code === questionnaireTypeCode) ??
+    globalQuestionnaireTypes.find((type) => type.code === questionnaireTypeCode) ??
+    null;
+
   const facultyEnrollmentsQuery = useFacultyEnrollments(
     {
       facultyId,
@@ -105,7 +153,7 @@ export function useFacultyReportDetailViewModel({
       questionnaireTypeCode,
       courseId: courseId || undefined,
     },
-    { enabled: Boolean(semesterId) }
+    { enabled: queriesReady }
   );
   const selectedCourse =
     availableCourses.find((course) => course.id === courseId) ??
@@ -118,14 +166,14 @@ export function useFacultyReportDetailViewModel({
           ),
         }
       : null);
+
   const qualitativeSummaryQuery = useQualitativeSummary(
     {
       facultyId,
       semesterId,
       questionnaireTypeCode,
-      courseId: courseId || undefined,
     },
-    { enabled: Boolean(semesterId && questionnaireTypeCode) }
+    { enabled: queriesReady }
   );
 
   const labelToId = useMemo(() => {
@@ -143,34 +191,66 @@ export function useFacultyReportDetailViewModel({
       facultyId,
       semesterId,
       questionnaireTypeCode,
-      courseId: courseId || undefined,
       page: commentsPage,
       limit: commentsLimit,
       sentiment: sentimentFilter ?? undefined,
       themeId: resolvedThemeId ?? undefined,
     },
-    { enabled: Boolean(semesterId) }
+    { enabled: queriesReady }
   );
 
-  useEffect(() => {
-    if (questionnaireTypes.length === 0) {
-      return;
-    }
+  const updateSearchParams = useCallback(
+    (updates: Record<string, string | null>) => {
+      const nextHref = buildFacultyReportHref(pathname, currentSearchParams, updates);
+      router.replace(nextHref, { scroll: false });
+    },
+    [currentSearchParams, pathname, router]
+  );
 
-    const hasSelectedType = questionnaireTypes.some((type) => type.code === questionnaireTypeCode);
-    if (hasSelectedType) {
-      return;
-    }
+  // Auto-correction notices (Decision §16) are derived from the raw URL
+  // values + currently-available data — never written via setState inside an
+  // effect (React 19 `react-hooks/set-state-in-effect` rule). Dismissals are
+  // tracked per-requested-value so a different invalid value re-surfaces the
+  // notice. URL cleanup happens at dismiss time, not at notice-display time.
+  const [dismissedQuestionnaireTypeCode, setDismissedQuestionnaireTypeCode] = useState<
+    string | null
+  >(null);
+  const [dismissedView, setDismissedView] = useState<string | null>(null);
+  const [dismissedThemeLabel, setDismissedThemeLabel] = useState<string | null>(null);
 
-    const fallbackType = questionnaireTypes[0];
-    const nextHref = buildFacultyReportHref(pathname, currentSearchParams, {
-      questionnaireTypeCode: fallbackType?.code ?? null,
-      page: "1",
-    });
+  const questionnaireTypeCodeAutoCorrection: ParamAutoCorrection | null = useMemo(() => {
+    if (!availableQuestionnaireTypesQuery.isSuccess) return null;
+    if (!rawQuestionnaireTypeCode) return null;
+    if (availableQuestionnaireTypes.length === 0) return null;
+    if (dismissedQuestionnaireTypeCode === rawQuestionnaireTypeCode) return null;
 
-    router.replace(nextHref, { scroll: false });
-  }, [currentSearchParams, pathname, questionnaireTypeCode, questionnaireTypes, router]);
+    const isValid = availableQuestionnaireTypes.some(
+      (option) => option.code === rawQuestionnaireTypeCode
+    );
+    if (isValid) return null;
 
+    const fallbackCode = availableQuestionnaireTypes[0]?.code ?? null;
+    return {
+      requested: rawQuestionnaireTypeCode,
+      actual: fallbackCode ?? "(none)",
+    };
+  }, [
+    availableQuestionnaireTypes,
+    availableQuestionnaireTypesQuery.isSuccess,
+    rawQuestionnaireTypeCode,
+    dismissedQuestionnaireTypeCode,
+  ]);
+
+  const viewAutoCorrection: ParamAutoCorrection | null = useMemo(() => {
+    if (!isInvalidViewParam(rawViewParam)) return null;
+    if (dismissedView === rawViewParam) return null;
+    return {
+      requested: rawViewParam ?? "",
+      actual: DEFAULT_REPORT_VIEW,
+    };
+  }, [rawViewParam, dismissedView]);
+
+  // Course-id decay (unchanged behaviour, no auto-correction notice).
   useEffect(() => {
     if (!courseId || !facultyEnrollmentsQuery.isSuccess) {
       return;
@@ -181,28 +261,8 @@ export function useFacultyReportDetailViewModel({
       return;
     }
 
-    const nextHref = buildFacultyReportHref(pathname, currentSearchParams, {
-      courseId: null,
-      page: "1",
-    });
-
-    router.replace(nextHref, { scroll: false });
-  }, [
-    availableCourses,
-    courseId,
-    currentSearchParams,
-    facultyEnrollmentsQuery.isSuccess,
-    pathname,
-    router,
-  ]);
-
-  const updateSearchParams = useCallback(
-    (updates: Record<string, string | null>) => {
-      const nextHref = buildFacultyReportHref(pathname, currentSearchParams, updates);
-      router.replace(nextHref, { scroll: false });
-    },
-    [currentSearchParams, pathname, router]
-  );
+    updateSearchParams({ courseId: null, page: null });
+  }, [availableCourses, courseId, facultyEnrollmentsQuery.isSuccess, updateSearchParams]);
 
   const updateSentimentFilter = useCallback(
     (next: SentimentLabel | null) => {
@@ -218,9 +278,43 @@ export function useFacultyReportDetailViewModel({
     [updateSearchParams]
   );
 
+  const selectView = useCallback(
+    (next: ReportView) => {
+      updateSearchParams({ view: next === DEFAULT_REPORT_VIEW ? null : next });
+    },
+    [updateSearchParams]
+  );
+
+  const selectQuestionnaireType = useCallback(
+    (code: string | null) => {
+      updateSearchParams({ questionnaireTypeCode: code, page: null });
+    },
+    [updateSearchParams]
+  );
+
   const clearAllFilters = useCallback(() => {
     updateSearchParams({ sentiment: null, themeLabel: null, page: null });
   }, [updateSearchParams]);
+
+  const dismissQuestionnaireTypeCodeAutoCorrection = useCallback(() => {
+    if (rawQuestionnaireTypeCode) {
+      setDismissedQuestionnaireTypeCode(rawQuestionnaireTypeCode);
+      // Strip the bad param so deep links self-clean on dismiss.
+      updateSearchParams({ questionnaireTypeCode: null, page: null });
+    }
+  }, [rawQuestionnaireTypeCode, updateSearchParams]);
+  const dismissThemeLabelAutoCorrection = useCallback(() => {
+    setDismissedThemeLabel(themeLabelFilter ?? null);
+    if (themeLabelFilter) {
+      updateSearchParams({ themeLabel: null, page: null });
+    }
+  }, [themeLabelFilter, updateSearchParams]);
+  const dismissViewAutoCorrection = useCallback(() => {
+    if (rawViewParam) {
+      setDismissedView(rawViewParam);
+      updateSearchParams({ view: null });
+    }
+  }, [rawViewParam, updateSearchParams]);
 
   // F4: Silently strip unknown sentiment values from the URL before any API call.
   useEffect(() => {
@@ -229,16 +323,27 @@ export function useFacultyReportDetailViewModel({
     }
   }, [rawSentiment, updateSentimentFilter]);
 
-  // Theme-label decay: clear when no match exists in the latest pipeline's themes.
+  // Active strip for the deprecated ?facet= URL param. Old bookmarked deep
+  // links self-clean on first load. Matches the primitive-dep pattern of
+  // the sentiment-cleanup effect above so we don't double-fire on unrelated
+  // URL changes.
   useEffect(() => {
-    if (!themeLabelFilter || !qualitativeSummaryQuery.isSuccess) {
-      return;
+    if (rawFacetParam !== null) {
+      updateSearchParams({ facet: null });
     }
-    if (!labelToId.has(themeLabelFilter)) {
-      updateThemeFilter(null);
-      toast.info("Theme not found in current analysis");
-    }
-  }, [themeLabelFilter, qualitativeSummaryQuery.isSuccess, labelToId, updateThemeFilter]);
+  }, [rawFacetParam, updateSearchParams]);
+
+  // Theme-label decay surfaces as a derived auto-correction notice
+  // (Decision §16, Task 7a). The orphaned label stays in the URL until the
+  // user dismisses; this avoids set-state-in-effect and keeps the notice
+  // visible for the lifetime of that param.
+  const themeLabelAutoCorrection: ParamAutoCorrection | null = useMemo(() => {
+    if (!themeLabelFilter) return null;
+    if (!qualitativeSummaryQuery.isSuccess) return null;
+    if (labelToId.has(themeLabelFilter)) return null;
+    if (dismissedThemeLabel === themeLabelFilter) return null;
+    return { requested: themeLabelFilter, actual: "(no filter)" };
+  }, [themeLabelFilter, qualitativeSummaryQuery.isSuccess, labelToId, dismissedThemeLabel]);
 
   const report = reportQuery.data ?? null;
   const reportTitle = report?.faculty.name || facultyNameParam || "Faculty report";
@@ -246,7 +351,7 @@ export function useFacultyReportDetailViewModel({
     report?.semester.label ||
     (semesterLabelParam.trim().length > 0 ? semesterLabelParam : "Selected semester");
   const questionnaireTypeLabel = resolveFacultyReportQuestionnaireTypeLabel(
-    report?.questionnaireType.code ?? questionnaireTypeCode,
+    report?.questionnaireType.code ?? questionnaireTypeCode ?? "",
     report?.questionnaireType.name ?? selectedQuestionnaireType?.name
   );
   const comments = commentsQuery.data?.items ?? [];
@@ -255,18 +360,25 @@ export function useFacultyReportDetailViewModel({
 
   const refreshAll = () => {
     void facultyEnrollmentsQuery.refetch();
-    void questionnaireTypesQuery.refetch();
+    void globalQuestionnaireTypesQuery.refetch();
+    void availableQuestionnaireTypesQuery.refetch();
     void reportQuery.refetch();
     void commentsQuery.refetch();
     void qualitativeSummaryQuery.refetch();
   };
 
   const { activeRole } = useActiveRole();
-  const routePrefix = activeRole ? getRoleConfig(activeRole).routePrefix : "/dean";
-  const backHref = `${routePrefix}/faculties`;
+  const roleConfig = activeRole ? getRoleConfig(activeRole) : null;
+  const isFacultySelf = activeRole === APP_ROLES.FACULTY;
+  const backHref = isFacultySelf
+    ? (roleConfig?.homePath ?? "/faculty/courses")
+    : `${roleConfig?.routePrefix ?? "/dean"}/faculties`;
+  const backLabel = isFacultySelf ? "Back to Courses" : "Back to Faculties";
 
   return {
     backHref,
+    backLabel,
+    isFacultySelfView: isFacultySelf,
     facultyId,
     semesterId,
     courseId,
@@ -277,7 +389,10 @@ export function useFacultyReportDetailViewModel({
     semesterLabel,
     questionnaireTypeCode,
     questionnaireTypeLabel,
+    selectedView,
+    selectView,
     availableQuestionnaireTypes,
+    selectQuestionnaireType,
     comments,
     commentsMeta,
     commentsPage,
@@ -286,7 +401,8 @@ export function useFacultyReportDetailViewModel({
     reportQuery,
     commentsQuery,
     qualitativeSummaryQuery,
-    questionnaireTypesQuery,
+    questionnaireTypesQuery: globalQuestionnaireTypesQuery,
+    availableQuestionnaireTypesQuery,
     facultyEnrollmentsQuery,
     sentimentFilter,
     themeLabelFilter,
@@ -294,15 +410,15 @@ export function useFacultyReportDetailViewModel({
     updateSentimentFilter,
     updateThemeFilter,
     clearAllFilters,
-    isQuestionnaireTypeLoading: questionnaireTypesQuery.isLoading,
+    questionnaireTypeCodeAutoCorrection,
+    themeLabelAutoCorrection,
+    viewAutoCorrection,
+    dismissQuestionnaireTypeCodeAutoCorrection,
+    dismissThemeLabelAutoCorrection,
+    dismissViewAutoCorrection,
+    isQuestionnaireTypeLoading: isQuestionnaireTypesResolving,
     isCourseLoading: facultyEnrollmentsQuery.isLoading,
     hasSemesterContext: Boolean(semesterId),
-    updateQuestionnaireType: (value: string) => {
-      updateSearchParams({
-        questionnaireTypeCode: value,
-        page: "1",
-      });
-    },
     updateCourse: (value: string) => {
       updateSearchParams({
         courseId: value === "ALL" ? null : value,

--- a/features/faculty-analytics/hooks/use-scoped-faculty-analytics-list-view-model.ts
+++ b/features/faculty-analytics/hooks/use-scoped-faculty-analytics-list-view-model.ts
@@ -16,12 +16,19 @@ import {
 import { useProgramOptions } from "@/features/faculty-analytics/hooks/use-program-options";
 import { useSemesterOptions } from "@/features/faculty-analytics/hooks/use-semester-options";
 
-export function useScopedFacultyAnalyticsListViewModel() {
+type UseScopedFacultyAnalyticsListViewModelOptions = {
+  allowAllPrograms?: boolean;
+};
+
+export function useScopedFacultyAnalyticsListViewModel(
+  options?: UseScopedFacultyAnalyticsListViewModelOptions
+) {
   const [selectedSemesterIdState, setSelectedSemesterId] = useState<string | null>(null);
   const [selectedProgramIdState, setSelectedProgramId] = useState<string | null>(null);
   const [searchValue, setSearchValue] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState<number>(DEFAULT_PAGE_SIZE);
+  const allowAllPrograms = options?.allowAllPrograms ?? true;
 
   const deferredSearchValue = useDeferredValue(searchValue.trim());
   const meQuery = useMe();
@@ -45,8 +52,8 @@ export function useScopedFacultyAnalyticsListViewModel() {
     { enabled: Boolean(selectedSemesterId) }
   );
   const programs = useMemo(
-    () => mapProgramOptionsToViewModel(programOptionsQuery.data?.data ?? []),
-    [programOptionsQuery.data]
+    () => mapProgramOptionsToViewModel(programOptionsQuery.data?.data ?? [], allowAllPrograms),
+    [allowAllPrograms, programOptionsQuery.data]
   );
   const selectedProgram =
     programs.find((program) => program.id === selectedProgramIdState) ?? programs[0] ?? null;
@@ -60,7 +67,7 @@ export function useScopedFacultyAnalyticsListViewModel() {
       page: currentPage,
       limit: rowsPerPage,
     },
-    { enabled: Boolean(selectedSemesterId) }
+    { enabled: Boolean(selectedSemesterId) && (allowAllPrograms || Boolean(selectedProgramId)) }
   );
 
   const selectedSemester =
@@ -72,7 +79,8 @@ export function useScopedFacultyAnalyticsListViewModel() {
     selectedSemesterId,
     selectedSemesterLabel: selectedSemester?.label ?? "Select semester",
     selectedProgramId,
-    selectedProgramLabel: selectedProgram?.label ?? ALL_PROGRAMS_LABEL,
+    selectedProgramLabel:
+      selectedProgram?.label ?? (allowAllPrograms ? ALL_PROGRAMS_LABEL : "Select program"),
     facultyList: facultyListQuery.data?.data ?? [],
     pagination: facultyListQuery.data?.meta ?? {
       totalItems: 0,
@@ -113,7 +121,7 @@ export function useScopedFacultyAnalyticsListViewModel() {
       setCurrentPage(1);
     },
     setSelectedProgramId: (value: string) => {
-      setSelectedProgramId(value === ALL_PROGRAMS_VALUE ? null : value);
+      setSelectedProgramId(value === ALL_PROGRAMS_VALUE && allowAllPrograms ? null : value);
       setCurrentPage(1);
     },
     setSearchValue: (value: string) => {

--- a/features/faculty-analytics/lib/facet-filter.ts
+++ b/features/faculty-analytics/lib/facet-filter.ts
@@ -1,0 +1,21 @@
+// FAC-135 Phase C facet helpers, shrunk post-Step D of the insights-facet
+// cleanup spec. Only `formatFacetLabel` + `FACET_LABELS` remain — used by
+// `pipeline-confirm-dialog.tsx` for the Voice composition row. The
+// filter/derive helpers are gone alongside the Insights facet tabs.
+
+import type { Facet } from "@/features/faculty-analytics/types";
+
+const FACET_LABELS: Record<Facet, string> = {
+  overall: "Overall",
+  facultyFeedback: "Faculty Feedback",
+  inClassroom: "In-Classroom",
+  outOfClassroom: "Out-of-Classroom",
+};
+
+/**
+ * Maps a Facet enum value to its display label. Never coerce enum values
+ * directly to display strings — always go through this helper.
+ */
+export function formatFacetLabel(facet: Facet): string {
+  return FACET_LABELS[facet];
+}

--- a/features/faculty-analytics/lib/faculty-analysis-routes.ts
+++ b/features/faculty-analytics/lib/faculty-analysis-routes.ts
@@ -6,7 +6,7 @@ type BuildScopedFacultyAnalysisHrefOptions = {
   semesterId: string;
   semesterLabel: string;
   questionnaireTypeCode?: string;
-  scopeLabel: "Campus" | "Department";
+  scopeLabel: "Campus" | "Department" | "Program";
 };
 
 export function buildScopedFacultyAnalysisHref({
@@ -24,6 +24,11 @@ export function buildScopedFacultyAnalysisHref({
     questionnaireTypeCode,
   });
 
-  const basePath = scopeLabel === "Campus" ? "/campus-head/faculties" : "/dean/faculties";
+  const basePath =
+    scopeLabel === "Campus"
+      ? "/campus-head/faculties"
+      : scopeLabel === "Program"
+        ? "/chairperson/faculties"
+        : "/dean/faculties";
   return `${basePath}/${facultyId}/analysis?${params.toString()}`;
 }

--- a/features/faculty-analytics/lib/faculty-report-detail.ts
+++ b/features/faculty-analytics/lib/faculty-report-detail.ts
@@ -2,7 +2,12 @@ import {
   resolveQuestionnaireType,
   resolveQuestionnaireTypeLabel,
 } from "@/features/questionnaires/types";
-import type { FacultyReportResponseDto } from "@/features/faculty-analytics/types";
+import {
+  DEFAULT_REPORT_VIEW,
+  REPORT_VIEW_ORDER,
+  type FacultyReportResponseDto,
+  type ReportView,
+} from "@/features/faculty-analytics/types";
 
 const FACULTY_REPORT_INTERPRETATION_STYLE_MAP = {
   "EXCELLENT PERFORMANCE": {
@@ -69,6 +74,21 @@ export function formatFacultyReportScore(value: number | null) {
 
 export function resolveFacultyReportQuestionnaireTypeCode(value: string | null) {
   return resolveQuestionnaireType(value);
+}
+
+export function resolveView(raw: string | null): ReportView {
+  if (!raw) return DEFAULT_REPORT_VIEW;
+  return REPORT_VIEW_ORDER.includes(raw as ReportView) ? (raw as ReportView) : DEFAULT_REPORT_VIEW;
+}
+
+/**
+ * Returns true when the raw URL value was provided but did not match any
+ * known view (case-sensitive). The view-model uses this signal to surface
+ * the auto-correction notice without re-running resolveView's fallback logic.
+ */
+export function isInvalidViewParam(raw: string | null): boolean {
+  if (!raw) return false;
+  return !REPORT_VIEW_ORDER.includes(raw as ReportView);
 }
 
 export function resolveFacultyReportQuestionnaireTypeLabel(code: string, name?: string | null) {

--- a/features/faculty-analytics/lib/scoped-analytics-view-model.ts
+++ b/features/faculty-analytics/lib/scoped-analytics-view-model.ts
@@ -57,14 +57,13 @@ export function mapSemesterOptionsToViewModel(
 }
 
 export function mapProgramOptionsToViewModel(programs: ProgramOptionDto[]): ScopedProgramOption[] {
-  return [
-    { id: null, code: null, label: ALL_PROGRAMS_LABEL },
-    ...programs.map((program) => ({
-      id: program.id,
-      code: program.code,
-      label: program.name?.trim() ? `${program.code} • ${program.name}` : program.code,
-    })),
-  ];
+  const mappedPrograms = programs.map((program) => ({
+    id: program.id,
+    code: program.code,
+    label: program.name?.trim() ? `${program.code} • ${program.name}` : program.code,
+  }));
+
+  return [{ id: null, code: null, label: ALL_PROGRAMS_LABEL }, ...mappedPrograms];
 }
 
 export function mapDepartmentOverviewToDashboardViewModel({

--- a/features/faculty-analytics/lib/scoped-analytics-view-model.ts
+++ b/features/faculty-analytics/lib/scoped-analytics-view-model.ts
@@ -56,12 +56,19 @@ export function mapSemesterOptionsToViewModel(
   }));
 }
 
-export function mapProgramOptionsToViewModel(programs: ProgramOptionDto[]): ScopedProgramOption[] {
+export function mapProgramOptionsToViewModel(
+  programs: ProgramOptionDto[],
+  allowAllPrograms = true
+): ScopedProgramOption[] {
   const mappedPrograms = programs.map((program) => ({
     id: program.id,
     code: program.code,
     label: program.name?.trim() ? `${program.code} • ${program.name}` : program.code,
   }));
+
+  if (!allowAllPrograms) {
+    return mappedPrograms;
+  }
 
   return [{ id: null, code: null, label: ALL_PROGRAMS_LABEL }, ...mappedPrograms];
 }

--- a/features/faculty-analytics/types/index.ts
+++ b/features/faculty-analytics/types/index.ts
@@ -332,6 +332,37 @@ export type FacultyReportCourseOption = {
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Tri-view split (FAC-135) — view tabs and per-faculty questionnaire types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type ReportView = "insights" | "scores" | "feedback";
+
+export const REPORT_VIEW_ORDER: readonly ReportView[] = ["insights", "scores", "feedback"];
+
+export const DEFAULT_REPORT_VIEW: ReportView = "insights";
+
+export const REPORT_VIEW_LABELS: Record<ReportView, string> = {
+  insights: "Insights",
+  scores: "Scores",
+  feedback: "Feedback",
+};
+
+export type FacultyQuestionnaireTypeOptionDto = {
+  code: string;
+  name: string;
+  submissionCount: number;
+};
+
+export type FacultyQuestionnaireTypesResponseDto = {
+  items: FacultyQuestionnaireTypeOptionDto[];
+};
+
+export type FacultyQuestionnaireTypesQuery = {
+  facultyId: string;
+  semesterId: string;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Analysis Pipeline (FAC-132)
 //
 // Mirrors backend shapes from api.faculytics:
@@ -357,20 +388,46 @@ export type PipelineStatus =
 
 export type RunStatus = "PENDING" | "PROCESSING" | "COMPLETED" | "FAILED";
 
-// IDs only — used for CreatePipelineRequest and ListPipelinesQuery inputs.
-// Every scope field is optional at the type level; the BACKEND enforces (per
-// TD-2) that non-SUPER_ADMIN callers supply at least one scope filter beyond
-// `semesterId`, else 400 Bad Request. Type-level branching by role is
-// deliberately avoided here — a clear comment + runtime contract is simpler.
+// FAC-135 Phase A: collapsed scope shape. The canonical pipeline scope now
+// consists of `{ scopeType, scopeId }` plus the mandatory `semesterId`.
+// Legacy fields (facultyId/departmentId/programId/campusId/courseId/
+// questionnaireTypeCode) are gone from the frontend surface entirely —
+// the API still accepts them via a backwards-compat preprocessor but we
+// switch to the canonical shape immediately (hard cutover per TD-2).
+export type ScopeType = "FACULTY" | "DEPARTMENT" | "CAMPUS";
+
+// POST /analysis/pipelines body: scopeType + scopeId are REQUIRED.
 export type PipelineScopeIds = {
   semesterId: string;
-  facultyId?: string;
-  departmentId?: string;
-  programId?: string;
-  campusId?: string;
-  courseId?: string;
+  scopeType: ScopeType;
+  scopeId: string;
   questionnaireVersionId?: string;
-  questionnaireTypeCode?: string;
+};
+
+// GET /analysis/pipelines query: scopeType + scopeId are OPTIONAL — the
+// backend resolves the caller's scope (Dean's department, Campus Head's
+// campus) when omitted. Faculty self-view still passes them explicitly.
+export type ListPipelinesQueryShape = {
+  semesterId: string;
+  scopeType?: ScopeType;
+  scopeId?: string;
+  questionnaireVersionId?: string;
+};
+
+// FAC-135 Phase C: the four recommendation facets. Backend enums are
+// camelCase for facet values (see recommendations.dto.ts) — match verbatim.
+export type Facet = "overall" | "facultyFeedback" | "inClassroom" | "outOfClassroom";
+
+export type CoverageSlice = {
+  submissionCount: number;
+  commentCount: number;
+};
+
+export type VoiceBreakdown = {
+  facultyFeedback: CoverageSlice;
+  inClassroom: CoverageSlice;
+  outOfClassroom: CoverageSlice;
+  other: CoverageSlice;
 };
 
 // IDs + display values paired — shape of pipeline.status response's `scope`
@@ -398,6 +455,9 @@ export type PipelineCoverage = {
   commentCount: number;
   responseRate: number;
   lastEnrollmentSyncAt: string | null;
+  // FAC-135 Phase A: per-questionnaire-type coverage slices. Optional for
+  // back-compat with pipelines cached before this field existed.
+  voiceBreakdown?: VoiceBreakdown | null;
 };
 
 export type PipelineStageStatus = {
@@ -415,6 +475,9 @@ export type PipelineSentimentGateStatus = PipelineStageStatus & {
 export type PipelineStatusResponse = {
   id: string;
   status: PipelineStatus;
+  // FAC-135 Phase A: non-optional human-readable scope label
+  // (e.g. "Faculty: Jane Cruz", "Department: CS", "Legacy scope").
+  scopeLabel: string;
   scope: PipelineScopeDisplay;
   coverage: PipelineCoverage;
   stages: {
@@ -431,11 +494,17 @@ export type PipelineStatusResponse = {
   updatedAt: string;
   confirmedAt: string | null;
   completedAt: string | null;
+  // FAC-135 Phase B: ISO timestamp of the next scheduled refresh from the
+  // tiered scheduler. Optional / nullable so the frontend falls back to
+  // generic copy if the registry lookup fails (R3 mitigation — AC38).
+  nextScheduledRunAt?: string | null;
 };
 
 export type PipelineSummary = {
   id: string;
   status: PipelineStatus;
+  // FAC-135 Phase A: non-optional human-readable scope label.
+  scopeLabel: string;
   scope: PipelineScopeDisplay;
   coverage: PipelineCoverage;
   warnings: string[];
@@ -445,7 +514,7 @@ export type PipelineSummary = {
 };
 
 export type CreatePipelineRequest = PipelineScopeIds;
-export type ListPipelinesQuery = PipelineScopeIds;
+export type ListPipelinesQuery = ListPipelinesQueryShape;
 
 // ─── Recommendations ──────────────────────────────────────────────────────
 
@@ -490,6 +559,8 @@ export type RecommendedActionDto = {
   priority: ActionPriority;
   supportingEvidence: SupportingEvidence;
   createdAt: string;
+  // Internal metadata only — no UI consumer post Step D. See tech-spec-insights-facet-removal-and-theme-action-relink.
+  facet: Facet;
 };
 
 export type RecommendationsResponse = {

--- a/network/endpoints.ts
+++ b/network/endpoints.ts
@@ -49,6 +49,7 @@ export enum Endpoints {
   analyticsFacultyReport = "/api/v1/analytics/faculty/:facultyId/report",
   analyticsFacultyReportComments = "/api/v1/analytics/faculty/:facultyId/report/comments",
   analyticsFacultyQualitativeSummary = "/api/v1/analytics/faculty/:facultyId/qualitative-summary",
+  analyticsFacultyQuestionnaireTypes = "/api/v1/analytics/faculty/:facultyId/questionnaire-types",
   reportsGenerate = "/api/v1/reports/generate",
   reportsGenerateBatch = "/api/v1/reports/generate/batch",
   reportsStatus = "/api/v1/reports/status/:jobId",


### PR DESCRIPTION
## Summary

- Add chairperson dashboard view with role-appropriate analytics
- Add chairperson faculties list and per-faculty analysis placeholder pages
- Overhaul faculty analytics with tri-view layout (Scores, Insights, Feedback tabs), faculty self-view with redactions, questionnaire type tabs, headline metrics strip, feedback filter bar, and auto-correction notice

## Changes

### Chairperson
- `app/(dashboard)/chairperson/dashboard/page.tsx` — updated dashboard page composition
- `app/(dashboard)/chairperson/faculties/page.tsx` — faculties list page
- `app/(dashboard)/chairperson/faculties/[facultyId]/analysis/page.tsx` — per-faculty analysis placeholder
- `features/faculty-analytics/components/scoped-*` — scoped analytics dashboard, header, attention card, faculty list, analysis table updated for chairperson context

### Faculty Analytics (tri-view)
- New components: `auto-correction-notice`, `feedback-filter-bar`, `feedback-tab`, `headline-metrics-strip`, `insights-tab`, `questionnaire-type-tabs`, `scores-tab`
- New hook: `use-faculty-questionnaire-types`
- New lib util: `facet-filter`
- Refactored `faculty-report-screen` and `use-faculty-report-detail-view-model` for tri-view layout
- Faculty self-view redactions applied via role-aware rendering

## Test plan

- [ ] Chairperson role can access dashboard and see analytics
- [ ] Chairperson faculties list renders and navigates to per-faculty analysis
- [ ] Faculty analytics page shows Scores / Insights / Feedback tabs and switches correctly
- [ ] Questionnaire type tabs filter data correctly
- [ ] Headline metrics strip displays aggregate figures
- [ ] Feedback filter bar filters responses
- [ ] Faculty self-view hides redacted fields appropriately
- [ ] Dean/SuperAdmin views unaffected by changes
- [ ] No TypeScript errors (`bun run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)