### PR TITLE
[FEAT][FAC-WEB-35] chairperson faculty analysis parity with program-scoped self-view handling

### DIFF
--- a/app/(dashboard)/chairperson/faculties/[facultyId]/analysis/page.tsx
+++ b/app/(dashboard)/chairperson/faculties/[facultyId]/analysis/page.tsx
@@ -1,55 +1,15 @@
-import Link from "next/link";
+import { FacultyReportScreen } from "@/features/faculty-analytics";
 
-import { Button } from "@/components/ui/button";
-
-type ChairpersonFacultyAnalysisPlaceholderPageProps = {
+type ChairpersonFacultyAnalysisPageProps = {
   params: Promise<{
     facultyId: string;
   }>;
-  searchParams: Promise<{
-    facultyName?: string;
-    semesterLabel?: string;
-  }>;
 };
 
-export default async function ChairpersonFacultyAnalysisPlaceholderPage({
+export default async function ChairpersonFacultyAnalysisPage({
   params,
-  searchParams,
-}: ChairpersonFacultyAnalysisPlaceholderPageProps) {
+}: ChairpersonFacultyAnalysisPageProps) {
   const { facultyId } = await params;
-  const { facultyName, semesterLabel } = await searchParams;
 
-  return (
-    <section className="space-y-6 px-1 pb-4 md:p-8">
-      <div className="space-y-2">
-        <h1 className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl">
-          Faculty Analysis
-        </h1>
-        <p className="font-sans text-sm text-muted-foreground">
-          This chairperson faculty analysis page is a placeholder for now.
-        </p>
-      </div>
-
-      <div className="rounded-2xl border border-border/70 bg-card p-5 shadow-sm">
-        <dl className="space-y-3 font-sans text-sm">
-          <div>
-            <dt className="text-muted-foreground">Faculty</dt>
-            <dd className="font-medium text-foreground">{facultyName ?? "Unknown faculty"}</dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">Faculty ID</dt>
-            <dd className="font-medium text-foreground">{facultyId}</dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">Semester</dt>
-            <dd className="font-medium text-foreground">{semesterLabel ?? "Not provided"}</dd>
-          </div>
-        </dl>
-      </div>
-
-      <Button asChild variant="outline">
-        <Link href="/chairperson/faculties">Back to Faculties</Link>
-      </Button>
-    </section>
-  );
+  return <FacultyReportScreen facultyId={facultyId} />;
 }

--- a/app/(dashboard)/faculty/courses/page.tsx
+++ b/app/(dashboard)/faculty/courses/page.tsx
@@ -1,8 +1,0 @@
-export default function FacultyCoursesPage() {
-  return (
-    <section className="md:p-8">
-      <h1 className="text-2xl font-semibold">Faculty Courses</h1>
-      <p className="mt-2 text-sm text-muted-foreground">Placeholder page for faculty courses.</p>
-    </section>
-  );
-}

--- a/app/(dashboard)/faculty/page.tsx
+++ b/app/(dashboard)/faculty/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function FacultyDashboardPage() {
-  redirect("/faculty/courses");
+  redirect("/faculty/analytics");
 }

--- a/features/auth/lib/role-route.ts
+++ b/features/auth/lib/role-route.ts
@@ -35,12 +35,9 @@ const ROLE_CONFIG: Record<AppRole, RoleConfig> = {
   },
   [APP_ROLES.FACULTY]: {
     label: "Faculty",
-    homePath: "/faculty/courses",
+    homePath: "/faculty/analytics",
     routePrefix: "/faculty",
-    navItems: [
-      { title: "Courses", url: "/faculty/courses", icon: BookOpen },
-      { title: "Analytics", url: "/faculty/analytics", icon: BarChart3 },
-    ],
+    navItems: [{ title: "Analytics", url: "/faculty/analytics", icon: BarChart3 }],
   },
   [APP_ROLES.DEAN]: {
     label: "Dean",

--- a/features/faculty-analytics/components/batch-report-export-dialog.tsx
+++ b/features/faculty-analytics/components/batch-report-export-dialog.tsx
@@ -164,7 +164,7 @@ export function BatchReportExportDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-4xl">
+      <DialogContent className="max-h-[90vh] overflow-hidden sm:max-w-4xl">
         <DialogHeader>
           <DialogTitle>Batch Report Export</DialogTitle>
           <DialogDescription>
@@ -172,7 +172,7 @@ export function BatchReportExportDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-5">
+        <div className="min-h-0 space-y-5 overflow-hidden">
           <div className="rounded-lg border border-border/70 bg-muted/20 p-4">
             <dl className="space-y-2 font-sans text-sm">
               <div className="flex items-center justify-between gap-4">
@@ -253,13 +253,13 @@ export function BatchReportExportDialog({
                           questionnaireTypesQuery.isLoading || questionnaireTypes.length === 0
                         }
                       >
-                      <span className="truncate">
-                        {effectiveQuestionnaireTypeCode
-                          ? resolveQuestionnaireTypeLabel(
-                              effectiveQuestionnaireTypeCode,
-                              selectedQuestionnaireTypeLabel
-                            )
-                          : "Select questionnaire type"}
+                        <span className="truncate">
+                          {effectiveQuestionnaireTypeCode
+                            ? resolveQuestionnaireTypeLabel(
+                                effectiveQuestionnaireTypeCode,
+                                selectedQuestionnaireTypeLabel
+                              )
+                            : "Select questionnaire type"}
                         </span>
                         <ChevronDown className="size-4" />
                       </Button>
@@ -271,7 +271,7 @@ export function BatchReportExportDialog({
                       <DropdownMenuRadioGroup
                         value={effectiveQuestionnaireTypeCode}
                         onValueChange={setSelectedQuestionnaireTypeCode}
-                    >
+                      >
                         {questionnaireTypes.map((type) => (
                           <DropdownMenuRadioItem
                             key={type.code}
@@ -380,90 +380,92 @@ export function BatchReportExportDialog({
 
               {!batchStatusQuery.isLoading && batchStatus && batchStatus.jobs.length > 0 ? (
                 <div className="space-y-4">
-                  <div className="data-table-wrapper">
-                    <Table className="w-full table-fixed [&_td]:whitespace-normal [&_th]:whitespace-normal">
-                      <TableHeader className="data-table-header">
-                        <TableRow>
-                          <TableHead className="data-table-head w-[24%]">Faculty</TableHead>
-                          <TableHead className="data-table-head w-[18%]">Status</TableHead>
-                          <TableHead className="data-table-head w-[38%]">Details</TableHead>
-                          <TableHead className="data-table-head w-[20%] text-right">
-                            Action
-                          </TableHead>
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {batchStatus.jobs.map((job) => {
-                          const expired = isPresignedUrlExpired(job.expiresAt);
+                  <div className="scrollbar-hidden max-h-[24rem] overflow-y-auto pr-1">
+                    <div className="data-table-wrapper">
+                      <Table className="w-full table-fixed [&_td]:whitespace-normal [&_th]:whitespace-normal">
+                        <TableHeader className="data-table-header">
+                          <TableRow>
+                            <TableHead className="data-table-head w-[24%]">Faculty</TableHead>
+                            <TableHead className="data-table-head w-[18%]">Status</TableHead>
+                            <TableHead className="data-table-head w-[38%]">Details</TableHead>
+                            <TableHead className="data-table-head w-[20%] text-right">
+                              Action
+                            </TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {batchStatus.jobs.map((job) => {
+                            const expired = isPresignedUrlExpired(job.expiresAt);
 
-                          return (
-                            <TableRow key={job.jobId} className="data-table-row">
-                              <TableCell className="data-table-cell align-top">
-                                <div>
-                                  <p className="font-sans text-sm font-semibold text-foreground">
-                                    {job.facultyName}
-                                  </p>
-                                  <p className="mt-1 font-sans text-xs text-muted-foreground">
-                                    Created {formatRelativeTime(job.createdAt)}
-                                  </p>
-                                </div>
-                              </TableCell>
-                              <TableCell className="data-table-cell align-top">
-                                <Badge variant="outline">
-                                  {formatReportJobStatusLabel(job.status)}
-                                </Badge>
-                              </TableCell>
-                              <TableCell className="data-table-cell align-top">
-                                <div className="space-y-1 font-sans text-sm text-muted-foreground">
-                                  {job.status === "completed" ? (
-                                    <>
-                                      <p>
-                                        {expired
-                                          ? "Secure link expired. Refresh status to get a new URL."
-                                          : `Secure link expires ${formatRelativeTime(job.expiresAt ?? "")}.`}
-                                      </p>
-                                      {job.completedAt ? (
-                                        <p className="text-xs">
-                                          Completed {formatDateTime(job.completedAt)}
-                                        </p>
-                                      ) : null}
-                                    </>
-                                  ) : null}
-                                  {job.status === "failed" ? (
-                                    <p>{job.error ?? "Export failed."}</p>
-                                  ) : null}
-                                  {job.status === "skipped" ? (
-                                    <p>{job.message ?? "Export skipped for this faculty."}</p>
-                                  ) : null}
-                                  {(job.status === "waiting" || job.status === "active") && (
-                                    <p>Report generation is still in progress.</p>
-                                  )}
-                                </div>
-                              </TableCell>
-                              <TableCell className="data-table-cell align-top text-right">
-                                {job.status === "completed" ? (
-                                  <div className="flex flex-wrap justify-end gap-2">
-                                    <Button
-                                      asChild
-                                      size="sm"
-                                      disabled={!job.downloadUrl || expired}
-                                    >
-                                      <a href={job.downloadUrl} target="_blank" rel="noreferrer">
-                                        View
-                                      </a>
-                                    </Button>
+                            return (
+                              <TableRow key={job.jobId} className="data-table-row">
+                                <TableCell className="data-table-cell align-top">
+                                  <div>
+                                    <p className="font-sans text-sm font-semibold text-foreground">
+                                      {job.facultyName}
+                                    </p>
+                                    <p className="mt-1 font-sans text-xs text-muted-foreground">
+                                      Created {formatRelativeTime(job.createdAt)}
+                                    </p>
                                   </div>
-                                ) : (
-                                  <span className="font-sans text-xs text-muted-foreground">
-                                    No action
-                                  </span>
-                                )}
-                              </TableCell>
-                            </TableRow>
-                          );
-                        })}
-                      </TableBody>
-                    </Table>
+                                </TableCell>
+                                <TableCell className="data-table-cell align-top">
+                                  <Badge variant="outline">
+                                    {formatReportJobStatusLabel(job.status)}
+                                  </Badge>
+                                </TableCell>
+                                <TableCell className="data-table-cell align-top">
+                                  <div className="space-y-1 font-sans text-sm text-muted-foreground">
+                                    {job.status === "completed" ? (
+                                      <>
+                                        <p>
+                                          {expired
+                                            ? "Secure link expired. Refresh status to get a new URL."
+                                            : `Secure link expires ${formatRelativeTime(job.expiresAt ?? "")}.`}
+                                        </p>
+                                        {job.completedAt ? (
+                                          <p className="text-xs">
+                                            Completed {formatDateTime(job.completedAt)}
+                                          </p>
+                                        ) : null}
+                                      </>
+                                    ) : null}
+                                    {job.status === "failed" ? (
+                                      <p>{job.error ?? "Export failed."}</p>
+                                    ) : null}
+                                    {job.status === "skipped" ? (
+                                      <p>{job.message ?? "Export skipped for this faculty."}</p>
+                                    ) : null}
+                                    {(job.status === "waiting" || job.status === "active") && (
+                                      <p>Report generation is still in progress.</p>
+                                    )}
+                                  </div>
+                                </TableCell>
+                                <TableCell className="data-table-cell align-top text-right">
+                                  {job.status === "completed" ? (
+                                    <div className="flex flex-wrap justify-end gap-2">
+                                      <Button
+                                        asChild
+                                        size="sm"
+                                        disabled={!job.downloadUrl || expired}
+                                      >
+                                        <a href={job.downloadUrl} target="_blank" rel="noreferrer">
+                                          View
+                                        </a>
+                                      </Button>
+                                    </div>
+                                  ) : (
+                                    <span className="font-sans text-xs text-muted-foreground">
+                                      No action
+                                    </span>
+                                  )}
+                                </TableCell>
+                              </TableRow>
+                            );
+                          })}
+                        </TableBody>
+                      </Table>
+                    </div>
                   </div>
 
                   <PaginationFooter

--- a/features/faculty-analytics/components/faculty-report-header.tsx
+++ b/features/faculty-analytics/components/faculty-report-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, ChevronLeft } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -47,10 +47,7 @@ export function FacultyReportHeader({
           variant="outline"
           className="w-full justify-center px-4 py-2.5 font-sans text-sm sm:w-auto sm:justify-start"
         >
-          <Link href={backHref}>
-            <ChevronLeft className="size-4" />
-            Back to faculties
-          </Link>
+          <Link href={backHref}>Back to faculties</Link>
         </Button>
       ) : null}
 

--- a/features/faculty-analytics/components/faculty-report-header.tsx
+++ b/features/faculty-analytics/components/faculty-report-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, ChevronLeft } from "lucide-react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 type FacultyReportHeaderProps = {
+  showBackButton?: boolean;
   backHref: string;
   courseId: string;
   courseLabel: string;
@@ -26,6 +27,7 @@ type FacultyReportHeaderProps = {
 };
 
 export function FacultyReportHeader({
+  showBackButton = true,
   backHref,
   courseId,
   courseLabel,
@@ -39,26 +41,29 @@ export function FacultyReportHeader({
       aria-label="Faculty report controls"
       className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between"
     >
-      <Button
-        asChild
-        variant="ghost"
-        size="sm"
-        className="w-fit px-2 font-sans text-xs uppercase tracking-[0.18em] text-stone-500 hover:text-stone-900"
-      >
-        <Link href={backHref}>← Back to faculties</Link>
-      </Button>
+      {showBackButton ? (
+        <Button
+          asChild
+          variant="outline"
+          className="w-full justify-center px-4 py-2.5 font-sans text-sm sm:w-auto sm:justify-start"
+        >
+          <Link href={backHref}>
+            <ChevronLeft className="size-4" />
+            Back to faculties
+          </Link>
+        </Button>
+      ) : null}
 
       <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              size="sm"
-              className="w-full min-w-0 justify-between border-stone-200 bg-white px-3 py-2 font-sans text-xs sm:w-56"
+              className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm sm:w-56"
               disabled={isCourseLoading || availableCourses.length === 0}
             >
-              <span className="truncate text-stone-700">{courseLabel}</span>
-              <ChevronDown className="size-3.5 text-stone-400" />
+              <span className="truncate">{courseLabel}</span>
+              <ChevronDown className="size-4" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent
@@ -85,8 +90,7 @@ export function FacultyReportHeader({
         <Button
           type="button"
           variant="brand"
-          size="sm"
-          className="w-full px-4 py-2 font-sans text-xs sm:w-auto"
+          className="w-full px-4 py-2.5 font-sans text-sm sm:w-auto"
           onClick={onExport}
         >
           Export PDF

--- a/features/faculty-analytics/components/faculty-report-screen.tsx
+++ b/features/faculty-analytics/components/faculty-report-screen.tsx
@@ -145,6 +145,7 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
         </div>
 
         <FacultyReportHeader
+          showBackButton={!viewModel.isFacultySelfView}
           backHref={viewModel.backHref}
           courseId={viewModel.courseId}
           courseLabel={viewModel.selectedCourseLabel}

--- a/features/faculty-analytics/components/report-export-dialog.tsx
+++ b/features/faculty-analytics/components/report-export-dialog.tsx
@@ -127,7 +127,7 @@ export function ReportExportDialog({
               tone="success"
               message={
                 urlExpired
-                  ? "The secure PDF link has expired. Refresh the link to access the report again."
+                  ? "The secure PDF link has expired. Close this dialog and generate a new PDF to access the report again."
                   : `Secure link expires ${formatRelativeTime(status?.expiresAt ?? "")}.`
               }
               meta={
@@ -190,27 +190,15 @@ export function ReportExportDialog({
             ) : null}
 
             {isCompleted ? (
-              <>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => {
-                    void statusQuery.refetch();
-                  }}
-                  className="w-full sm:w-auto"
-                >
-                  Refresh Link
-                </Button>
-                <Button
-                  asChild
-                  disabled={!status?.downloadUrl || urlExpired}
-                  className="w-full sm:w-auto"
-                >
-                  <a href={status?.downloadUrl} target="_blank" rel="noreferrer">
-                    View PDF
-                  </a>
-                </Button>
-              </>
+              <Button
+                asChild
+                disabled={!status?.downloadUrl || urlExpired}
+                className="w-full sm:w-auto"
+              >
+                <a href={status?.downloadUrl} target="_blank" rel="noreferrer">
+                  View PDF
+                </a>
+              </Button>
             ) : null}
           </div>
         </DialogFooter>

--- a/features/faculty-analytics/components/scoped-faculty-analysis-table.tsx
+++ b/features/faculty-analytics/components/scoped-faculty-analysis-table.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 import { PaginationFooter } from "@/components/shared/pagination-footer";
+import { APP_ROLES } from "@/constants/roles";
+import { useMe } from "@/features/auth/hooks/use-me";
 import { FacultySubjects } from "@/features/faculty-analytics/components/faculty-subjects";
-import { buildScopedFacultyAnalysisHref } from "@/features/faculty-analytics/lib/faculty-analysis-routes";
+import {
+  buildFacultySelfAnalysisHref,
+  buildScopedFacultyAnalysisHref,
+} from "@/features/faculty-analytics/lib/faculty-analysis-routes";
 import type { FacultyListItemDto, PaginationMetaDto } from "@/features/faculty-analytics/types";
+import { useAuthStore } from "@/stores/auth-store";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -27,6 +34,15 @@ type ScopedFacultyAnalysisTableProps = {
   scopeLabel: "Campus" | "Department" | "Program";
 };
 
+type FacultyAnalysisActionLinkOptions = {
+  facultyId: string;
+  facultyName: string;
+  selectedSemesterId: string;
+  selectedSemesterLabel: string;
+  scopeLabel: ScopedFacultyAnalysisTableProps["scopeLabel"];
+  currentUserId?: string;
+};
+
 function getFacultyInitials(name: string) {
   return name
     .split(/\s+/)
@@ -34,6 +50,33 @@ function getFacultyInitials(name: string) {
     .slice(0, 2)
     .map((part) => part[0]?.toUpperCase() ?? "")
     .join("");
+}
+
+function resolveFacultyAnalysisHref({
+  facultyId,
+  facultyName,
+  selectedSemesterId,
+  selectedSemesterLabel,
+  scopeLabel,
+  currentUserId,
+}: FacultyAnalysisActionLinkOptions) {
+  const isCurrentUser = scopeLabel === "Program" && currentUserId === facultyId;
+
+  return {
+    isCurrentUser,
+    href: isCurrentUser
+      ? buildFacultySelfAnalysisHref({
+          semesterId: selectedSemesterId,
+          semesterLabel: selectedSemesterLabel,
+        })
+      : buildScopedFacultyAnalysisHref({
+          facultyId,
+          facultyName,
+          semesterId: selectedSemesterId,
+          semesterLabel: selectedSemesterLabel,
+          scopeLabel,
+        }),
+  };
 }
 
 export function ScopedFacultyAnalysisTable({
@@ -45,6 +88,13 @@ export function ScopedFacultyAnalysisTable({
   onRowsPerPageChange,
   scopeLabel,
 }: ScopedFacultyAnalysisTableProps) {
+  const router = useRouter();
+  const meQuery = useMe();
+  const setActiveRole = useAuthStore((state) => state.setActiveRole);
+  const setPendingRedirectPath = useAuthStore((state) => state.setPendingRedirectPath);
+  const actionButtonClassName =
+    "h-auto px-2 py-2 text-center font-sans text-xs leading-none md:px-3 md:text-sm";
+
   return (
     <div className="space-y-5">
       <div className="data-table-wrapper">
@@ -63,52 +113,71 @@ export function ScopedFacultyAnalysisTable({
             </TableRow>
           </TableHeader>
           <TableBody className="[&_tr:last-child]:border-b-0">
-            {facultyList.map((faculty) => (
-              <TableRow key={faculty.id} className="data-table-row w-full">
-                <TableCell className="data-table-cell px-2 md:px-3 lg:px-5">
-                  <div className="flex min-w-0 items-center gap-3">
-                    <Avatar size="default" className="border border-border/70">
-                      {faculty.profilePicture ? (
-                        <AvatarImage src={faculty.profilePicture} alt={faculty.fullName} />
-                      ) : null}
-                      <AvatarFallback className="bg-slate-100 font-sans text-xs font-semibold text-slate-700">
-                        {getFacultyInitials(faculty.fullName)}
-                      </AvatarFallback>
-                    </Avatar>
-                    <span className="truncate font-sans text-xs font-semibold text-foreground md:text-sm">
-                      {faculty.fullName}
-                    </span>
-                  </div>
-                </TableCell>
-                <TableCell className="data-table-cell w-0 px-2 md:px-3 lg:px-5">
-                  <div className="w-full min-w-0">
-                    <FacultySubjects subjects={faculty.subjects} />
-                  </div>
-                </TableCell>
-                <TableCell className="data-table-cell px-2 text-right md:px-3 lg:px-5">
-                  <Button
-                    asChild
-                    variant="secondary"
-                    size="sm"
-                    className="h-auto px-2 py-2 text-center font-sans text-xs leading-none md:px-3 md:text-sm"
-                  >
-                    <Link
-                      href={buildScopedFacultyAnalysisHref({
-                        facultyId: faculty.id,
-                        facultyName: faculty.fullName,
-                        semesterId: selectedSemesterId,
-                        semesterLabel: selectedSemesterLabel,
-                        scopeLabel,
-                      })}
-                      className="text-center leading-none"
-                    >
-                      <span className="sm:hidden">View</span>
-                      <span className="hidden sm:inline">View Analysis</span>
-                    </Link>
-                  </Button>
-                </TableCell>
-              </TableRow>
-            ))}
+            {facultyList.map((faculty) => {
+              const { isCurrentUser, href } = resolveFacultyAnalysisHref({
+                facultyId: faculty.id,
+                facultyName: faculty.fullName,
+                selectedSemesterId,
+                selectedSemesterLabel,
+                scopeLabel,
+                currentUserId: meQuery.data?.id,
+              });
+
+              return (
+                <TableRow key={faculty.id} className="data-table-row w-full">
+                  <TableCell className="data-table-cell px-2 md:px-3 lg:px-5">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <Avatar size="default" className="border border-border/70">
+                        {faculty.profilePicture ? (
+                          <AvatarImage src={faculty.profilePicture} alt={faculty.fullName} />
+                        ) : null}
+                        <AvatarFallback className="bg-slate-100 font-sans text-xs font-semibold text-slate-700">
+                          {getFacultyInitials(faculty.fullName)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <span className="truncate font-sans text-xs font-semibold text-foreground md:text-sm">
+                        {faculty.fullName}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="data-table-cell w-0 px-2 md:px-3 lg:px-5">
+                    <div className="w-full min-w-0">
+                      <FacultySubjects subjects={faculty.subjects} />
+                    </div>
+                  </TableCell>
+                  <TableCell className="data-table-cell px-2 text-right md:px-3 lg:px-5">
+                    {isCurrentUser ? (
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        className={actionButtonClassName}
+                        onClick={() => {
+                          setPendingRedirectPath("/faculty/analytics");
+                          setActiveRole(APP_ROLES.FACULTY);
+                          router.push(href);
+                        }}
+                      >
+                        <span className="sm:hidden">View</span>
+                        <span className="hidden sm:inline">View Analysis</span>
+                      </Button>
+                    ) : (
+                      <Button
+                        asChild
+                        variant="secondary"
+                        size="sm"
+                        className={actionButtonClassName}
+                      >
+                        <Link href={href} className="text-center leading-none">
+                          <span className="sm:hidden">View</span>
+                          <span className="hidden sm:inline">View Analysis</span>
+                        </Link>
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       </div>

--- a/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
+++ b/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
@@ -371,9 +371,9 @@ export function useFacultyReportDetailViewModel({
   const roleConfig = activeRole ? getRoleConfig(activeRole) : null;
   const isFacultySelf = activeRole === APP_ROLES.FACULTY;
   const backHref = isFacultySelf
-    ? (roleConfig?.homePath ?? "/faculty/courses")
+    ? (roleConfig?.homePath ?? "/faculty/analytics")
     : `${roleConfig?.routePrefix ?? "/dean"}/faculties`;
-  const backLabel = isFacultySelf ? "Back to Courses" : "Back to Faculties";
+  const backLabel = "Back to Faculties";
 
   return {
     backHref,

--- a/features/faculty-analytics/lib/faculty-analysis-routes.ts
+++ b/features/faculty-analytics/lib/faculty-analysis-routes.ts
@@ -9,6 +9,26 @@ type BuildScopedFacultyAnalysisHrefOptions = {
   scopeLabel: "Campus" | "Department" | "Program";
 };
 
+type BuildFacultySelfAnalysisHrefOptions = {
+  semesterId: string;
+  semesterLabel: string;
+  questionnaireTypeCode?: string;
+};
+
+export function buildFacultySelfAnalysisHref({
+  semesterId,
+  semesterLabel,
+  questionnaireTypeCode = DEFAULT_QUESTIONNAIRE_TYPE,
+}: BuildFacultySelfAnalysisHrefOptions) {
+  const params = new URLSearchParams({
+    semesterId,
+    semesterLabel,
+    questionnaireTypeCode,
+  });
+
+  return `/faculty/analytics?${params.toString()}`;
+}
+
 export function buildScopedFacultyAnalysisHref({
   facultyId,
   facultyName,


### PR DESCRIPTION
## Summary
- replace the chairperson faculty analysis placeholder route with the shared faculty report screen
- align faculty analytics report controls and export dialog behavior with the current shared UI patterns
- route chairperson self-analysis clicks to faculty self-view to avoid multi-role guard conflicts

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] Open `/chairperson/faculties` and confirm `View Analysis` loads the shared analysis experience
- [x] Confirm chairperson back navigation returns to `/chairperson/faculties`
- [x] Confirm clicking the current user’s own row from the chairperson list opens `/faculty/analytics`
- [x] Confirm other faculty rows still open the chairperson analysis route
- [x] Confirm dean and campus-head analysis routes remain unchanged

Closes #91