### PR TITLE
FAC WEB feat: add dimension radar, impact scatter, and rating distribution charts to Scores tab

### DIFF
--- a/features/faculty-analytics/components/faculty-report-dimension-radar-chart.tsx
+++ b/features/faculty-analytics/components/faculty-report-dimension-radar-chart.tsx
@@ -94,7 +94,7 @@ export function FacultyReportDimensionRadarChart({
                           </span>
                         </div>
                         <div className="flex items-center justify-between gap-4">
-                          <span className="text-muted-foreground">Responses</span>
+                          <span className="text-muted-foreground">Ratings</span>
                           <span className="font-mono font-medium text-foreground">
                             {dimension.responseCount}
                           </span>

--- a/features/faculty-analytics/components/faculty-report-dimension-radar-chart.tsx
+++ b/features/faculty-analytics/components/faculty-report-dimension-radar-chart.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  PolarAngleAxis,
-  PolarGrid,
-  PolarRadiusAxis,
-  Radar,
-  RadarChart,
-} from "recharts";
+import { PolarAngleAxis, PolarGrid, PolarRadiusAxis, Radar, RadarChart } from "recharts";
 
 import {
   ChartContainer,
@@ -14,13 +8,7 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatFacultyReportScore } from "@/features/faculty-analytics/lib/faculty-report-detail";
 import type { FacultyReportDimensionDto } from "@/features/faculty-analytics/types";
 import { useIsMobile } from "@/lib/use-mobile";
@@ -84,23 +72,16 @@ export function FacultyReportDimensionRadarChart({
         >
           <RadarChart data={chartData} outerRadius="72%">
             <PolarGrid />
-            <PolarAngleAxis
-              dataKey="label"
-              tick={{ fontSize: isMobile ? 10 : 12 }}
-            />
-            <PolarRadiusAxis
-              angle={90}
-              domain={[0, 5]}
-              tick={{ fontSize: 10 }}
-            />
+            <PolarAngleAxis dataKey="label" tick={{ fontSize: isMobile ? 10 : 12 }} />
+            <PolarRadiusAxis angle={90} domain={[0, 5]} tick={{ fontSize: 10 }} />
             <ChartTooltip
               cursor={false}
               content={
                 <ChartTooltipContent
                   indicator="dot"
                   labelFormatter={(_, payload) => {
-                    const dimension = payload as unknown as (typeof chartData)[number];
-                    return dimension.fullLabel;
+                    const first = payload?.[0]?.payload as (typeof chartData)[number] | undefined;
+                    return first?.fullLabel ?? "";
                   }}
                   formatter={(_, __, item, ___, payload) => {
                     const dimension = payload as unknown as (typeof chartData)[number];
@@ -113,9 +94,7 @@ export function FacultyReportDimensionRadarChart({
                           </span>
                         </div>
                         <div className="flex items-center justify-between gap-4">
-                          <span className="text-muted-foreground">
-                            Responses
-                          </span>
+                          <span className="text-muted-foreground">Responses</span>
                           <span className="font-mono font-medium text-foreground">
                             {dimension.responseCount}
                           </span>

--- a/features/faculty-analytics/components/faculty-report-dimension-radar-chart.tsx
+++ b/features/faculty-analytics/components/faculty-report-dimension-radar-chart.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+} from "recharts";
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { formatFacultyReportScore } from "@/features/faculty-analytics/lib/faculty-report-detail";
+import type { FacultyReportDimensionDto } from "@/features/faculty-analytics/types";
+import { useIsMobile } from "@/lib/use-mobile";
+
+const dimensionRadarChartConfig = {
+  average: {
+    label: "Average",
+    color: "#5b8cff",
+  },
+} satisfies ChartConfig;
+
+type FacultyReportDimensionRadarChartProps = {
+  dimensions: FacultyReportDimensionDto[];
+};
+
+function truncateLabel(label: string, maxLength: number) {
+  if (label.length <= maxLength) {
+    return label;
+  }
+
+  return `${label.slice(0, maxLength - 1)}…`;
+}
+
+export function FacultyReportDimensionRadarChart({
+  dimensions,
+}: FacultyReportDimensionRadarChartProps) {
+  const isMobile = useIsMobile();
+
+  // A radar with fewer than 3 axes collapses into a line/point and is
+  // misleading — fall back to rendering nothing and let the section bar
+  // chart carry the load in that case.
+  if (dimensions.length < 3) {
+    return null;
+  }
+
+  const chartData = dimensions.map((dimension) => ({
+    code: dimension.code,
+    label: truncateLabel(dimension.displayName, isMobile ? 14 : 22),
+    fullLabel: dimension.displayName,
+    average: Number(dimension.average.toFixed(2)),
+    responseCount: dimension.responseCount,
+  }));
+
+  const chartHeight = isMobile ? 300 : 360;
+
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl font-semibold sm:text-2xl">
+          Dimension Profile
+        </CardTitle>
+        <CardDescription>
+          Weighted averages grouped by competency dimension on a 0–5 scale.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer
+          config={dimensionRadarChartConfig}
+          className="aspect-auto w-full"
+          style={{ height: chartHeight }}
+        >
+          <RadarChart data={chartData} outerRadius="72%">
+            <PolarGrid />
+            <PolarAngleAxis
+              dataKey="label"
+              tick={{ fontSize: isMobile ? 10 : 12 }}
+            />
+            <PolarRadiusAxis
+              angle={90}
+              domain={[0, 5]}
+              tick={{ fontSize: 10 }}
+            />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  indicator="dot"
+                  labelFormatter={(_, payload) => {
+                    const dimension = payload as unknown as (typeof chartData)[number];
+                    return dimension.fullLabel;
+                  }}
+                  formatter={(_, __, item, ___, payload) => {
+                    const dimension = payload as unknown as (typeof chartData)[number];
+                    return (
+                      <div className="flex min-w-[12rem] flex-col gap-1">
+                        <div className="flex items-center justify-between gap-4">
+                          <span className="text-muted-foreground">Average</span>
+                          <span className="font-mono font-medium text-foreground">
+                            {formatFacultyReportScore(item.value as number)}
+                          </span>
+                        </div>
+                        <div className="flex items-center justify-between gap-4">
+                          <span className="text-muted-foreground">
+                            Responses
+                          </span>
+                          <span className="font-mono font-medium text-foreground">
+                            {dimension.responseCount}
+                          </span>
+                        </div>
+                      </div>
+                    );
+                  }}
+                />
+              }
+            />
+            <Radar
+              dataKey="average"
+              fill="var(--color-average)"
+              fillOpacity={0.35}
+              stroke="var(--color-average)"
+              strokeWidth={2}
+              dot={{ r: 3, fillOpacity: 1 }}
+            />
+          </RadarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/faculty-analytics/components/faculty-report-impact-scatter-chart.tsx
+++ b/features/faculty-analytics/components/faculty-report-impact-scatter-chart.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import {
+  CartesianGrid,
+  ReferenceLine,
+  Scatter,
+  ScatterChart,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+
+import {
+  ChartContainer,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { formatFacultyReportScore } from "@/features/faculty-analytics/lib/faculty-report-detail";
+import type { FacultyReportSectionDto } from "@/features/faculty-analytics/types";
+import { useIsMobile } from "@/lib/use-mobile";
+
+const impactChartConfig = {
+  section: {
+    label: "Section",
+    color: "#5b8cff",
+  },
+} satisfies ChartConfig;
+
+type FacultyReportImpactScatterChartProps = {
+  sections: FacultyReportSectionDto[];
+};
+
+export function FacultyReportImpactScatterChart({
+  sections,
+}: FacultyReportImpactScatterChartProps) {
+  const isMobile = useIsMobile();
+
+  if (sections.length === 0) {
+    return null;
+  }
+
+  const chartData = sections.map((section) => ({
+    id: section.sectionId,
+    title: section.title,
+    weight: section.weight,
+    sectionAverage: Number(section.sectionAverage.toFixed(2)),
+    responseCount:
+      section.responseCount ??
+      section.questions.reduce((sum, q) => sum + q.responseCount, 0),
+    interpretation: section.sectionInterpretation,
+  }));
+
+  const chartHeight = isMobile ? 280 : 340;
+
+  const maxResponses = chartData.reduce(
+    (max, row) => (row.responseCount > max ? row.responseCount : max),
+    0,
+  );
+  const zRange: [number, number] = [80, Math.max(80, maxResponses > 0 ? 420 : 80)];
+
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl font-semibold sm:text-2xl">
+          Weight × Score Impact
+        </CardTitle>
+        <CardDescription>
+          Each bubble is a section — higher weight on the right, stronger
+          performance toward the top. Bubble size reflects response volume.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer
+          config={impactChartConfig}
+          className="aspect-auto w-full"
+          style={{ height: chartHeight }}
+        >
+          <ScatterChart
+            accessibilityLayer
+            margin={{
+              top: 12,
+              right: isMobile ? 12 : 24,
+              bottom: 24,
+              left: 12,
+            }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              type="number"
+              dataKey="weight"
+              name="Weight"
+              unit="%"
+              domain={[0, "dataMax"]}
+              tick={{ fontSize: 11 }}
+              label={
+                isMobile
+                  ? undefined
+                  : {
+                      value: "Section weight (%)",
+                      position: "insideBottom",
+                      offset: -8,
+                      fontSize: 11,
+                    }
+              }
+            />
+            <YAxis
+              type="number"
+              dataKey="sectionAverage"
+              name="Average"
+              domain={[0, 5]}
+              tick={{ fontSize: 11 }}
+              label={
+                isMobile
+                  ? undefined
+                  : {
+                      value: "Section average",
+                      angle: -90,
+                      position: "insideLeft",
+                      offset: 10,
+                      fontSize: 11,
+                    }
+              }
+            />
+            <ZAxis
+              type="number"
+              dataKey="responseCount"
+              name="Responses"
+              range={zRange}
+            />
+            <ReferenceLine
+              y={3.5}
+              strokeDasharray="4 4"
+              stroke="var(--border)"
+            />
+            <RechartsTooltip
+              cursor={{ strokeDasharray: "3 3" }}
+              content={({ active, payload }) => {
+                if (!active || !payload || payload.length === 0) return null;
+                const section = payload[0]
+                  .payload as (typeof chartData)[number];
+                return (
+                  <div className="grid min-w-[12rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+                    <div className="font-medium">{section.title}</div>
+                    <div className="flex items-center justify-between gap-4">
+                      <span className="text-muted-foreground">Average</span>
+                      <span className="font-mono font-medium text-foreground">
+                        {formatFacultyReportScore(section.sectionAverage)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-4">
+                      <span className="text-muted-foreground">Weight</span>
+                      <span className="font-mono font-medium text-foreground">
+                        {section.weight}%
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-4">
+                      <span className="text-muted-foreground">Responses</span>
+                      <span className="font-mono font-medium text-foreground">
+                        {section.responseCount}
+                      </span>
+                    </div>
+                  </div>
+                );
+              }}
+            />
+            <Scatter
+              name="Sections"
+              data={chartData}
+              fill="var(--color-section)"
+              fillOpacity={0.75}
+            />
+          </ScatterChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/faculty-analytics/components/faculty-report-impact-scatter-chart.tsx
+++ b/features/faculty-analytics/components/faculty-report-impact-scatter-chart.tsx
@@ -11,17 +11,8 @@ import {
   ZAxis,
 } from "recharts";
 
-import {
-  ChartContainer,
-  type ChartConfig,
-} from "@/components/ui/chart";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { ChartContainer, type ChartConfig } from "@/components/ui/chart";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatFacultyReportScore } from "@/features/faculty-analytics/lib/faculty-report-detail";
 import type { FacultyReportSectionDto } from "@/features/faculty-analytics/types";
 import { useIsMobile } from "@/lib/use-mobile";
@@ -52,8 +43,7 @@ export function FacultyReportImpactScatterChart({
     weight: section.weight,
     sectionAverage: Number(section.sectionAverage.toFixed(2)),
     responseCount:
-      section.responseCount ??
-      section.questions.reduce((sum, q) => sum + q.responseCount, 0),
+      section.responseCount ?? section.questions.reduce((sum, q) => sum + q.responseCount, 0),
     interpretation: section.sectionInterpretation,
   }));
 
@@ -61,7 +51,7 @@ export function FacultyReportImpactScatterChart({
 
   const maxResponses = chartData.reduce(
     (max, row) => (row.responseCount > max ? row.responseCount : max),
-    0,
+    0
   );
   const zRange: [number, number] = [80, Math.max(80, maxResponses > 0 ? 420 : 80)];
 
@@ -72,8 +62,8 @@ export function FacultyReportImpactScatterChart({
           Weight × Score Impact
         </CardTitle>
         <CardDescription>
-          Each bubble is a section — higher weight on the right, stronger
-          performance toward the top. Bubble size reflects response volume.
+          Each bubble is a section — higher weight on the right, stronger performance toward the
+          top. Bubble size reflects total ratings collected.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -128,23 +118,13 @@ export function FacultyReportImpactScatterChart({
                     }
               }
             />
-            <ZAxis
-              type="number"
-              dataKey="responseCount"
-              name="Responses"
-              range={zRange}
-            />
-            <ReferenceLine
-              y={3.5}
-              strokeDasharray="4 4"
-              stroke="var(--border)"
-            />
+            <ZAxis type="number" dataKey="responseCount" name="Ratings" range={zRange} />
+            <ReferenceLine y={3.5} strokeDasharray="4 4" stroke="var(--border)" />
             <RechartsTooltip
               cursor={{ strokeDasharray: "3 3" }}
               content={({ active, payload }) => {
                 if (!active || !payload || payload.length === 0) return null;
-                const section = payload[0]
-                  .payload as (typeof chartData)[number];
+                const section = payload[0].payload as (typeof chartData)[number];
                 return (
                   <div className="grid min-w-[12rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
                     <div className="font-medium">{section.title}</div>
@@ -161,7 +141,7 @@ export function FacultyReportImpactScatterChart({
                       </span>
                     </div>
                     <div className="flex items-center justify-between gap-4">
-                      <span className="text-muted-foreground">Responses</span>
+                      <span className="text-muted-foreground">Ratings</span>
                       <span className="font-mono font-medium text-foreground">
                         {section.responseCount}
                       </span>

--- a/features/faculty-analytics/components/faculty-report-rating-distribution-chart.tsx
+++ b/features/faculty-analytics/components/faculty-report-rating-distribution-chart.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { FacultyReportSectionDto } from "@/features/faculty-analytics/types";
+import { useIsMobile } from "@/lib/use-mobile";
+
+// Diverging 5-step palette (low → high). Also covers YES_NO ("0" / "1")
+// by mapping 0 → low and 1 → high.
+const RATING_COLORS: Record<string, string> = {
+  "1": "#dc2626",
+  "2": "#f97316",
+  "3": "#eab308",
+  "4": "#84cc16",
+  "5": "#16a34a",
+  "0": "#dc2626",
+};
+
+const RATING_LABELS: Record<string, string> = {
+  "1": "1",
+  "2": "2",
+  "3": "3",
+  "4": "4",
+  "5": "5",
+  "0": "No",
+};
+
+type FacultyReportRatingDistributionChartProps = {
+  sections: FacultyReportSectionDto[];
+};
+
+function truncateLabel(label: string, maxLength: number) {
+  if (label.length <= maxLength) {
+    return label;
+  }
+  return `${label.slice(0, maxLength - 1)}…`;
+}
+
+export function FacultyReportRatingDistributionChart({
+  sections,
+}: FacultyReportRatingDistributionChartProps) {
+  const isMobile = useIsMobile();
+
+  // Aggregate per-question ratingCounts up to the section level so the chart
+  // stays readable even when a questionnaire has 30+ questions. The table
+  // below the chart already exposes per-question detail.
+  const rows = sections
+    .map((section) => {
+      const totals: Record<string, number> = {};
+      for (const question of section.questions) {
+        const ratingCounts = question.ratingCounts ?? {};
+        for (const [rating, count] of Object.entries(ratingCounts)) {
+          totals[rating] = (totals[rating] ?? 0) + count;
+        }
+      }
+      const total = Object.values(totals).reduce((sum, n) => sum + n, 0);
+      return {
+        sectionId: section.sectionId,
+        title: section.title,
+        label: truncateLabel(section.title, isMobile ? 18 : 30),
+        total,
+        totals,
+      };
+    })
+    .filter((row) => row.total > 0);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  // Determine which rating keys actually appear, in a consistent low→high
+  // order. We support "0"/"1" (YES_NO) and "1".."5" (Likert).
+  const presentKeys = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row.totals)) {
+      presentKeys.add(key);
+    }
+  }
+  const orderedKeys = ["0", "1", "2", "3", "4", "5"].filter((k) =>
+    presentKeys.has(k),
+  );
+
+  // Convert to percentages so small-N sections stay visually comparable,
+  // while raw counts remain in the tooltip.
+  const chartData = rows.map((row) => {
+    const entry: Record<string, number | string> = {
+      label: row.label,
+      fullLabel: row.title,
+      total: row.total,
+    };
+    for (const key of orderedKeys) {
+      const count = row.totals[key] ?? 0;
+      entry[`pct_${key}`] = row.total > 0 ? (count / row.total) * 100 : 0;
+      entry[`count_${key}`] = count;
+    }
+    return entry;
+  });
+
+  const chartConfig: ChartConfig = {};
+  for (const key of orderedKeys) {
+    chartConfig[`pct_${key}`] = {
+      label: `Rating ${RATING_LABELS[key] ?? key}`,
+      color: RATING_COLORS[key] ?? "#94a3b8",
+    };
+  }
+
+  const rowHeight = isMobile ? 36 : 44;
+  const chartHeight = Math.max(isMobile ? 260 : 300, chartData.length * rowHeight);
+
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl font-semibold sm:text-2xl">
+          Rating Distribution
+        </CardTitle>
+        <CardDescription>
+          Share of responses at each rating level, aggregated per section. Raw
+          counts appear in the tooltip.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer
+          config={chartConfig}
+          className="aspect-auto w-full"
+          style={{ height: chartHeight }}
+        >
+          <BarChart
+            accessibilityLayer
+            data={chartData}
+            layout="vertical"
+            margin={{ top: 8, bottom: 8, right: isMobile ? 8 : 16, left: 0 }}
+            barCategoryGap={isMobile ? 8 : 10}
+            maxBarSize={isMobile ? 22 : 28}
+            stackOffset="expand"
+          >
+            <CartesianGrid horizontal={false} />
+            <XAxis
+              type="number"
+              domain={[0, 100]}
+              tickFormatter={(value: number) => `${Math.round(value)}%`}
+              tick={{ fontSize: 10 }}
+            />
+            <YAxis
+              type="category"
+              dataKey="label"
+              tickLine={false}
+              axisLine={false}
+              width={isMobile ? 110 : 170}
+              tick={{ fontSize: 11 }}
+            />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  indicator="dot"
+                  labelFormatter={(_, payload) => {
+                    const row = payload as unknown as (typeof chartData)[number];
+                    return `${row.fullLabel} · ${row.total} responses`;
+                  }}
+                  formatter={(value, _name, item, __, payload) => {
+                    const row = payload as unknown as (typeof chartData)[number];
+                    const key = String(item.dataKey).replace("pct_", "");
+                    const count = Number(row[`count_${key}`] ?? 0);
+                    return (
+                      <div className="flex min-w-[10rem] items-center justify-between gap-4">
+                        <span className="text-muted-foreground">
+                          Rating {RATING_LABELS[key] ?? key}
+                        </span>
+                        <span className="font-mono font-medium text-foreground">
+                          {count} ({(value as number).toFixed(0)}%)
+                        </span>
+                      </div>
+                    );
+                  }}
+                />
+              }
+            />
+            {orderedKeys.map((key) => (
+              <Bar
+                key={key}
+                dataKey={`pct_${key}`}
+                stackId="rating"
+                fill={`var(--color-pct_${key})`}
+              />
+            ))}
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/faculty-analytics/components/faculty-report-rating-distribution-chart.tsx
+++ b/features/faculty-analytics/components/faculty-report-rating-distribution-chart.tsx
@@ -119,8 +119,8 @@ export function FacultyReportRatingDistributionChart({
           Rating Distribution
         </CardTitle>
         <CardDescription>
-          Share of responses at each rating level, aggregated per section. Raw counts appear in the
-          tooltip.
+          Share of individual ratings at each score level, aggregated per section (one rating per
+          question × respondent). Raw counts appear in the tooltip.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -160,7 +160,7 @@ export function FacultyReportRatingDistributionChart({
                   labelFormatter={(_, payload) => {
                     const first = payload?.[0]?.payload as (typeof chartData)[number] | undefined;
                     if (!first) return "";
-                    return `${first.fullLabel} · ${first.total} responses`;
+                    return `${first.fullLabel} · ${first.total} ratings`;
                   }}
                   formatter={(value, _name, item, __, payload) => {
                     const row = payload as unknown as (typeof chartData)[number];

--- a/features/faculty-analytics/components/faculty-report-rating-distribution-chart.tsx
+++ b/features/faculty-analytics/components/faculty-report-rating-distribution-chart.tsx
@@ -8,13 +8,7 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { FacultyReportSectionDto } from "@/features/faculty-analytics/types";
 import { useIsMobile } from "@/lib/use-mobile";
 
@@ -89,9 +83,7 @@ export function FacultyReportRatingDistributionChart({
       presentKeys.add(key);
     }
   }
-  const orderedKeys = ["0", "1", "2", "3", "4", "5"].filter((k) =>
-    presentKeys.has(k),
-  );
+  const orderedKeys = ["0", "1", "2", "3", "4", "5"].filter((k) => presentKeys.has(k));
 
   // Convert to percentages so small-N sections stay visually comparable,
   // while raw counts remain in the tooltip.
@@ -127,8 +119,8 @@ export function FacultyReportRatingDistributionChart({
           Rating Distribution
         </CardTitle>
         <CardDescription>
-          Share of responses at each rating level, aggregated per section. Raw
-          counts appear in the tooltip.
+          Share of responses at each rating level, aggregated per section. Raw counts appear in the
+          tooltip.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -144,7 +136,6 @@ export function FacultyReportRatingDistributionChart({
             margin={{ top: 8, bottom: 8, right: isMobile ? 8 : 16, left: 0 }}
             barCategoryGap={isMobile ? 8 : 10}
             maxBarSize={isMobile ? 22 : 28}
-            stackOffset="expand"
           >
             <CartesianGrid horizontal={false} />
             <XAxis
@@ -167,8 +158,9 @@ export function FacultyReportRatingDistributionChart({
                 <ChartTooltipContent
                   indicator="dot"
                   labelFormatter={(_, payload) => {
-                    const row = payload as unknown as (typeof chartData)[number];
-                    return `${row.fullLabel} · ${row.total} responses`;
+                    const first = payload?.[0]?.payload as (typeof chartData)[number] | undefined;
+                    if (!first) return "";
+                    return `${first.fullLabel} · ${first.total} responses`;
                   }}
                   formatter={(value, _name, item, __, payload) => {
                     const row = payload as unknown as (typeof chartData)[number];

--- a/features/faculty-analytics/components/quantitative-scores-section.tsx
+++ b/features/faculty-analytics/components/quantitative-scores-section.tsx
@@ -3,13 +3,20 @@
 import { useState } from "react";
 import { ChevronDown } from "lucide-react";
 
+import { FacultyReportDimensionRadarChart } from "@/features/faculty-analytics/components/faculty-report-dimension-radar-chart";
+import { FacultyReportImpactScatterChart } from "@/features/faculty-analytics/components/faculty-report-impact-scatter-chart";
+import { FacultyReportRatingDistributionChart } from "@/features/faculty-analytics/components/faculty-report-rating-distribution-chart";
 import { FacultyReportSectionPerformanceChart } from "@/features/faculty-analytics/components/faculty-report-section-performance-chart";
 import { FacultyReportSections } from "@/features/faculty-analytics/components/faculty-report-sections";
 import { cn } from "@/lib/utils";
-import type { FacultyReportSectionDto } from "@/features/faculty-analytics/types";
+import type {
+  FacultyReportDimensionDto,
+  FacultyReportSectionDto,
+} from "@/features/faculty-analytics/types";
 
 type QuantitativeScoresSectionProps = {
   sections: FacultyReportSectionDto[];
+  dimensions: FacultyReportDimensionDto[];
   submissionCount: number;
   defaultOpen?: boolean;
   /**
@@ -20,8 +27,38 @@ type QuantitativeScoresSectionProps = {
   collapsible?: boolean;
 };
 
+function ChartsStack({
+  sections,
+  dimensions,
+}: {
+  sections: FacultyReportSectionDto[];
+  dimensions: FacultyReportDimensionDto[];
+}) {
+  const hasRadar = dimensions.length >= 3;
+
+  return (
+    <div className="space-y-6">
+      <FacultyReportSectionPerformanceChart sections={sections} />
+      <div
+        className={cn(
+          "grid gap-6",
+          hasRadar ? "lg:grid-cols-2" : "grid-cols-1",
+        )}
+      >
+        {hasRadar ? (
+          <FacultyReportDimensionRadarChart dimensions={dimensions} />
+        ) : null}
+        <FacultyReportImpactScatterChart sections={sections} />
+      </div>
+      <FacultyReportRatingDistributionChart sections={sections} />
+      <FacultyReportSections sections={sections} />
+    </div>
+  );
+}
+
 export function QuantitativeScoresSection({
   sections,
+  dimensions,
   submissionCount,
   defaultOpen = false,
   collapsible = true,
@@ -46,9 +83,8 @@ export function QuantitativeScoresSection({
             {submissionCount === 1 ? "" : "s"}.
           </p>
         </div>
-        <div className="space-y-6 border-t border-border/70 px-6 py-6">
-          <FacultyReportSectionPerformanceChart sections={sections} />
-          <FacultyReportSections sections={sections} />
+        <div className="border-t border-border/70 px-6 py-6">
+          <ChartsStack sections={sections} dimensions={dimensions} />
         </div>
       </section>
     );
@@ -90,9 +126,8 @@ export function QuantitativeScoresSection({
         className="grid transition-[grid-template-rows] duration-300 ease-out data-[state=closed]:grid-rows-[0fr] data-[state=open]:grid-rows-[1fr]"
       >
         <div className="overflow-hidden">
-          <div className="space-y-6 border-t border-border/70 px-6 py-6">
-            <FacultyReportSectionPerformanceChart sections={sections} />
-            <FacultyReportSections sections={sections} />
+          <div className="border-t border-border/70 px-6 py-6">
+            <ChartsStack sections={sections} dimensions={dimensions} />
           </div>
         </div>
       </div>

--- a/features/faculty-analytics/components/scores-tab.tsx
+++ b/features/faculty-analytics/components/scores-tab.tsx
@@ -89,6 +89,7 @@ export function ScoresTab({
 
           <QuantitativeScoresSection
             sections={report.sections}
+            dimensions={report.dimensions ?? []}
             submissionCount={submissionCount}
             collapsible={false}
           />

--- a/features/faculty-analytics/types/index.ts
+++ b/features/faculty-analytics/types/index.ts
@@ -261,6 +261,9 @@ export type FacultyReportQuestionDto = {
   average: number;
   responseCount: number;
   interpretation: string;
+  // Counts keyed by the stringified numericValue ("1".."5" for Likert-5,
+  // "0"/"1" for YES_NO). Empty object when no responses were recorded.
+  ratingCounts: Record<string, number>;
 };
 
 export type FacultyReportSectionDto = {
@@ -271,6 +274,15 @@ export type FacultyReportSectionDto = {
   questions: FacultyReportQuestionDto[];
   sectionAverage: number;
   sectionInterpretation: string;
+  responseCount: number;
+};
+
+export type FacultyReportDimensionDto = {
+  code: string;
+  displayName: string;
+  average: number;
+  responseCount: number;
+  interpretation: string;
 };
 
 export type FacultyReportResponseDto = {
@@ -282,6 +294,7 @@ export type FacultyReportResponseDto = {
   sections: FacultyReportSectionDto[];
   overallRating: number | null;
   overallInterpretation: string | null;
+  dimensions: FacultyReportDimensionDto[];
 };
 
 export type FacultyReportCommentDto = {


### PR DESCRIPTION
## Summary

Surfaces three new derived charts on the Faculty Analysis **Scores** tab, powered by the expanded `/analytics/faculty/:id/report` response:

- **Dimension Profile (radar)** — one axis per competency dimension, weighted averages on 0–5. Auto-hidden when fewer than 3 dimensions are present so a degenerate two-point shape is never shown.
- **Weight × Score Impact (scatter)** — `x = section weight`, `y = section average`, bubble size = response count. Surfaces high-weight-low-score sections that disproportionately drag the overall rating. Uses a reference line at 3.5 (VERY SATISFACTORY threshold).
- **Rating Distribution (stacked bar)** — share of responses per rating level aggregated per section. Supports Likert-5 and YES_NO via a diverging red-to-green palette; tooltip shows raw counts.

Existing charts (`FacultyReportSectionPerformanceChart`) and the per-question table (`FacultyReportSections`) are unchanged. On `lg:` breakpoints the radar and impact scatter render side-by-side; they stack on mobile.

## Files changed

- Types extended in `features/faculty-analytics/types/index.ts`:
  - `FacultyReportQuestionDto` gains `ratingCounts: Record<string, number>`
  - `FacultyReportSectionDto` gains `responseCount: number`
  - `FacultyReportResponseDto` gains `dimensions: FacultyReportDimensionDto[]`
- Three new chart components under `features/faculty-analytics/components/`.
- `quantitative-scores-section.tsx` extracted a `ChartsStack` and now takes a `dimensions` prop.
- `scores-tab.tsx` forwards `report.dimensions` (with `?? []` fallback for defensive handling of stale cached responses).

## Test plan

- [ ] `bun run typecheck` — dependencies not installed in this environment.
- [ ] `bun run lint` — dependencies not installed in this environment.
- [ ] `bun dev` and verify each role's Scores tab renders all charts:
  - `/faculty/analytics` (faculty self-view)
  - `/dean/faculties/<id>/analysis`
  - `/chairperson/faculties/<id>/analysis`
  - `/campus-head/faculties/<id>/analysis`
- [ ] Edge cases:
  - 0 submissions → empty state renders, no chart crash.
  - Schema with only 1–2 dimensions → radar is hidden; scatter + distribution still render.
  - YES_NO-only questionnaire → rating distribution shows `"0"` / `"1"` stacks correctly.
  - Mobile viewport (≤768 px) → charts reflow to single column; tooltips remain readable.
- [ ] Tooltips show full (untruncated) section / question / dimension text.

## Companion PR

Backend: [`api.faculytics#claude/add-faculty-analytics-charts-EkM1n`](https://github.com/CtrlAltElite-Devs/api.faculytics/compare/develop...claude/add-faculty-analytics-charts-EkM1n) — **must merge first** (frontend depends on the new response fields).

https://claude.ai/code/session_013AQMrjMn8mUwuRVP9X7qRr