### PR TITLE
FAC-WEB perf: student evaluation mobile render performance

### DIFF
--- a/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-form.tsx
+++ b/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-form.tsx
@@ -134,11 +134,11 @@ export function EvaluationForm({
       facultyName={facultyName}
       enrollmentSectionName={enrollmentSectionName}
     >
-      <div className="mt-8">
+      <div className="mt-5 sm:mt-8">
         <QuestionnaireRatingScaleInstructions />
       </div>
 
-      <div className="mt-8">
+      <div className="mt-5 sm:mt-8">
         <QuestionnaireFormRenderer
           key={draftHydrationKey}
           model={model}
@@ -167,7 +167,13 @@ export function EvaluationForm({
       </div>
 
       <div className="mt-6 flex flex-wrap items-center justify-end gap-3">
-        <Button variant="brand" onClick={handleSubmit} disabled={isPending}>
+        <Button
+          variant="brand"
+          size="lg"
+          onClick={handleSubmit}
+          disabled={isPending}
+          className="w-full sm:w-auto"
+        >
           {isPending ? (
             <>
               <Loader2 className="mr-2 size-4 animate-spin" />

--- a/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-page-shell.tsx
+++ b/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-page-shell.tsx
@@ -20,7 +20,7 @@ export function EvaluationPageShell({
   enrollmentSectionName,
 }: EvaluationPageShellProps) {
   return (
-    <section className="px-4 py-5 sm:px-6 md:px-10 md:py-10">
+    <section className="py-5 sm:px-6 md:px-10 md:py-10">
       <div className="mx-auto max-w-6xl">
         {/* Mobile: compact back link */}
         <Button

--- a/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-page-shell.tsx
+++ b/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-page-shell.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -21,48 +22,67 @@ export function EvaluationPageShell({
   return (
     <section className="px-4 py-5 sm:px-6 md:px-10 md:py-10">
       <div className="mx-auto max-w-6xl">
+        {/* Mobile: compact back link */}
+        <Button
+          asChild
+          variant="ghost"
+          size="sm"
+          className="-ml-2 mb-2 h-8 gap-1.5 px-2 text-xs text-muted-foreground sm:hidden"
+        >
+          <Link href="/student/courses">
+            <ArrowLeft className="size-3.5" aria-hidden="true" />
+            Back to Courses
+          </Link>
+        </Button>
+
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              Faculty Evaluation Questionnaire
+            <h1 className="font-playfair text-2xl font-bold leading-tight tracking-tight text-foreground sm:text-4xl">
+              Faculty Evaluation
+              <span className="block text-base font-medium text-muted-foreground sm:hidden">
+                Questionnaire
+              </span>
+              <span className="hidden sm:inline"> Questionnaire</span>
             </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground sm:mt-3 sm:text-base">
               Your honest feedback helps improve the quality of education.
             </p>
           </div>
-          <Button asChild variant="outline" className="shrink-0 self-start">
+          <Button asChild variant="outline" className="hidden shrink-0 self-start sm:inline-flex">
             <Link href="/student/courses">Back to Courses</Link>
           </Button>
         </div>
 
         {courseName && facultyName && (
-          <Card className="mt-8 overflow-hidden border-border/70 bg-card shadow-sm">
+          <Card className="mt-5 overflow-hidden border-border/70 bg-card py-0 shadow-sm sm:mt-8">
             <CardContent className="grid gap-0 p-0 md:grid-cols-3">
-              <div className="flex flex-col items-center px-5 py-5 text-center sm:px-6">
-                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+              <div className="flex flex-col items-start gap-0.5 px-4 py-3.5 text-left sm:items-center sm:gap-0 sm:px-6 sm:py-5 sm:text-center">
+                <p className="text-[0.62rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground sm:text-[0.68rem]">
                   Instructor
                 </p>
-                <p className="mt-2 font-playfair text-xl font-semibold leading-tight text-foreground">
+                <p className="font-playfair text-base font-semibold leading-tight text-foreground sm:mt-2 sm:text-xl">
                   {facultyName}
                 </p>
               </div>
-              <div className="flex flex-col items-center border-t border-border/60 px-5 py-5 text-center sm:px-6 md:border-t-0 md:border-l">
-                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+              <div className="flex flex-col items-start gap-0.5 border-t border-border/60 px-4 py-3.5 text-left sm:items-center sm:gap-0 sm:px-6 sm:py-5 sm:text-center md:border-t-0 md:border-l">
+                <p className="text-[0.62rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground sm:text-[0.68rem]">
                   Course
                 </p>
-                <p className="mt-2 text-base font-semibold leading-6 text-foreground sm:text-lg">
+                <p className="text-sm font-semibold leading-snug text-foreground sm:mt-2 sm:text-lg">
                   {courseName}
                 </p>
                 {courseShortname && (
-                  <p className="mt-1 text-sm text-muted-foreground">{courseShortname}</p>
+                  <p className="text-xs text-muted-foreground sm:mt-1 sm:text-sm">
+                    {courseShortname}
+                  </p>
                 )}
               </div>
               {enrollmentSectionName && (
-                <div className="flex flex-col items-center border-t border-border/60 px-5 py-5 text-center sm:px-6 md:border-t-0 md:border-l">
-                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                <div className="flex flex-col items-start gap-0.5 border-t border-border/60 px-4 py-3.5 text-left sm:items-center sm:gap-0 sm:px-6 sm:py-5 sm:text-center md:border-t-0 md:border-l">
+                  <p className="text-[0.62rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground sm:text-[0.68rem]">
                     Section
                   </p>
-                  <p className="mt-2 text-base font-semibold leading-6 text-foreground sm:text-lg">
+                  <p className="text-sm font-semibold leading-snug text-foreground sm:mt-2 sm:text-lg">
                     {enrollmentSectionName}
                   </p>
                 </div>

--- a/features/questionnaires/components/form/questionnaire-form-matrix.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-matrix.tsx
@@ -12,22 +12,17 @@ import {
 import type {
   BuilderQuestionType,
   QuestionnaireBuilderPreviewQuestion,
-  QuestionnaireFormAnswers,
   QuestionnaireFormMode,
 } from "@/features/questionnaires/types";
+
+import { useFormActions, useQuestionAnswer } from "./questionnaire-form-store";
 
 type QuestionnaireFormMatrixProps = {
   questions: QuestionnaireBuilderPreviewQuestion[];
   questionType: BuilderQuestionType;
   mode: QuestionnaireFormMode;
-  answers: QuestionnaireFormAnswers;
-  onAnswer: (questionId: string, value: number) => void;
 };
 
-/**
- * A custom radio button that looks like shadcn's RadioGroupItem.
- * Used in the matrix to select options for each question.
- */
 function MatrixRadio({
   checked,
   disabled,
@@ -59,28 +54,62 @@ function MatrixRadio({
   );
 }
 
-/**
- * Converts a stored numeric answer back to the string key used for comparison.
- *
- * - Likert: numeric 4 → string "4"
- * - Yes/No: numeric 5 → string "Yes", numeric 1 → string "No"
- *
- * Returns "" if the question hasn't been answered yet.
- */
 function getSelectedOptionKey(value: number | undefined, isLikert: boolean): string {
   if (value === undefined) return "";
   return isLikert ? value.toString() : YES_NO_REVERSE_MAP[value];
 }
 
-/**
- * Converts a display option string to the numeric value stored in answers.
- *
- * - Likert: "4" → 4
- * - Yes/No: "Yes" → 5, "No" → 1 (scale-aligned)
- */
 function getNumericValue(option: string, isLikert: boolean): number {
   return isLikert ? Number(option) : YES_NO_VALUE_MAP[option];
 }
+
+type MatrixRowProps = {
+  question: QuestionnaireBuilderPreviewQuestion;
+  isLikert: boolean;
+  options: readonly string[];
+  disabled: boolean;
+  isInteractive: boolean;
+};
+
+function MatrixRowBase({ question, isLikert, options, disabled, isInteractive }: MatrixRowProps) {
+  const value = useQuestionAnswer(question.id);
+  const { setAnswer } = useFormActions();
+
+  const selectedKey = getSelectedOptionKey(value, isLikert);
+  const questionLabel = question.prompt || "Untitled question";
+
+  return (
+    <tr
+      role="radiogroup"
+      aria-label={questionLabel}
+      className="border-b transition-colors last:border-b-0 hover:bg-muted/50"
+    >
+      <th scope="row" className="px-3 py-3 text-left text-sm font-normal">
+        {questionLabel}
+      </th>
+      {options.map((option) => {
+        const isSelected = selectedKey === option;
+        return (
+          <td key={option} className="w-14 px-2 py-3">
+            <div className="flex justify-center">
+              <MatrixRadio
+                checked={isSelected}
+                disabled={disabled}
+                onClick={() => {
+                  if (!isInteractive) return;
+                  setAnswer(question.id, getNumericValue(option, isLikert));
+                }}
+                ariaLabel={isLikert ? `Rating ${option}` : option}
+              />
+            </div>
+          </td>
+        );
+      })}
+    </tr>
+  );
+}
+
+const MatrixRow = memo(MatrixRowBase);
 
 /**
  * Desktop Likert matrix table.
@@ -92,12 +121,11 @@ function QuestionnaireFormMatrixBase({
   questions,
   questionType,
   mode,
-  answers,
-  onAnswer,
 }: QuestionnaireFormMatrixProps) {
   const isLikert = questionType === "LIKERT_1_5";
   const options = isLikert ? LIKERT_OPTIONS : YES_NO_OPTIONS;
   const disabled = mode === "preview";
+  const isInteractive = mode === "interactive";
 
   return (
     <div className="overflow-x-auto">
@@ -122,39 +150,16 @@ function QuestionnaireFormMatrixBase({
           </tr>
         </thead>
         <tbody>
-          {questions.map((question) => {
-            const selectedKey = getSelectedOptionKey(answers[question.id], isLikert);
-            const questionLabel = question.prompt || "Untitled question";
-
-            return (
-              <tr
-                key={question.id}
-                role="radiogroup"
-                aria-label={questionLabel}
-                className="border-b transition-colors last:border-b-0 hover:bg-muted/50"
-              >
-                <th scope="row" className="px-3 py-3 text-left text-sm font-normal">
-                  {questionLabel}
-                </th>
-                {options.map((option) => {
-                  const isSelected = selectedKey === option;
-
-                  return (
-                    <td key={option} className="w-14 px-2 py-3">
-                      <div className="flex justify-center">
-                        <MatrixRadio
-                          checked={isSelected}
-                          disabled={disabled}
-                          onClick={() => onAnswer(question.id, getNumericValue(option, isLikert))}
-                          ariaLabel={isLikert ? `Rating ${option}` : option}
-                        />
-                      </div>
-                    </td>
-                  );
-                })}
-              </tr>
-            );
-          })}
+          {questions.map((question) => (
+            <MatrixRow
+              key={question.id}
+              question={question}
+              isLikert={isLikert}
+              options={options}
+              disabled={disabled}
+              isInteractive={isInteractive}
+            />
+          ))}
         </tbody>
       </table>
     </div>

--- a/features/questionnaires/components/form/questionnaire-form-progress.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-progress.tsx
@@ -1,25 +1,33 @@
 "use client";
 
+import { memo } from "react";
+
 import { Progress } from "@/components/ui/progress";
 
+import { useAnsweredCountFor, useHasQualitativeContent } from "./questionnaire-form-store";
+
 type QuestionnaireFormProgressProps = {
-  answeredCount: number;
-  totalRequired: number;
-  isComplete: boolean;
+  requiredIds: string[];
+  qualitativeRequired: boolean;
   /** Optional slot rendered beside the percentage (e.g. draft status badge). */
   trailing?: React.ReactNode;
 };
 
-export function QuestionnaireFormProgress({
-  answeredCount,
-  totalRequired,
-  isComplete,
+function QuestionnaireFormProgressBase({
+  requiredIds,
+  qualitativeRequired,
   trailing,
 }: QuestionnaireFormProgressProps) {
+  const answeredCount = useAnsweredCountFor(requiredIds);
+  const hasQualitativeContent = useHasQualitativeContent();
+  const totalRequired = requiredIds.length;
+
+  const hasRequiredComment = !qualitativeRequired || hasQualitativeContent;
+  const isComplete = answeredCount === totalRequired && hasRequiredComment;
   const percentage = totalRequired > 0 ? Math.round((answeredCount / totalRequired) * 100) : 0;
 
   return (
-    <div className="sticky top-0 z-20 -mx-4 space-y-2 border-b border-border/60 bg-background/85 px-4 py-3 backdrop-blur-md sm:static sm:mx-0 sm:border-0 sm:bg-transparent sm:p-0 sm:backdrop-blur-none">
+    <div className="sticky top-0 z-20 -mx-4 space-y-2 border-b border-border/60 bg-background px-4 py-3 sm:static sm:mx-0 sm:border-0 sm:bg-transparent sm:p-0">
       <div className="flex items-center justify-between gap-3 text-sm">
         <p className="truncate text-muted-foreground">
           <span className="font-medium tabular-nums text-foreground">{answeredCount}</span>
@@ -43,3 +51,5 @@ export function QuestionnaireFormProgress({
     </div>
   );
 }
+
+export const QuestionnaireFormProgress = memo(QuestionnaireFormProgressBase);

--- a/features/questionnaires/components/form/questionnaire-form-progress.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-progress.tsx
@@ -19,19 +19,27 @@ export function QuestionnaireFormProgress({
   const percentage = totalRequired > 0 ? Math.round((answeredCount / totalRequired) * 100) : 0;
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between text-sm">
-        <p className="text-muted-foreground">
-          {answeredCount} / {totalRequired} questions answered
+    <div className="sticky top-0 z-20 -mx-4 space-y-2 border-b border-border/60 bg-background/85 px-4 py-3 backdrop-blur-md sm:static sm:mx-0 sm:border-0 sm:bg-transparent sm:p-0 sm:backdrop-blur-none">
+      <div className="flex items-center justify-between gap-3 text-sm">
+        <p className="truncate text-muted-foreground">
+          <span className="font-medium tabular-nums text-foreground">{answeredCount}</span>
+          <span className="text-muted-foreground"> / {totalRequired}</span>
+          <span className="hidden sm:inline"> questions answered</span>
+          <span className="sm:hidden"> answered</span>
         </p>
         <div className="flex items-center gap-2">
           {trailing}
-          <p className={isComplete ? "font-medium text-green-600" : "text-muted-foreground"}>
+          <p
+            className={
+              "tabular-nums " +
+              (isComplete ? "font-semibold text-green-600" : "text-muted-foreground")
+            }
+          >
             {percentage}%
           </p>
         </div>
       </div>
-      <Progress value={percentage} className="bg-brand-blue/20 [&>*]:bg-brand-blue" />
+      <Progress value={percentage} className="h-1.5 bg-brand-blue/20 [&>*]:bg-brand-blue" />
     </div>
   );
 }

--- a/features/questionnaires/components/form/questionnaire-form-qualitative.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-qualitative.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { memo } from "react";
+
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
@@ -8,20 +10,18 @@ import type {
   QuestionnaireFormMode,
 } from "@/features/questionnaires/types";
 
+import { useFormActions, useQualitativeComment } from "./questionnaire-form-store";
+
 type QuestionnaireFormQualitativeProps = {
   config: QuestionnaireBuilderQualitativeConfig;
   mode: QuestionnaireFormMode;
-  value: string;
-  onChangeComment: (value: string) => void;
 };
 
-export function QuestionnaireFormQualitative({
-  config,
-  mode,
-  value,
-  onChangeComment,
-}: QuestionnaireFormQualitativeProps) {
+function QuestionnaireFormQualitativeBase({ config, mode }: QuestionnaireFormQualitativeProps) {
+  const value = useQualitativeComment();
+  const { setComment } = useFormActions();
   const disabled = mode === "preview";
+  const isInteractive = mode === "interactive";
   const charCount = value.length;
 
   return (
@@ -40,10 +40,13 @@ export function QuestionnaireFormQualitative({
           aria-label="Qualitative comments"
           maxLength={config.maxLength}
           value={value}
-          onChange={(e) => onChangeComment(e.target.value)}
+          onChange={(e) => {
+            if (!isInteractive) return;
+            setComment(e.target.value);
+          }}
           rows={4}
         />
-        {mode === "interactive" && (
+        {isInteractive && (
           <p className="text-xs text-muted-foreground text-right">
             {charCount} / {config.maxLength}
           </p>
@@ -52,3 +55,5 @@ export function QuestionnaireFormQualitative({
     </Card>
   );
 }
+
+export const QuestionnaireFormQualitative = memo(QuestionnaireFormQualitativeBase);

--- a/features/questionnaires/components/form/questionnaire-form-renderer.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-renderer.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import type {
   QuestionnaireBuilderPreviewModel,
   QuestionnaireBuilderPreviewSection,
-  QuestionnaireFormAnswers,
   QuestionnaireFormMode,
   QuestionnaireFormValues,
 } from "@/features/questionnaires/types";
@@ -13,6 +12,10 @@ import type {
 import { QuestionnaireFormProgress } from "./questionnaire-form-progress";
 import { QuestionnaireFormQualitative } from "./questionnaire-form-qualitative";
 import { QuestionnaireFormSection } from "./questionnaire-form-section";
+import {
+  createQuestionnaireFormStore,
+  QuestionnaireFormStoreProvider,
+} from "./questionnaire-form-store";
 
 type QuestionnaireFormRendererProps = {
   /** The questionnaire data to render (sections, questions, qualitative config). */
@@ -33,11 +36,9 @@ type QuestionnaireFormRendererProps = {
  */
 function collectRequiredQuestionIds(sections: QuestionnaireBuilderPreviewSection[]): string[] {
   return sections.flatMap((section) => {
-    // Leaf section: has questions directly
     if (section.questions.length > 0) {
       return section.questions.filter((q) => q.required).map((q) => q.id);
     }
-    // Parent section: recurse into children
     return collectRequiredQuestionIds(section.children);
   });
 }
@@ -51,82 +52,55 @@ export function QuestionnaireFormRenderer({
 }: QuestionnaireFormRendererProps) {
   const isInteractive = mode === "interactive";
 
-  // --- Form state ---
-  const [answers, setAnswers] = useState<QuestionnaireFormAnswers>(defaultValues?.answers ?? {});
-  const [qualitativeComment, setQualitativeComment] = useState<string>(
-    defaultValues?.qualitativeComment ?? ""
-  );
+  // Lazy-init: one store per mount. `defaultValues` is captured here — matches
+  // the previous useState(initialValue) semantics.
+  const [store] = useState(() => createQuestionnaireFormStore(defaultValues));
 
-  // --- Completion tracking ---
   const requiredQuestionIds = useMemo(
     () => collectRequiredQuestionIds(model.sections),
     [model.sections]
   );
 
-  const answeredCount = useMemo(
-    () => requiredQuestionIds.filter((id) => id in answers).length,
-    [requiredQuestionIds, answers]
-  );
-
-  const totalRequired = requiredQuestionIds.length;
-
-  const hasAnsweredAllQuestions = answeredCount === totalRequired;
-  const hasRequiredComment = !model.qualitative.required || qualitativeComment.trim().length > 0;
-  const isComplete = hasAnsweredAllQuestions && hasRequiredComment;
-
-  // --- Callbacks (stable references for memoized children) ---
-  const handleAnswer = useCallback(
-    (questionId: string, value: number) => {
-      if (!isInteractive) return;
-      setAnswers((prev) => ({ ...prev, [questionId]: value }));
-    },
-    [isInteractive]
-  );
-
-  const handleCommentChange = useCallback(
-    (value: string) => {
-      if (!isInteractive) return;
-      setQualitativeComment(value);
-    },
-    [isInteractive]
-  );
-
-  // Notify the parent whenever form values change
+  // Autosave wiring lives outside React's render cycle: store.subscribe fires
+  // only when state actually changes, and mutating a ref + calling the stable
+  // debounced callback does not cause the renderer to re-render.
+  const onChangeRef = useRef(onChange);
   useEffect(() => {
-    if (!isInteractive || !onChange) return;
-    onChange({ answers, qualitativeComment });
-  }, [answers, qualitativeComment, isInteractive, onChange]);
+    onChangeRef.current = onChange;
+  }, [onChange]);
 
-  // --- Render ---
+  useEffect(() => {
+    if (!isInteractive) return;
+    return store.subscribe((state, prev) => {
+      if (state.answers === prev.answers && state.qualitativeComment === prev.qualitativeComment) {
+        return;
+      }
+      onChangeRef.current?.({
+        answers: state.answers,
+        qualitativeComment: state.qualitativeComment,
+      });
+    });
+  }, [store, isInteractive]);
+
   return (
-    <div className="space-y-5">
-      {isInteractive && (
-        <QuestionnaireFormProgress
-          answeredCount={answeredCount}
-          totalRequired={totalRequired}
-          isComplete={isComplete}
-          trailing={progressTrailing}
-        />
-      )}
+    <QuestionnaireFormStoreProvider value={store}>
+      <div className="space-y-5">
+        {isInteractive && (
+          <QuestionnaireFormProgress
+            requiredIds={requiredQuestionIds}
+            qualitativeRequired={model.qualitative.required}
+            trailing={progressTrailing}
+          />
+        )}
 
-      {model.sections.map((section) => (
-        <QuestionnaireFormSection
-          key={section.id}
-          section={section}
-          mode={mode}
-          answers={answers}
-          onAnswer={handleAnswer}
-        />
-      ))}
+        {model.sections.map((section) => (
+          <QuestionnaireFormSection key={section.id} section={section} mode={mode} />
+        ))}
 
-      {model.qualitative.enabled && (
-        <QuestionnaireFormQualitative
-          config={model.qualitative}
-          mode={mode}
-          value={qualitativeComment}
-          onChangeComment={handleCommentChange}
-        />
-      )}
-    </div>
+        {model.qualitative.enabled && (
+          <QuestionnaireFormQualitative config={model.qualitative} mode={mode} />
+        )}
+      </div>
+    </QuestionnaireFormStoreProvider>
   );
 }

--- a/features/questionnaires/components/form/questionnaire-form-section.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-section.tsx
@@ -67,22 +67,45 @@ function QuestionnaireFormSectionBase({
   // All questions within a leaf section share the same type (enforced by the builder).
   const questionType = isLeaf ? (section.questions[0]?.type ?? "LIKERT_1_5") : "LIKERT_1_5";
 
+  const isSectionComplete = answeredCount === totalQuestions && totalQuestions > 0;
+
   return (
     <div
       className={
-        isChild ? "space-y-4 pl-4 sm:pl-6" : "space-y-4 rounded-2xl border bg-background p-4 sm:p-5"
+        isChild ? "space-y-4 pl-3 sm:pl-6" : "space-y-4 rounded-2xl border bg-background p-4 sm:p-5"
       }
     >
       {/* Section header: title + weight badge (preview) or progress count (interactive) */}
-      <div className="flex flex-wrap items-center justify-between gap-2">
+      <div
+        className={
+          "flex flex-wrap items-center justify-between gap-x-3 gap-y-2 " +
+          (isChild ? "" : "border-b border-border/50 pb-3 sm:pb-4")
+        }
+      >
         <div className="flex flex-wrap items-center gap-2">
-          <h3 className="font-playfair text-lg font-semibold sm:text-xl">{section.title}</h3>
+          <h3 className="font-playfair text-xl leading-tight font-semibold tracking-tight text-foreground sm:text-2xl">
+            {section.title}
+          </h3>
           {section.weight !== null && mode === "preview" && (
             <Badge variant="outline">Weight: {section.weight}%</Badge>
           )}
         </div>
         {mode === "interactive" && totalQuestions > 0 && !hideCounter && (
-          <span className="text-xs text-muted-foreground">
+          <span
+            className={
+              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[0.7rem] font-semibold tabular-nums transition-colors " +
+              (isSectionComplete
+                ? "border-brand-blue/40 bg-brand-blue/10 text-brand-blue"
+                : "border-border bg-muted/40 text-muted-foreground")
+            }
+          >
+            <span
+              aria-hidden="true"
+              className={
+                "size-1.5 rounded-full " +
+                (isSectionComplete ? "bg-brand-blue" : "bg-muted-foreground/40")
+              }
+            />
             {answeredCount} / {totalQuestions}
           </span>
         )}

--- a/features/questionnaires/components/form/questionnaire-form-section.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-section.tsx
@@ -5,18 +5,16 @@ import { memo, useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
 import type {
   QuestionnaireBuilderPreviewSection,
-  QuestionnaireFormAnswers,
   QuestionnaireFormMode,
 } from "@/features/questionnaires/types";
 
 import { QuestionnaireFormMatrix } from "./questionnaire-form-matrix";
 import { QuestionnaireFormStacked } from "./questionnaire-form-stacked";
+import { useAnsweredCountFor } from "./questionnaire-form-store";
 
 type QuestionnaireFormSectionProps = {
   section: QuestionnaireBuilderPreviewSection;
   mode: QuestionnaireFormMode;
-  answers: QuestionnaireFormAnswers;
-  onAnswer: (questionId: string, value: number) => void;
   /** Hide the question counter on child sections to avoid duplication with the parent. */
   hideCounter?: boolean;
   /** When true, renders without the card wrapper (border/bg/padding). Used for child sections. */
@@ -37,34 +35,16 @@ function collectQuestionIds(section: QuestionnaireBuilderPreviewSection): string
 function QuestionnaireFormSectionBase({
   section,
   mode,
-  answers,
-  onAnswer,
   hideCounter = false,
   isChild = false,
 }: QuestionnaireFormSectionProps) {
   const questionIds = useMemo(() => collectQuestionIds(section), [section]);
-
-  // Extract only the answers that belong to this section's questions.
-  // This prevents unnecessary re-renders of sibling sections when an answer changes.
-  const sectionAnswers = useMemo(() => {
-    const filtered: QuestionnaireFormAnswers = {};
-    for (const id of questionIds) {
-      if (id in answers) {
-        filtered[id] = answers[id];
-      }
-    }
-    return filtered;
-  }, [questionIds, answers]);
-
-  const answeredCount = Object.keys(sectionAnswers).length;
+  const answeredCount = useAnsweredCountFor(questionIds);
   const totalQuestions = questionIds.length;
 
-  // A "leaf" section contains questions directly.
-  // An "internal" section contains child sections (subsections) instead.
   const isLeaf = section.questions.length > 0;
   const isInternal = section.children.length > 0;
 
-  // All questions within a leaf section share the same type (enforced by the builder).
   const questionType = isLeaf ? (section.questions[0]?.type ?? "LIKERT_1_5") : "LIKERT_1_5";
 
   const isSectionComplete = answeredCount === totalQuestions && totalQuestions > 0;
@@ -75,7 +55,6 @@ function QuestionnaireFormSectionBase({
         isChild ? "space-y-4 pl-3 sm:pl-6" : "space-y-4 rounded-2xl border bg-background p-4 sm:p-5"
       }
     >
-      {/* Section header: title + weight badge (preview) or progress count (interactive) */}
       <div
         className={
           "flex flex-wrap items-center justify-between gap-x-3 gap-y-2 " +
@@ -111,7 +90,6 @@ function QuestionnaireFormSectionBase({
         )}
       </div>
 
-      {/* Leaf section: show matrix table on desktop, stacked pills on mobile */}
       {isLeaf && (
         <>
           <div className="hidden md:block">
@@ -119,8 +97,6 @@ function QuestionnaireFormSectionBase({
               questions={section.questions}
               questionType={questionType}
               mode={mode}
-              answers={sectionAnswers}
-              onAnswer={onAnswer}
             />
           </div>
           <div className="md:hidden">
@@ -128,14 +104,11 @@ function QuestionnaireFormSectionBase({
               questions={section.questions}
               questionType={questionType}
               mode={mode}
-              answers={sectionAnswers}
-              onAnswer={onAnswer}
             />
           </div>
         </>
       )}
 
-      {/* Internal section: recursively render child sections */}
       {isInternal && (
         <div className="space-y-4">
           {section.children.map((child) => (
@@ -143,8 +116,6 @@ function QuestionnaireFormSectionBase({
               key={child.id}
               section={child}
               mode={mode}
-              answers={answers}
-              onAnswer={onAnswer}
               hideCounter
               isChild
             />

--- a/features/questionnaires/components/form/questionnaire-form-stacked.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-stacked.tsx
@@ -13,16 +13,15 @@ import {
 import type {
   BuilderQuestionType,
   QuestionnaireBuilderPreviewQuestion,
-  QuestionnaireFormAnswers,
   QuestionnaireFormMode,
 } from "@/features/questionnaires/types";
+
+import { useFormActions, useQuestionAnswer } from "./questionnaire-form-store";
 
 type QuestionnaireFormStackedProps = {
   questions: QuestionnaireBuilderPreviewQuestion[];
   questionType: BuilderQuestionType;
   mode: QuestionnaireFormMode;
-  answers: QuestionnaireFormAnswers;
-  onAnswer: (questionId: string, value: number) => void;
 };
 
 const LIKERT_LABELS: Record<string, string> = {
@@ -42,98 +41,126 @@ function getNumericValue(option: string, isLikert: boolean): number {
   return isLikert ? Number(option) : YES_NO_VALUE_MAP[option];
 }
 
+type StackedRowProps = {
+  question: QuestionnaireBuilderPreviewQuestion;
+  index: number;
+  isLikert: boolean;
+  options: readonly string[];
+  disabled: boolean;
+  isInteractive: boolean;
+};
+
+function StackedRowBase({
+  question,
+  index,
+  isLikert,
+  options,
+  disabled,
+  isInteractive,
+}: StackedRowProps) {
+  const value = useQuestionAnswer(question.id);
+  const { setAnswer } = useFormActions();
+
+  const questionLabel = question.prompt || "Untitled question";
+  const selectedKey = getSelectedOptionKey(value, isLikert);
+  const isAnswered = selectedKey !== "";
+
+  return (
+    <li
+      className={cn(
+        "rounded-xl border bg-card/60 p-4 transition-colors",
+        isAnswered ? "border-brand-blue/40 bg-brand-blue/[0.03]" : "border-border/70"
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className={cn(
+            "mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-full border text-[0.7rem] font-semibold tabular-nums transition-colors",
+            isAnswered
+              ? "border-brand-blue bg-brand-blue text-white"
+              : "border-border text-muted-foreground"
+          )}
+          aria-hidden="true"
+        >
+          {isAnswered ? <Check className="size-3.5" strokeWidth={3} /> : index + 1}
+        </span>
+        <p className="text-[0.95rem] leading-snug font-medium text-foreground">{questionLabel}</p>
+      </div>
+
+      <div role="radiogroup" aria-label={questionLabel} className="mt-4 flex flex-col gap-1.5">
+        {options.map((option) => {
+          const isSelected = selectedKey === option;
+          const label = isLikert ? LIKERT_LABELS[option] : option;
+          const ariaLabel = isLikert ? `${option} ${label}` : option;
+
+          return (
+            <button
+              key={option}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              aria-label={ariaLabel}
+              disabled={disabled}
+              onClick={() => {
+                if (!isInteractive) return;
+                setAnswer(question.id, getNumericValue(option, isLikert));
+              }}
+              className={cn(
+                "group relative flex min-h-12 w-full items-center gap-3 rounded-lg border px-3 py-2.5 text-left text-sm transition-all outline-none",
+                "focus-visible:ring-2 focus-visible:ring-brand-blue/50 focus-visible:ring-offset-1",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+                isSelected
+                  ? "border-brand-blue bg-brand-blue text-white shadow-sm shadow-brand-blue/20"
+                  : "border-border bg-background text-foreground hover:border-brand-blue/50 hover:bg-brand-blue/5 active:scale-[0.99]"
+              )}
+            >
+              {isLikert && (
+                <span
+                  className={cn(
+                    "inline-flex size-7 shrink-0 items-center justify-center rounded-md text-sm font-semibold tabular-nums transition-colors",
+                    isSelected
+                      ? "bg-white/15 text-white"
+                      : "bg-muted text-muted-foreground group-hover:bg-brand-blue/10 group-hover:text-brand-blue"
+                  )}
+                  aria-hidden="true"
+                >
+                  {option}
+                </span>
+              )}
+              <span className="flex-1 font-medium">{label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </li>
+  );
+}
+
+const StackedRow = memo(StackedRowBase);
+
 function QuestionnaireFormStackedBase({
   questions,
   questionType,
   mode,
-  answers,
-  onAnswer,
 }: QuestionnaireFormStackedProps) {
   const isLikert = questionType === "LIKERT_1_5";
   const options = isLikert ? LIKERT_OPTIONS : YES_NO_OPTIONS;
   const disabled = mode === "preview";
+  const isInteractive = mode === "interactive";
 
   return (
     <ol className="space-y-4">
-      {questions.map((question, index) => {
-        const questionLabel = question.prompt || "Untitled question";
-        const selectedKey = getSelectedOptionKey(answers[question.id], isLikert);
-        const isAnswered = selectedKey !== "";
-
-        return (
-          <li
-            key={question.id}
-            className={cn(
-              "rounded-xl border bg-card/60 p-4 transition-colors",
-              isAnswered ? "border-brand-blue/40 bg-brand-blue/[0.03]" : "border-border/70"
-            )}
-          >
-            <div className="flex items-start gap-3">
-              <span
-                className={cn(
-                  "mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-full border text-[0.7rem] font-semibold tabular-nums transition-colors",
-                  isAnswered
-                    ? "border-brand-blue bg-brand-blue text-white"
-                    : "border-border text-muted-foreground"
-                )}
-                aria-hidden="true"
-              >
-                {isAnswered ? <Check className="size-3.5" strokeWidth={3} /> : index + 1}
-              </span>
-              <p className="text-[0.95rem] leading-snug font-medium text-foreground">
-                {questionLabel}
-              </p>
-            </div>
-
-            <div
-              role="radiogroup"
-              aria-label={questionLabel}
-              className="mt-4 flex flex-col gap-1.5"
-            >
-              {options.map((option) => {
-                const isSelected = selectedKey === option;
-                const label = isLikert ? LIKERT_LABELS[option] : option;
-                const ariaLabel = isLikert ? `${option} ${label}` : option;
-
-                return (
-                  <button
-                    key={option}
-                    type="button"
-                    role="radio"
-                    aria-checked={isSelected}
-                    aria-label={ariaLabel}
-                    disabled={disabled}
-                    onClick={() => onAnswer(question.id, getNumericValue(option, isLikert))}
-                    className={cn(
-                      "group relative flex min-h-12 w-full items-center gap-3 rounded-lg border px-3 py-2.5 text-left text-sm transition-all outline-none",
-                      "focus-visible:ring-2 focus-visible:ring-brand-blue/50 focus-visible:ring-offset-1",
-                      "disabled:cursor-not-allowed disabled:opacity-50",
-                      isSelected
-                        ? "border-brand-blue bg-brand-blue text-white shadow-sm shadow-brand-blue/20"
-                        : "border-border bg-background text-foreground hover:border-brand-blue/50 hover:bg-brand-blue/5 active:scale-[0.99]"
-                    )}
-                  >
-                    {isLikert && (
-                      <span
-                        className={cn(
-                          "inline-flex size-7 shrink-0 items-center justify-center rounded-md text-sm font-semibold tabular-nums transition-colors",
-                          isSelected
-                            ? "bg-white/15 text-white"
-                            : "bg-muted text-muted-foreground group-hover:bg-brand-blue/10 group-hover:text-brand-blue"
-                        )}
-                        aria-hidden="true"
-                      >
-                        {option}
-                      </span>
-                    )}
-                    <span className="flex-1 font-medium">{label}</span>
-                  </button>
-                );
-              })}
-            </div>
-          </li>
-        );
-      })}
+      {questions.map((question, index) => (
+        <StackedRow
+          key={question.id}
+          question={question}
+          index={index}
+          isLikert={isLikert}
+          options={options}
+          disabled={disabled}
+          isInteractive={isInteractive}
+        />
+      ))}
     </ol>
   );
 }

--- a/features/questionnaires/components/form/questionnaire-form-stacked.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-stacked.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { memo } from "react";
+import { Check } from "lucide-react";
 
-import { Label } from "@/components/ui/label";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { cn } from "@/lib/utils";
 import {
   LIKERT_OPTIONS,
   YES_NO_OPTIONS,
@@ -25,35 +25,23 @@ type QuestionnaireFormStackedProps = {
   onAnswer: (questionId: string, value: number) => void;
 };
 
-/**
- * Converts a stored numeric answer back to the string key used by the RadioGroup.
- *
- * - Likert: numeric 4 → string "4"
- * - Yes/No: numeric 5 → string "Yes", numeric 1 → string "No"
- *
- * Returns "" if the question hasn't been answered yet.
- */
+const LIKERT_LABELS: Record<string, string> = {
+  "1": "Strongly Disagree",
+  "2": "Disagree",
+  "3": "Neutral",
+  "4": "Agree",
+  "5": "Strongly Agree",
+};
+
 function getSelectedOptionKey(value: number | undefined, isLikert: boolean): string {
   if (value === undefined) return "";
   return isLikert ? value.toString() : YES_NO_REVERSE_MAP[value];
 }
 
-/**
- * Converts a display option string to the numeric value stored in answers.
- *
- * - Likert: "4" → 4
- * - Yes/No: "Yes" → 5, "No" → 1 (scale-aligned)
- */
 function getNumericValue(option: string, isLikert: boolean): number {
   return isLikert ? Number(option) : YES_NO_VALUE_MAP[option];
 }
 
-/**
- * Mobile stacked layout for questionnaire questions.
- *
- * Renders each question as a card with selectable pill-style radio options.
- * This is the mobile counterpart to the desktop QuestionnaireFormMatrix table.
- */
 function QuestionnaireFormStackedBase({
   questions,
   questionType,
@@ -66,39 +54,87 @@ function QuestionnaireFormStackedBase({
   const disabled = mode === "preview";
 
   return (
-    <div className="space-y-5">
-      {questions.map((question) => {
+    <ol className="space-y-4">
+      {questions.map((question, index) => {
         const questionLabel = question.prompt || "Untitled question";
         const selectedKey = getSelectedOptionKey(answers[question.id], isLikert);
+        const isAnswered = selectedKey !== "";
 
         return (
-          <div key={question.id} className="space-y-2.5">
-            <p className="text-sm font-medium">{questionLabel}</p>
+          <li
+            key={question.id}
+            className={cn(
+              "rounded-xl border bg-card/60 p-4 transition-colors",
+              isAnswered ? "border-brand-blue/40 bg-brand-blue/[0.03]" : "border-border/70"
+            )}
+          >
+            <div className="flex items-start gap-3">
+              <span
+                className={cn(
+                  "mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-full border text-[0.7rem] font-semibold tabular-nums transition-colors",
+                  isAnswered
+                    ? "border-brand-blue bg-brand-blue text-white"
+                    : "border-border text-muted-foreground"
+                )}
+                aria-hidden="true"
+              >
+                {isAnswered ? <Check className="size-3.5" strokeWidth={3} /> : index + 1}
+              </span>
+              <p className="text-[0.95rem] leading-snug font-medium text-foreground">
+                {questionLabel}
+              </p>
+            </div>
 
-            <RadioGroup
-              value={selectedKey}
-              onValueChange={(val) => {
-                if (disabled) return;
-                onAnswer(question.id, getNumericValue(val, isLikert));
-              }}
-              disabled={disabled}
+            <div
+              role="radiogroup"
               aria-label={questionLabel}
-              className="flex flex-wrap justify-center gap-8"
+              className="mt-4 flex flex-col gap-1.5"
             >
-              {options.map((option) => (
-                <Label
-                  key={option}
-                  className="flex cursor-pointer items-center gap-1.5 rounded-lg border px-3 py-2 text-sm transition-colors has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50"
-                >
-                  <RadioGroupItem value={option} className="sr-only" />
-                  <span className="font-medium">{option}</span>
-                </Label>
-              ))}
-            </RadioGroup>
-          </div>
+              {options.map((option) => {
+                const isSelected = selectedKey === option;
+                const label = isLikert ? LIKERT_LABELS[option] : option;
+                const ariaLabel = isLikert ? `${option} ${label}` : option;
+
+                return (
+                  <button
+                    key={option}
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    aria-label={ariaLabel}
+                    disabled={disabled}
+                    onClick={() => onAnswer(question.id, getNumericValue(option, isLikert))}
+                    className={cn(
+                      "group relative flex min-h-12 w-full items-center gap-3 rounded-lg border px-3 py-2.5 text-left text-sm transition-all outline-none",
+                      "focus-visible:ring-2 focus-visible:ring-brand-blue/50 focus-visible:ring-offset-1",
+                      "disabled:cursor-not-allowed disabled:opacity-50",
+                      isSelected
+                        ? "border-brand-blue bg-brand-blue text-white shadow-sm shadow-brand-blue/20"
+                        : "border-border bg-background text-foreground hover:border-brand-blue/50 hover:bg-brand-blue/5 active:scale-[0.99]"
+                    )}
+                  >
+                    {isLikert && (
+                      <span
+                        className={cn(
+                          "inline-flex size-7 shrink-0 items-center justify-center rounded-md text-sm font-semibold tabular-nums transition-colors",
+                          isSelected
+                            ? "bg-white/15 text-white"
+                            : "bg-muted text-muted-foreground group-hover:bg-brand-blue/10 group-hover:text-brand-blue"
+                        )}
+                        aria-hidden="true"
+                      >
+                        {option}
+                      </span>
+                    )}
+                    <span className="flex-1 font-medium">{label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </li>
         );
       })}
-    </div>
+    </ol>
   );
 }
 

--- a/features/questionnaires/components/form/questionnaire-form-store.ts
+++ b/features/questionnaires/components/form/questionnaire-form-store.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { createContext, useContext, useSyncExternalStore } from "react";
+import { createStore, type StoreApi } from "zustand/vanilla";
+
+import type {
+  QuestionnaireFormAnswers,
+  QuestionnaireFormValues,
+} from "@/features/questionnaires/types";
+
+type QuestionnaireFormState = {
+  answers: QuestionnaireFormAnswers;
+  qualitativeComment: string;
+  setAnswer: (questionId: string, value: number) => void;
+  setComment: (value: string) => void;
+  getValues: () => QuestionnaireFormValues;
+};
+
+export type QuestionnaireFormStore = StoreApi<QuestionnaireFormState>;
+
+export function createQuestionnaireFormStore(
+  defaults?: Partial<QuestionnaireFormValues>
+): QuestionnaireFormStore {
+  return createStore<QuestionnaireFormState>((set, get) => ({
+    answers: defaults?.answers ?? {},
+    qualitativeComment: defaults?.qualitativeComment ?? "",
+    setAnswer: (questionId, value) =>
+      set((state) => ({ answers: { ...state.answers, [questionId]: value } })),
+    setComment: (value) => set({ qualitativeComment: value }),
+    getValues: () => ({
+      answers: get().answers,
+      qualitativeComment: get().qualitativeComment,
+    }),
+  }));
+}
+
+const QuestionnaireFormStoreContext = createContext<QuestionnaireFormStore | null>(null);
+
+export const QuestionnaireFormStoreProvider = QuestionnaireFormStoreContext.Provider;
+
+function useStoreApi(): QuestionnaireFormStore {
+  const store = useContext(QuestionnaireFormStoreContext);
+  if (!store) {
+    throw new Error(
+      "QuestionnaireFormStore missing: component must be rendered inside QuestionnaireFormRenderer"
+    );
+  }
+  return store;
+}
+
+export function useQuestionnaireFormStore(): QuestionnaireFormStore {
+  return useStoreApi();
+}
+
+export function useQuestionAnswer(questionId: string): number | undefined {
+  const store = useStoreApi();
+  return useSyncExternalStore(
+    store.subscribe,
+    () => store.getState().answers[questionId],
+    () => store.getState().answers[questionId]
+  );
+}
+
+export function useQualitativeComment(): string {
+  const store = useStoreApi();
+  return useSyncExternalStore(
+    store.subscribe,
+    () => store.getState().qualitativeComment,
+    () => store.getState().qualitativeComment
+  );
+}
+
+export function useHasQualitativeContent(): boolean {
+  const store = useStoreApi();
+  const get = () => store.getState().qualitativeComment.trim().length > 0;
+  return useSyncExternalStore(store.subscribe, get, get);
+}
+
+export function useAnsweredCountFor(ids: string[]): number {
+  const store = useStoreApi();
+  const getCount = () => {
+    const { answers } = store.getState();
+    let count = 0;
+    for (const id of ids) if (id in answers) count++;
+    return count;
+  };
+  return useSyncExternalStore(store.subscribe, getCount, getCount);
+}
+
+type FormActions = Pick<QuestionnaireFormState, "setAnswer" | "setComment">;
+
+export function useFormActions(): FormActions {
+  const store = useStoreApi();
+  const { setAnswer, setComment } = store.getState();
+  return { setAnswer, setComment };
+}

--- a/features/questionnaires/components/questionnaire-rating-scale-instructions.tsx
+++ b/features/questionnaires/components/questionnaire-rating-scale-instructions.tsx
@@ -1,45 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, Info } from "lucide-react";
+
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 
 const RATING_SCALE_ITEMS = [
   {
-    label: "1 - Strongly Disagree",
+    value: "1",
+    label: "Strongly Disagree",
     description: "Performance does not conform with University of Cebu standards.",
   },
   {
-    label: "2 - Disagree",
+    value: "2",
+    label: "Disagree",
     description: "Performance is below University of Cebu standards.",
   },
   {
-    label: "3 - Neutral",
+    value: "3",
+    label: "Neutral",
     description: "Performance is within standards in many instances.",
   },
   {
-    label: "4 - Agree",
+    value: "4",
+    label: "Agree",
     description: "Performance is within standards in most cases.",
   },
   {
-    label: "5 - Strongly Agree",
+    value: "5",
+    label: "Strongly Agree",
     description: "Performance exceeds University of Cebu standards consistently.",
   },
 ] as const;
 
 export function QuestionnaireRatingScaleInstructions() {
+  const [open, setOpen] = useState(false);
+
   return (
-    <Card className="border-brand-yellow/90 bg-brand-yellow/30">
-      <CardHeader>
+    <Card className="gap-0 overflow-hidden border-brand-yellow/90 bg-brand-yellow/30 py-0">
+      {/* Mobile: collapsible trigger */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition-colors hover:bg-brand-yellow/10 sm:hidden"
+        aria-expanded={open}
+        aria-controls="rating-scale-content"
+      >
+        <span className="flex items-center gap-2.5">
+          <Info className="size-4 text-primary/70" aria-hidden="true" />
+          <span className="font-playfair text-base font-semibold text-foreground">
+            Rating scale
+          </span>
+        </span>
+        <span className="flex items-center gap-1.5 text-[0.7rem] font-medium uppercase tracking-[0.14em] text-primary/70">
+          {open ? "Hide" : "Show"}
+          <ChevronDown
+            className={cn("size-3.5 transition-transform duration-200", open && "rotate-180")}
+            aria-hidden="true"
+          />
+        </span>
+      </button>
+
+      {/* Desktop: always-visible header */}
+      <CardHeader className="hidden px-6 pt-6 pb-3 sm:block">
         <CardTitle className="font-playfair text-lg">Rating scale</CardTitle>
         <CardDescription className="text-primary">
           Use this scale when reviewing each quantitative statement.
         </CardDescription>
       </CardHeader>
-      <CardContent className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-5">
-        {RATING_SCALE_ITEMS.map((item) => (
-          <div key={item.label}>
-            <p className="font-medium">{item.label}</p>
-            <p className="mt-1 text-primary">{item.description}</p>
-          </div>
-        ))}
-      </CardContent>
+
+      <div
+        id="rating-scale-content"
+        className={cn(
+          "grid grid-rows-[0fr] transition-[grid-template-rows] duration-300 sm:grid-rows-[1fr]",
+          open && "grid-rows-[1fr]"
+        )}
+      >
+        <div className="overflow-hidden">
+          <CardContent className="grid gap-2.5 px-5 pb-5 text-sm sm:grid-cols-2 sm:gap-3 sm:px-6 sm:pb-6 lg:grid-cols-5">
+            {RATING_SCALE_ITEMS.map((item) => (
+              <div
+                key={item.value}
+                className="flex gap-2.5 rounded-lg bg-white/40 p-2.5 sm:block sm:bg-transparent sm:p-0"
+              >
+                <span className="font-playfair flex size-7 shrink-0 items-center justify-center rounded-md bg-brand-yellow/70 text-base font-bold text-foreground sm:hidden">
+                  {item.value}
+                </span>
+                <div className="min-w-0">
+                  <p className="font-medium leading-tight">
+                    <span className="hidden sm:inline">{item.value} - </span>
+                    {item.label}
+                  </p>
+                  <p className="mt-1 text-xs leading-snug text-primary sm:text-sm">
+                    {item.description}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </div>
+      </div>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

Two commits bundled on `feat/fac-web-questionnaire-enhancements`, both targeting the student evaluation form on mobile:

- **feat (8c74b73):** Mobile UX pass — stacked pill layout for Likert/Yes-No questions on small screens, sticky progress, improved section cards.
- **perf (b814279):** Eliminate render cascade on every tap. Form state moves from a single `useState<Record<string, number>>` in `QuestionnaireFormRenderer` into a form-scoped Zustand vanilla store consumed via React context. Each question row subscribes only to its own answer; sections, progress, and qualitative each use narrow selectors; autosave hooks into `store.subscribe` outside React's render cycle. Drop `backdrop-blur-md` on the mobile sticky progress bar.

Before the perf commit, every tap created a new `answers` object reference that was prop-drilled to every section, causing the full form tree to re-render. Now only the tapped row + progress update per tap.

Public props on `QuestionnaireFormRenderer` (`model`, `mode`, `defaultValues`, `onChange`, `progressTrailing`) are preserved, so all existing callers (student evaluation, faculty self-evaluation, superadmin preview pages) are unchanged.

## Test plan

- [ ] `bun run typecheck` passes (verified locally).
- [ ] `bun run lint` passes (verified locally).
- [ ] On a throttled mobile emulator (iPhone 14, 4x CPU throttle), tap through a full Likert section — answers feel instant, progress counter updates, per-section counter updates.
- [ ] React DevTools Profiler: record a 5-tap sequence. Only `StackedRow` for the tapped question + `QuestionnaireFormProgress` should render. Sibling rows and sections should **not**.
- [ ] Draft autosave still fires after 3s of idle (`draftStatus` transitions idle → saving → saved).
- [ ] Reload mid-draft — answers re-hydrate via `draftHydrationKey`.
- [ ] Submit the form — `handleSubmit` reads the latest values via `formValuesRef.current` populated by the store subscription.
- [ ] Superadmin questionnaire preview pages still render with inputs disabled (`mode="preview"`).

Closes #92