### PR TITLE
FAC WEB feat: add dimension radar, impact scatter, and rating distribution charts to Scores tab (#99)

### DIFF
--- a/features/faculty-analytics/components/faculty-report-dimension-radar-chart.tsx
+++ b/features/faculty-analytics/components/faculty-report-dimension-radar-chart.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { PolarAngleAxis, PolarGrid, PolarRadiusAxis, Radar, RadarChart } from "recharts";
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatFacultyReportScore } from "@/features/faculty-analytics/lib/faculty-report-detail";
+import type { FacultyReportDimensionDto } from "@/features/faculty-analytics/types";
+import { useIsMobile } from "@/lib/use-mobile";
+
+const dimensionRadarChartConfig = {
+  average: {
+    label: "Average",
+    color: "#5b8cff",
+  },
+} satisfies ChartConfig;
+
+type FacultyReportDimensionRadarChartProps = {
+  dimensions: FacultyReportDimensionDto[];
+};
+
+function truncateLabel(label: string, maxLength: number) {
+  if (label.length <= maxLength) {
+    return label;
+  }
+
+  return `${label.slice(0, maxLength - 1)}…`;
+}
+
+export function FacultyReportDimensionRadarChart({
+  dimensions,
+}: FacultyReportDimensionRadarChartProps) {
+  const isMobile = useIsMobile();
+
+  // A radar with fewer than 3 axes collapses into a line/point and is
+  // misleading — fall back to rendering nothing and let the section bar
+  // chart carry the load in that case.
+  if (dimensions.length < 3) {
+    return null;
+  }
+
+  const chartData = dimensions.map((dimension) => ({
+    code: dimension.code,
+    label: truncateLabel(dimension.displayName, isMobile ? 14 : 22),
+    fullLabel: dimension.displayName,
+    average: Number(dimension.average.toFixed(2)),
+    responseCount: dimension.responseCount,
+  }));
+
+  const chartHeight = isMobile ? 300 : 360;
+
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl font-semibold sm:text-2xl">
+          Dimension Profile
+        </CardTitle>
+        <CardDescription>
+          Weighted averages grouped by competency dimension on a 0–5 scale.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer
+          config={dimensionRadarChartConfig}
+          className="aspect-auto w-full"
+          style={{ height: chartHeight }}
+        >
+          <RadarChart data={chartData} outerRadius="72%">
+            <PolarGrid />
+            <PolarAngleAxis dataKey="label" tick={{ fontSize: isMobile ? 10 : 12 }} />
+            <PolarRadiusAxis angle={90} domain={[0, 5]} tick={{ fontSize: 10 }} />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  indicator="dot"
+                  labelFormatter={(_, payload) => {
+                    const first = payload?.[0]?.payload as (typeof chartData)[number] | undefined;
+                    return first?.fullLabel ?? "";
+                  }}
+                  formatter={(_, __, item, ___, payload) => {
+                    const dimension = payload as unknown as (typeof chartData)[number];
+                    return (
+                      <div className="flex min-w-[12rem] flex-col gap-1">
+                        <div className="flex items-center justify-between gap-4">
+                          <span className="text-muted-foreground">Average</span>
+                          <span className="font-mono font-medium text-foreground">
+                            {formatFacultyReportScore(item.value as number)}
+                          </span>
+                        </div>
+                        <div className="flex items-center justify-between gap-4">
+                          <span className="text-muted-foreground">Ratings</span>
+                          <span className="font-mono font-medium text-foreground">
+                            {dimension.responseCount}
+                          </span>
+                        </div>
+                      </div>
+                    );
+                  }}
+                />
+              }
+            />
+            <Radar
+              dataKey="average"
+              fill="var(--color-average)"
+              fillOpacity={0.35}
+              stroke="var(--color-average)"
+              strokeWidth={2}
+              dot={{ r: 3, fillOpacity: 1 }}
+            />
+          </RadarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/faculty-analytics/components/faculty-report-impact-scatter-chart.tsx
+++ b/features/faculty-analytics/components/faculty-report-impact-scatter-chart.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import {
+  CartesianGrid,
+  ReferenceLine,
+  Scatter,
+  ScatterChart,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+
+import { ChartContainer, type ChartConfig } from "@/components/ui/chart";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatFacultyReportScore } from "@/features/faculty-analytics/lib/faculty-report-detail";
+import type { FacultyReportSectionDto } from "@/features/faculty-analytics/types";
+import { useIsMobile } from "@/lib/use-mobile";
+
+const impactChartConfig = {
+  section: {
+    label: "Section",
+    color: "#5b8cff",
+  },
+} satisfies ChartConfig;
+
+type FacultyReportImpactScatterChartProps = {
+  sections: FacultyReportSectionDto[];
+};
+
+export function FacultyReportImpactScatterChart({
+  sections,
+}: FacultyReportImpactScatterChartProps) {
+  const isMobile = useIsMobile();
+
+  if (sections.length === 0) {
+    return null;
+  }
+
+  const chartData = sections.map((section) => ({
+    id: section.sectionId,
+    title: section.title,
+    weight: section.weight,
+    sectionAverage: Number(section.sectionAverage.toFixed(2)),
+    responseCount:
+      section.responseCount ?? section.questions.reduce((sum, q) => sum + q.responseCount, 0),
+    interpretation: section.sectionInterpretation,
+  }));
+
+  const chartHeight = isMobile ? 280 : 340;
+
+  const maxResponses = chartData.reduce(
+    (max, row) => (row.responseCount > max ? row.responseCount : max),
+    0
+  );
+  const zRange: [number, number] = [80, Math.max(80, maxResponses > 0 ? 420 : 80)];
+
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl font-semibold sm:text-2xl">
+          Weight × Score Impact
+        </CardTitle>
+        <CardDescription>
+          Each bubble is a section — higher weight on the right, stronger performance toward the
+          top. Bubble size reflects total ratings collected.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer
+          config={impactChartConfig}
+          className="aspect-auto w-full"
+          style={{ height: chartHeight }}
+        >
+          <ScatterChart
+            accessibilityLayer
+            margin={{
+              top: 12,
+              right: isMobile ? 12 : 24,
+              bottom: 24,
+              left: 12,
+            }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              type="number"
+              dataKey="weight"
+              name="Weight"
+              unit="%"
+              domain={[0, "dataMax"]}
+              tick={{ fontSize: 11 }}
+              label={
+                isMobile
+                  ? undefined
+                  : {
+                      value: "Section weight (%)",
+                      position: "insideBottom",
+                      offset: -8,
+                      fontSize: 11,
+                    }
+              }
+            />
+            <YAxis
+              type="number"
+              dataKey="sectionAverage"
+              name="Average"
+              domain={[0, 5]}
+              tick={{ fontSize: 11 }}
+              label={
+                isMobile
+                  ? undefined
+                  : {
+                      value: "Section average",
+                      angle: -90,
+                      position: "insideLeft",
+                      offset: 10,
+                      fontSize: 11,
+                    }
+              }
+            />
+            <ZAxis type="number" dataKey="responseCount" name="Ratings" range={zRange} />
+            <ReferenceLine y={3.5} strokeDasharray="4 4" stroke="var(--border)" />
+            <RechartsTooltip
+              cursor={{ strokeDasharray: "3 3" }}
+              content={({ active, payload }) => {
+                if (!active || !payload || payload.length === 0) return null;
+                const section = payload[0].payload as (typeof chartData)[number];
+                return (
+                  <div className="grid min-w-[12rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+                    <div className="font-medium">{section.title}</div>
+                    <div className="flex items-center justify-between gap-4">
+                      <span className="text-muted-foreground">Average</span>
+                      <span className="font-mono font-medium text-foreground">
+                        {formatFacultyReportScore(section.sectionAverage)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-4">
+                      <span className="text-muted-foreground">Weight</span>
+                      <span className="font-mono font-medium text-foreground">
+                        {section.weight}%
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-4">
+                      <span className="text-muted-foreground">Ratings</span>
+                      <span className="font-mono font-medium text-foreground">
+                        {section.responseCount}
+                      </span>
+                    </div>
+                  </div>
+                );
+              }}
+            />
+            <Scatter
+              name="Sections"
+              data={chartData}
+              fill="var(--color-section)"
+              fillOpacity={0.75}
+            />
+          </ScatterChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/faculty-analytics/components/faculty-report-rating-distribution-chart.tsx
+++ b/features/faculty-analytics/components/faculty-report-rating-distribution-chart.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { FacultyReportSectionDto } from "@/features/faculty-analytics/types";
+import { useIsMobile } from "@/lib/use-mobile";
+
+// Diverging 5-step palette (low → high). Also covers YES_NO ("0" / "1")
+// by mapping 0 → low and 1 → high.
+const RATING_COLORS: Record<string, string> = {
+  "1": "#dc2626",
+  "2": "#f97316",
+  "3": "#eab308",
+  "4": "#84cc16",
+  "5": "#16a34a",
+  "0": "#dc2626",
+};
+
+const RATING_LABELS: Record<string, string> = {
+  "1": "1",
+  "2": "2",
+  "3": "3",
+  "4": "4",
+  "5": "5",
+  "0": "No",
+};
+
+type FacultyReportRatingDistributionChartProps = {
+  sections: FacultyReportSectionDto[];
+};
+
+function truncateLabel(label: string, maxLength: number) {
+  if (label.length <= maxLength) {
+    return label;
+  }
+  return `${label.slice(0, maxLength - 1)}…`;
+}
+
+export function FacultyReportRatingDistributionChart({
+  sections,
+}: FacultyReportRatingDistributionChartProps) {
+  const isMobile = useIsMobile();
+
+  // Aggregate per-question ratingCounts up to the section level so the chart
+  // stays readable even when a questionnaire has 30+ questions. The table
+  // below the chart already exposes per-question detail.
+  const rows = sections
+    .map((section) => {
+      const totals: Record<string, number> = {};
+      for (const question of section.questions) {
+        const ratingCounts = question.ratingCounts ?? {};
+        for (const [rating, count] of Object.entries(ratingCounts)) {
+          totals[rating] = (totals[rating] ?? 0) + count;
+        }
+      }
+      const total = Object.values(totals).reduce((sum, n) => sum + n, 0);
+      return {
+        sectionId: section.sectionId,
+        title: section.title,
+        label: truncateLabel(section.title, isMobile ? 18 : 30),
+        total,
+        totals,
+      };
+    })
+    .filter((row) => row.total > 0);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  // Determine which rating keys actually appear, in a consistent low→high
+  // order. We support "0"/"1" (YES_NO) and "1".."5" (Likert).
+  const presentKeys = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row.totals)) {
+      presentKeys.add(key);
+    }
+  }
+  const orderedKeys = ["0", "1", "2", "3", "4", "5"].filter((k) => presentKeys.has(k));
+
+  // Convert to percentages so small-N sections stay visually comparable,
+  // while raw counts remain in the tooltip.
+  const chartData = rows.map((row) => {
+    const entry: Record<string, number | string> = {
+      label: row.label,
+      fullLabel: row.title,
+      total: row.total,
+    };
+    for (const key of orderedKeys) {
+      const count = row.totals[key] ?? 0;
+      entry[`pct_${key}`] = row.total > 0 ? (count / row.total) * 100 : 0;
+      entry[`count_${key}`] = count;
+    }
+    return entry;
+  });
+
+  const chartConfig: ChartConfig = {};
+  for (const key of orderedKeys) {
+    chartConfig[`pct_${key}`] = {
+      label: `Rating ${RATING_LABELS[key] ?? key}`,
+      color: RATING_COLORS[key] ?? "#94a3b8",
+    };
+  }
+
+  const rowHeight = isMobile ? 36 : 44;
+  const chartHeight = Math.max(isMobile ? 260 : 300, chartData.length * rowHeight);
+
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl font-semibold sm:text-2xl">
+          Rating Distribution
+        </CardTitle>
+        <CardDescription>
+          Share of individual ratings at each score level, aggregated per section (one rating per
+          question × respondent). Raw counts appear in the tooltip.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer
+          config={chartConfig}
+          className="aspect-auto w-full"
+          style={{ height: chartHeight }}
+        >
+          <BarChart
+            accessibilityLayer
+            data={chartData}
+            layout="vertical"
+            margin={{ top: 8, bottom: 8, right: isMobile ? 8 : 16, left: 0 }}
+            barCategoryGap={isMobile ? 8 : 10}
+            maxBarSize={isMobile ? 22 : 28}
+          >
+            <CartesianGrid horizontal={false} />
+            <XAxis
+              type="number"
+              domain={[0, 100]}
+              tickFormatter={(value: number) => `${Math.round(value)}%`}
+              tick={{ fontSize: 10 }}
+            />
+            <YAxis
+              type="category"
+              dataKey="label"
+              tickLine={false}
+              axisLine={false}
+              width={isMobile ? 110 : 170}
+              tick={{ fontSize: 11 }}
+            />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  indicator="dot"
+                  labelFormatter={(_, payload) => {
+                    const first = payload?.[0]?.payload as (typeof chartData)[number] | undefined;
+                    if (!first) return "";
+                    return `${first.fullLabel} · ${first.total} ratings`;
+                  }}
+                  formatter={(value, _name, item, __, payload) => {
+                    const row = payload as unknown as (typeof chartData)[number];
+                    const key = String(item.dataKey).replace("pct_", "");
+                    const count = Number(row[`count_${key}`] ?? 0);
+                    return (
+                      <div className="flex min-w-[10rem] items-center justify-between gap-4">
+                        <span className="text-muted-foreground">
+                          Rating {RATING_LABELS[key] ?? key}
+                        </span>
+                        <span className="font-mono font-medium text-foreground">
+                          {count} ({(value as number).toFixed(0)}%)
+                        </span>
+                      </div>
+                    );
+                  }}
+                />
+              }
+            />
+            {orderedKeys.map((key) => (
+              <Bar
+                key={key}
+                dataKey={`pct_${key}`}
+                stackId="rating"
+                fill={`var(--color-pct_${key})`}
+              />
+            ))}
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/faculty-analytics/components/quantitative-scores-section.tsx
+++ b/features/faculty-analytics/components/quantitative-scores-section.tsx
@@ -3,13 +3,20 @@
 import { useState } from "react";
 import { ChevronDown } from "lucide-react";
 
+import { FacultyReportDimensionRadarChart } from "@/features/faculty-analytics/components/faculty-report-dimension-radar-chart";
+import { FacultyReportImpactScatterChart } from "@/features/faculty-analytics/components/faculty-report-impact-scatter-chart";
+import { FacultyReportRatingDistributionChart } from "@/features/faculty-analytics/components/faculty-report-rating-distribution-chart";
 import { FacultyReportSectionPerformanceChart } from "@/features/faculty-analytics/components/faculty-report-section-performance-chart";
 import { FacultyReportSections } from "@/features/faculty-analytics/components/faculty-report-sections";
 import { cn } from "@/lib/utils";
-import type { FacultyReportSectionDto } from "@/features/faculty-analytics/types";
+import type {
+  FacultyReportDimensionDto,
+  FacultyReportSectionDto,
+} from "@/features/faculty-analytics/types";
 
 type QuantitativeScoresSectionProps = {
   sections: FacultyReportSectionDto[];
+  dimensions: FacultyReportDimensionDto[];
   submissionCount: number;
   defaultOpen?: boolean;
   /**
@@ -20,8 +27,38 @@ type QuantitativeScoresSectionProps = {
   collapsible?: boolean;
 };
 
+function ChartsStack({
+  sections,
+  dimensions,
+}: {
+  sections: FacultyReportSectionDto[];
+  dimensions: FacultyReportDimensionDto[];
+}) {
+  const hasRadar = dimensions.length >= 3;
+
+  return (
+    <div className="space-y-6">
+      <FacultyReportSectionPerformanceChart sections={sections} />
+      <div
+        className={cn(
+          "grid gap-6",
+          hasRadar ? "lg:grid-cols-2" : "grid-cols-1",
+        )}
+      >
+        {hasRadar ? (
+          <FacultyReportDimensionRadarChart dimensions={dimensions} />
+        ) : null}
+        <FacultyReportImpactScatterChart sections={sections} />
+      </div>
+      <FacultyReportRatingDistributionChart sections={sections} />
+      <FacultyReportSections sections={sections} />
+    </div>
+  );
+}
+
 export function QuantitativeScoresSection({
   sections,
+  dimensions,
   submissionCount,
   defaultOpen = false,
   collapsible = true,
@@ -46,9 +83,8 @@ export function QuantitativeScoresSection({
             {submissionCount === 1 ? "" : "s"}.
           </p>
         </div>
-        <div className="space-y-6 border-t border-border/70 px-6 py-6">
-          <FacultyReportSectionPerformanceChart sections={sections} />
-          <FacultyReportSections sections={sections} />
+        <div className="border-t border-border/70 px-6 py-6">
+          <ChartsStack sections={sections} dimensions={dimensions} />
         </div>
       </section>
     );
@@ -90,9 +126,8 @@ export function QuantitativeScoresSection({
         className="grid transition-[grid-template-rows] duration-300 ease-out data-[state=closed]:grid-rows-[0fr] data-[state=open]:grid-rows-[1fr]"
       >
         <div className="overflow-hidden">
-          <div className="space-y-6 border-t border-border/70 px-6 py-6">
-            <FacultyReportSectionPerformanceChart sections={sections} />
-            <FacultyReportSections sections={sections} />
+          <div className="border-t border-border/70 px-6 py-6">
+            <ChartsStack sections={sections} dimensions={dimensions} />
           </div>
         </div>
       </div>

--- a/features/faculty-analytics/components/scores-tab.tsx
+++ b/features/faculty-analytics/components/scores-tab.tsx
@@ -89,6 +89,7 @@ export function ScoresTab({
 
           <QuantitativeScoresSection
             sections={report.sections}
+            dimensions={report.dimensions ?? []}
             submissionCount={submissionCount}
             collapsible={false}
           />

--- a/features/faculty-analytics/types/index.ts
+++ b/features/faculty-analytics/types/index.ts
@@ -261,6 +261,9 @@ export type FacultyReportQuestionDto = {
   average: number;
   responseCount: number;
   interpretation: string;
+  // Counts keyed by the stringified numericValue ("1".."5" for Likert-5,
+  // "0"/"1" for YES_NO). Empty object when no responses were recorded.
+  ratingCounts: Record<string, number>;
 };
 
 export type FacultyReportSectionDto = {
@@ -271,6 +274,15 @@ export type FacultyReportSectionDto = {
   questions: FacultyReportQuestionDto[];
   sectionAverage: number;
   sectionInterpretation: string;
+  responseCount: number;
+};
+
+export type FacultyReportDimensionDto = {
+  code: string;
+  displayName: string;
+  average: number;
+  responseCount: number;
+  interpretation: string;
 };
 
 export type FacultyReportResponseDto = {
@@ -282,6 +294,7 @@ export type FacultyReportResponseDto = {
   sections: FacultyReportSectionDto[];
   overallRating: number | null;
   overallInterpretation: string | null;
+  dimensions: FacultyReportDimensionDto[];
 };
 
 export type FacultyReportCommentDto = {


### PR DESCRIPTION
* feat: add dimension radar, impact scatter, and rating distribution charts to Scores tab

Surfaces three new derived views on the Faculty Analysis Scores tab, powered by the expanded /analytics/faculty/:id/report response:

- **Dimension Profile (radar)** - one axis per competency dimension, weighted averages on 0-5. Auto-hidden when fewer than 3 dimensions are present so a degenerate shape is not shown.
- **Weight x Score Impact (scatter)** - x=section weight, y=section average, bubble size=response count. Surfaces high-weight/low-score sections that disproportionately drag overall rating.
- **Rating Distribution (stacked bar)** - share of responses per rating level aggregated per section; supports Likert-5 and YES_NO. Uses a diverging red-to-green palette with raw counts in the tooltip.

Types extended to mirror backend additions (`dimensions[]`, `sections[].responseCount`, `questions[].ratingCounts`). Charts sit above the existing per-section bar chart and per-question table; radar and scatter render side-by-side on `lg:` and stack on mobile.

* fix: rating distribution bars render full-width and tooltip label shows section name

- Remove `stackOffset="expand"` on the rating distribution BarChart. Data is already precomputed as percentages summing to 100 with XAxis domain [0, 100], so `expand` was double-normalizing the stacks and squashing every bar into the 0-1% band of the axis.
- Fix `labelFormatter` in rating distribution and dimension radar tooltips. The second arg is the full tooltip payload array, not the row data — the row lives at `payload[0].payload`. Previously the tooltip header rendered "undefined . undefined responses".

* fix: relabel answer counts as "Ratings" in faculty report charts

"Responses" was overloaded — the Scores tab header uses it to mean submission count (one per respondent), while the new charts use the underlying `responseCount` field which is a count of individual answer rows (one per question × respondent). A faculty with 51 submissions and 5 questions in a section would show "255 responses" on the rating distribution tooltip, contradicting the header's "51 responses".

Rename the in-chart label to "Ratings" (Dimension Profile, Weight x Score Impact, Rating Distribution) and update card copy accordingly. No logic change — only affected strings in the tooltips, ZAxis `name`, and card descriptions.

---------