### PR TITLE
[FEAT][FAC-WEB-36] improve campus head analytics scope

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-campus-head-dashboard-remove-mis-scoped-sections.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-campus-head-dashboard-remove-mis-scoped-sections.md
@@ -1,0 +1,164 @@
+---
+title: 'Campus Head Dashboard Remove Mis-Scoped Sections'
+slug: 'campus-head-dashboard-remove-mis-scoped-sections'
+created: '2026-04-18T00:00:00+08:00'
+status: 'Implementation Complete'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack:
+  - 'Next.js App Router'
+  - 'React 19 client components'
+  - 'TypeScript strict mode'
+  - 'Tailwind CSS'
+  - 'TanStack Query'
+files_to_modify:
+  - 'features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx'
+  - 'features/faculty-analytics/components/scoped-attention-card.tsx'
+  - 'features/faculty-analytics/components/recommendations-card.tsx'
+code_patterns:
+  - 'Role-specific dashboard routes reuse the shared ScopedAnalyticsDashboardScreen with a scopeLabel prop'
+  - 'Role-specific visibility is handled inside shared feature components rather than duplicating route pages'
+  - 'Dashboard sections are composed conditionally from hook-driven query state inside feature-owned screen components'
+  - 'Feature UI remains in features/faculty-analytics and pages stay thin'
+test_patterns:
+  - 'No dedicated automated test framework is configured'
+  - 'Validation gate is bun run lint and bun run typecheck'
+  - 'Manual role-based UI verification is required for campus head, dean, and chairperson dashboards'
+---
+
+# Tech-Spec: Campus Head Dashboard Remove Mis-Scoped Sections
+
+**Created:** 2026-04-18T00:00:00+08:00
+
+## Overview
+
+### Problem Statement
+
+The campus head dashboard now supports department-level filtering, but it still renders sections that imply dean-level or operational ownership: `Faculty Requiring Attention`, `Suggested Actions`, and the `Analytics Pipeline` trigger. This creates role confusion because campus head is positioned as an oversight user, not the actor who manages faculty-level interventions or analytics operations.
+
+### Solution
+
+Restrict the campus head dashboard to summary-oriented content by removing those three sections only from the `Campus` scope within the shared scoped dashboard screen. Keep the rest of the dashboard intact, preserve existing dean and chairperson behavior, and adjust any campus-head-only empty-state copy so it no longer instructs the user to trigger analysis manually.
+
+### Scope
+
+**In Scope:**
+- remove the `PipelineTriggerCard` from the campus head dashboard
+- remove the `Faculty Requiring Attention` panel from the campus head dashboard
+- remove the `Suggested Actions` panel from the campus head dashboard
+- keep existing campus head dashboard metrics, filters, charts, and themes behavior otherwise unchanged
+- update campus-head-specific empty-state copy if it currently references running analysis or waiting for suggested actions
+- preserve dean and chairperson dashboard behavior
+
+**Out of Scope:**
+- adding replacement sections such as `Department Health Overview` or `Departments Needing Review`
+- changing backend permissions or API contracts
+- changing dean or chairperson dashboard scope/content
+- removing top themes or other existing non-targeted dashboard sections
+- redesigning the campus head dashboard layout beyond what is necessary after removing the sections
+
+## Context for Development
+
+### Codebase Patterns
+
+- The route entry points are thin and role-specific pages pass a `scopeLabel` into the shared `ScopedAnalyticsDashboardScreen`; campus head uses `scopeLabel="Campus"` at [page.tsx](/home/aya/Codes/THESIS/app.faculytics/app/(dashboard)/campus-head/dashboard/page.tsx:1).
+- Shared dashboard composition lives in feature-owned components, consistent with `docs/ARCHITECTURE.md`; the campus head change should stay inside `features/faculty-analytics/components/*`.
+- `ScopedAnalyticsDashboardScreen` already branches on `scopeLabel` for campus-specific behavior such as the pipeline trigger, so it is the correct place to add or tighten visibility rules.
+- `ScopedAttentionCard` and `RecommendationsCard` are reusable across scope variants; if edited, changes must preserve dean/program labels and content.
+- Pipeline queries currently serve two different concerns in the shared screen: showing the campus trigger and gating qualitative themes/recommendations. Removing the trigger must not accidentally suppress existing theme rendering if pipeline results already exist.
+- The current empty insights placeholder is two-column and includes a `Suggested Actions` card plus copy telling the user to run analysis; that is inconsistent once the campus trigger is removed.
+
+### Files to Reference
+
+| File | Purpose |
+| ---- | ------- |
+| [app/(dashboard)/campus-head/dashboard/page.tsx](/home/aya/Codes/THESIS/app.faculytics/app/(dashboard)/campus-head/dashboard/page.tsx:1) | Confirms campus head uses the shared scoped dashboard with `scopeLabel="Campus"` |
+| [app/(dashboard)/dean/dashboard/page.tsx](/home/aya/Codes/THESIS/app.faculytics/app/(dashboard)/dean/dashboard/page.tsx:1) | Confirms dean uses the same shared screen with `scopeLabel="Department"` |
+| [app/(dashboard)/chairperson/dashboard/page.tsx](/home/aya/Codes/THESIS/app.faculytics/app/(dashboard)/chairperson/dashboard/page.tsx:1) | Confirms chairperson uses the same shared screen with `scopeLabel="Program"` |
+| [features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx](/home/aya/Codes/THESIS/app.faculytics/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx:1) | Primary composition file for campus/dean/chairperson analytics dashboard sections |
+| [features/faculty-analytics/components/scoped-attention-card.tsx](/home/aya/Codes/THESIS/app.faculytics/features/faculty-analytics/components/scoped-attention-card.tsx:1) | Faculty attention panel with scope-specific copy |
+| [features/faculty-analytics/components/recommendations-card.tsx](/home/aya/Codes/THESIS/app.faculytics/features/faculty-analytics/components/recommendations-card.tsx:1) | Suggested actions panel rendered when recommendations are available |
+| [features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model.ts](/home/aya/Codes/THESIS/app.faculytics/features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model.ts:1) | Confirms campus head department filtering and attention data are prepared in the shared view model |
+| [docs/ARCHITECTURE.md](/home/aya/Codes/THESIS/app.faculytics/docs/ARCHITECTURE.md:1) | Governing rule for keeping this work inside the feature slice rather than in route pages |
+
+### Technical Decisions
+
+- The change is campus-head-only and should be keyed off `scopeLabel === "Campus"`.
+- The campus head route stays on the shared screen component; do not fork a separate campus-specific page implementation for this removal-only change.
+- `PipelineTriggerCard` should stop rendering for campus head, but pipeline-backed themes may still render if data already exists from backend or prior runs.
+- `ScopedAttentionCard` should not render for campus head. Dean and chairperson should keep current behavior.
+- `RecommendationsCard` should not render for campus head even if recommendations data exists. The underlying data fetching may remain for now unless a small cleanup is obvious and safe.
+- The campus-head empty insights state must not mention `Suggested Actions` or instruct the user to run analysis, since the trigger is being removed and no replacement action UI is being added.
+- Avoid broad refactors. This is a visibility and copy-adjustment change, not a dashboard redesign.
+
+## Implementation Plan
+
+### Tasks
+
+- [x] Task 1: Remove the campus-head analytics trigger card from the shared dashboard composition
+  - File: `features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx`
+  - Action: Stop rendering `PipelineTriggerCard` when `scopeLabel === "Campus"`.
+  - Notes: Preserve existing dean/program behavior and avoid breaking any remaining pipeline-status-driven theme display logic.
+
+- [x] Task 2: Remove the campus-head attention panel from the shared dashboard layout
+  - File: `features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx`
+  - Action: Prevent `ScopedAttentionCard` from rendering for `Campus` scope while keeping the sentiment chart and surrounding layout coherent.
+  - Notes: If the two-column layout becomes awkward after the card is removed, collapse or rebalance only as much as needed to keep the existing chart presentation clean.
+
+- [x] Task 3: Remove campus-head suggested actions while preserving top themes
+  - File: `features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx`
+  - Action: Prevent `RecommendationsCard` from rendering for `Campus` scope, but keep `ThemesRankedList` behavior intact for available qualitative insights.
+  - Notes: Ensure the layout does not reserve an empty second column for campus head when only themes remain.
+
+- [x] Task 4: Update campus-head empty-state copy to match the removal-only decision
+  - File: `features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx`
+  - Action: Adjust `EmptyInsightsPlaceholder` so the campus-head variant no longer includes a `Suggested Actions` placeholder or copy telling the user to run analysis.
+  - Notes: The placeholder can remain richer for non-campus scopes if needed; campus copy should be passive and summary-oriented.
+
+- [x] Task 5: Verify shared component copy and surface area remain correct for dean and chairperson
+  - Files:
+    - `features/faculty-analytics/components/scoped-attention-card.tsx`
+    - `features/faculty-analytics/components/recommendations-card.tsx`
+  - Action: Make only minimal edits if needed to support campus-only suppression cleanly, otherwise leave these reusable components unchanged.
+  - Notes: Do not rewrite labels or semantics for department/program scopes as part of this spec.
+
+### Acceptance Criteria
+
+- [ ] AC 1: Given an authenticated campus head user on `/campus-head/dashboard`, when the dashboard renders, then the `Analytics Pipeline` trigger card is not shown.
+- [ ] AC 2: Given an authenticated campus head user on `/campus-head/dashboard`, when the dashboard renders, then the `Faculty Requiring Attention` section is not shown.
+- [ ] AC 3: Given an authenticated campus head user on `/campus-head/dashboard`, when the dashboard renders, then the `Suggested Actions` section is not shown.
+- [ ] AC 4: Given an authenticated campus head user on `/campus-head/dashboard`, when qualitative theme data exists, then `Top Themes` can still render without a companion `Suggested Actions` panel.
+- [ ] AC 5: Given an authenticated campus head user on `/campus-head/dashboard`, when no qualitative insights are available yet, then the empty state does not instruct the user to run analysis and does not show a `Suggested Actions` placeholder.
+- [ ] AC 6: Given an authenticated dean user on `/dean/dashboard`, when the dashboard renders, then existing attention and suggested-actions sections continue to behave as before.
+- [ ] AC 7: Given an authenticated chairperson user on `/chairperson/dashboard`, when the dashboard renders, then existing shared dashboard sections continue to behave as before.
+- [ ] AC 8: Given an authenticated campus head user changes the department filter, when the dashboard rerenders, then the removed sections remain hidden and the remaining campus dashboard content continues to update normally.
+- [ ] AC 9: Given this change is implemented, when `bun run lint` and `bun run typecheck` are run, then the touched files pass the project’s minimum quality gate without introducing new errors.
+
+## Additional Context
+
+### Dependencies
+
+- Existing scoped analytics dashboard composition in `features/faculty-analytics`
+- Existing `scopeLabel` role differentiation across campus, dean, and chairperson dashboards
+- Existing pipeline/recommendation queries, which may still feed top themes even after action-oriented campus widgets are removed
+- No backend changes are required for this spec
+
+### Testing Strategy
+
+- Run `bun run lint`
+- Run `bun run typecheck`
+- Manual verification:
+  - log in as a campus head user and confirm `/campus-head/dashboard` no longer shows `Faculty Requiring Attention`
+  - confirm the campus head dashboard no longer shows `Suggested Actions`
+  - confirm the campus head dashboard no longer shows the pipeline trigger card
+  - confirm campus head still sees the remaining dashboard metrics and charts
+  - confirm the department filter still updates the remaining campus dashboard content
+  - confirm any campus empty-state copy no longer tells the user to run analysis
+  - log in as a dean user and confirm attention and suggested-actions panels still render
+  - log in as a chairperson user and confirm shared dashboard behavior is unchanged
+
+### Notes
+
+- This spec intentionally avoids introducing replacement sections. Empty space reduction or simple layout rebalancing is allowed only where required to avoid visually broken composition.
+- Risk: removing the pipeline trigger while retaining theme queries can expose copy or gating assumptions that previously depended on the trigger being visible. Review placeholder and loading states carefully.
+- Risk: because the same screen is shared by three roles, broad conditional edits can unintentionally regress dean or chairperson dashboards. Keep role checks narrow and explicit.
+- If implementation reveals that `RecommendationsCard` or `ScopedAttentionCard` can remain untouched by handling all visibility in the parent screen, prefer that smaller change.

--- a/features/faculty-analytics/api/faculty-analytics.requests.ts
+++ b/features/faculty-analytics/api/faculty-analytics.requests.ts
@@ -7,6 +7,7 @@ import type {
   BatchStatusResponseDto,
   DepartmentOverviewQuery,
   DepartmentOverviewResponseDto,
+  DepartmentListResponseDto,
   FacultyReportCommentsQuery,
   FacultyReportCommentsResponseDto,
   FacultyReportQuery,
@@ -18,6 +19,7 @@ import type {
   GenerateSingleReportRequest,
   GenerateSingleReportResponse,
   ListProgramsQuery,
+  ListDepartmentsQuery,
   ListSemestersQuery,
   ProgramListResponseDto,
   QualitativeSummaryQuery,
@@ -151,6 +153,14 @@ export async function fetchFacultyEnrollments({
 
 export async function fetchProgramOptions(params: ListProgramsQuery) {
   const response = await apiClient.get<ProgramListResponseDto>(Endpoints.curriculumPrograms, {
+    params,
+  });
+
+  return response.data;
+}
+
+export async function fetchDepartmentOptions(params: ListDepartmentsQuery) {
+  const response = await apiClient.get<DepartmentListResponseDto>(Endpoints.curriculumDepartments, {
     params,
   });
 

--- a/features/faculty-analytics/components/batch-report-export-dialog.tsx
+++ b/features/faculty-analytics/components/batch-report-export-dialog.tsx
@@ -53,6 +53,8 @@ type BatchReportExportDialogProps = {
   onOpenChange: (open: boolean) => void;
   semesterId: string | null;
   semesterLabel: string;
+  departmentId: string | null;
+  departmentLabel: string;
   programId: string | null;
   programs: Array<{
     id: string | null;
@@ -65,6 +67,8 @@ export function BatchReportExportDialog({
   onOpenChange,
   semesterId,
   semesterLabel,
+  departmentId,
+  departmentLabel,
   programId,
   programs,
 }: BatchReportExportDialogProps) {
@@ -125,6 +129,7 @@ export function BatchReportExportDialog({
       const response = await generateBatchReportMutation.mutateAsync({
         semesterId,
         questionnaireTypeCode: effectiveQuestionnaireTypeCode,
+        departmentId: departmentId ?? undefined,
         programId: selectedProgramId ?? undefined,
       });
 
@@ -181,6 +186,10 @@ export function BatchReportExportDialog({
               </div>
               {batchId ? (
                 <>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-muted-foreground">Department</dt>
+                    <dd className="text-right font-medium">{departmentLabel}</dd>
+                  </div>
                   <div className="flex items-center justify-between gap-4">
                     <dt className="text-muted-foreground">Program</dt>
                     <dd className="text-right font-medium">{selectedProgramLabel}</dd>

--- a/features/faculty-analytics/components/faculty-report-screen.tsx
+++ b/features/faculty-analytics/components/faculty-report-screen.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { APP_ROLES } from "@/constants/roles";
+import { useActiveRole } from "@/features/auth/hooks/use-active-role";
 import { AutoCorrectionNotice } from "@/features/faculty-analytics/components/auto-correction-notice";
 import { FeedbackTab } from "@/features/faculty-analytics/components/feedback-tab";
 import { HeadlineMetricsStrip } from "@/features/faculty-analytics/components/headline-metrics-strip";
@@ -43,6 +45,8 @@ const SENTIMENT_READY_STATUSES: ReadonlySet<PipelineStatus> = new Set<PipelineSt
 export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const viewModel = useFacultyReportDetailViewModel({ facultyId });
+  const { activeRole } = useActiveRole();
+  const showPipelineTrigger = activeRole !== APP_ROLES.CAMPUS_HEAD;
 
   const pipelineScope = useMemo(
     () => ({
@@ -184,7 +188,7 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
         <ScopedAnalyticsEmptyState description="No evaluation analytics are available for this faculty in the selected filters." />
       ) : (
         <>
-          {viewModel.semesterId ? (
+          {showPipelineTrigger && viewModel.semesterId ? (
             <PipelineTriggerCard scope={pipelineScope} pipeline={latestPipeline} />
           ) : null}
 

--- a/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
+++ b/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo } from "react";
 
-import { useMe } from "@/features/auth/hooks/use-me";
 import { ScopedDashboardHeader } from "@/features/faculty-analytics/components/scoped-dashboard-header";
 import { ScopedAttentionCard } from "@/features/faculty-analytics/components/scoped-attention-card";
 import { ScopedOverallSentimentBarChart } from "@/features/faculty-analytics/components/scoped-charts";
@@ -15,7 +14,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
 import { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
 import { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
-import type { PipelineScopeIds } from "@/features/faculty-analytics/types";
 import {
   aggregateThemes,
   type RankedTheme,
@@ -98,7 +96,12 @@ function EmptyInsightsPlaceholder() {
 }
 
 export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: ScopeLabel }) {
+  const isCampusScope = scopeLabel === "Campus";
   const {
+    departments,
+    selectedDepartmentId,
+    selectedDepartmentLabel,
+    setSelectedDepartmentId,
     semesters,
     programs,
     selectedSemesterId,
@@ -116,44 +119,24 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
     isAttentionLoading,
     isError,
     retry,
-  } = useScopedAnalyticsDashboardViewModel();
-
-  // FAC-135 Phase C: for LIST queries, scopeType/scopeId are optional — the
-  // backend resolves the DEAN/CAMPUS_HEAD's scope automatically. For CREATE
-  // we need an explicit scope (see `campusPipelineScope` below).
-  const meQuery = useMe();
-  const campusId = meQuery.data?.campus?.id ?? null;
-
+  } = useScopedAnalyticsDashboardViewModel(scopeLabel);
   const pipelineQuery = useMemo(
     () => ({ semesterId: selectedSemesterId ?? "" }),
     [selectedSemesterId]
   );
   const { latestPipeline } = useLatestPipelineForScope(pipelineQuery, {
-    enabled: Boolean(selectedSemesterId),
+    enabled: !isCampusScope && Boolean(selectedSemesterId),
   });
-
-  // FAC-135 Phase C (Task C11): on Campus Head dashboards only, provide a
-  // CAMPUS scope for the trigger card so "Run campus-wide themes" posts the
-  // correct canonical shape. Dean dashboard suppresses the trigger card —
-  // AC26 ("Dean-on-/dean/dashboard must NOT see this button").
-  const campusPipelineScope: PipelineScopeIds | null = useMemo(() => {
-    if (scopeLabel !== "Campus") return null;
-    if (!selectedSemesterId || !campusId) return null;
-    return {
-      semesterId: selectedSemesterId,
-      scopeType: "CAMPUS",
-      scopeId: campusId,
-    };
-  }, [scopeLabel, selectedSemesterId, campusId]);
-  // Poll status at the screen level so themes/recs gating reacts to the
-  // live terminal transition — without this, `latestPipeline.status` comes
-  // from the stale list cache and the completed-state UI doesn't appear
-  // until the next list refetch or page reload.
   const pipelineStatusQuery = usePipelineStatus(latestPipeline?.id ?? null, {
-    enabled: Boolean(latestPipeline?.id),
+    enabled: !isCampusScope && Boolean(latestPipeline?.id),
   });
-  const liveStatus = pipelineStatusQuery.data?.status ?? latestPipeline?.status;
-  const recommendationsQuery = usePipelineRecommendations(latestPipeline?.id ?? null, liveStatus);
+  const liveStatus = isCampusScope
+    ? undefined
+    : (pipelineStatusQuery.data?.status ?? latestPipeline?.status);
+  const recommendationsQuery = usePipelineRecommendations(
+    isCampusScope ? null : (latestPipeline?.id ?? null),
+    liveStatus
+  );
   const themes = useMemo(
     () =>
       recommendationsQuery.data
@@ -161,8 +144,10 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
         : [],
     [recommendationsQuery.data]
   );
-  const showRecommendationPanels = liveStatus === "COMPLETED" && themes.length > 0;
-  const showEmptyInsightsPlaceholder = Boolean(selectedSemesterId) && !showRecommendationPanels;
+  const showRecommendationPanels =
+    !isCampusScope && liveStatus === "COMPLETED" && themes.length > 0;
+  const showEmptyInsightsPlaceholder =
+    !isCampusScope && Boolean(selectedSemesterId) && !showRecommendationPanels;
 
   const { scopeLower, facultiesHref } = SCOPE_METADATA[scopeLabel];
   const emptyStateDescription =
@@ -181,6 +166,10 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
       <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
         <ScopedDashboardHeader
           scopeLabel={scopeLabel}
+          departments={departments}
+          selectedDepartmentId={selectedDepartmentId}
+          selectedDepartmentLabel={selectedDepartmentLabel}
+          onDepartmentChange={setSelectedDepartmentId}
           semesters={semesters}
           programs={programs}
           selectedSemesterId={selectedSemesterId}
@@ -192,12 +181,11 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
           lastUpdatedLabel={lastUpdatedLabel}
         />
 
-        {/* FAC-135 Phase C (Task C11 / AC26): campus-wide trigger only on
-            Campus Head dashboard. Dean dashboard intentionally omits this —
-            Dean-level pipelines are not supported under the current scope
-            tiers and trying to trigger one would 400 on the new DTO. */}
-        {campusPipelineScope ? (
-          <PipelineTriggerCard scope={campusPipelineScope} pipeline={latestPipeline} />
+        {!isCampusScope && selectedSemesterId ? (
+          <PipelineTriggerCard
+            scope={{ semesterId: selectedSemesterId }}
+            pipeline={latestPipeline}
+          />
         ) : null}
 
         {semesters.length === 0 ? (
@@ -210,15 +198,23 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
           <>
             <ScopedMetricsGrid summary={summary} />
 
-            <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1.15fr)_minmax(19rem,0.85fr)]">
+            <div
+              className={
+                isCampusScope
+                  ? "grid gap-6"
+                  : "grid gap-6 min-[900px]:grid-cols-[minmax(0,1.15fr)_minmax(19rem,0.85fr)]"
+              }
+            >
               <ScopedOverallSentimentBarChart overallSentiment={overallSentiment} />
-              <ScopedAttentionCard
-                items={attentionItems}
-                isLoading={isAttentionLoading}
-                hasAnalyticsData={overview?.lastRefreshedAt !== null}
-                scopeLabel={scopeLabel}
-                facultiesHref={facultiesHref}
-              />
+              {isCampusScope ? null : (
+                <ScopedAttentionCard
+                  items={attentionItems}
+                  isLoading={isAttentionLoading}
+                  hasAnalyticsData={overview?.lastRefreshedAt !== null}
+                  scopeLabel={scopeLabel}
+                  facultiesHref={facultiesHref}
+                />
+              )}
             </div>
 
             {showRecommendationPanels ? (

--- a/features/faculty-analytics/components/scoped-dashboard-header.tsx
+++ b/features/faculty-analytics/components/scoped-dashboard-header.tsx
@@ -4,6 +4,7 @@ import { ChevronDown } from "lucide-react";
 
 import { ALL_PROGRAMS_VALUE } from "@/features/faculty-analytics/constants/filters";
 import type {
+  ScopedDepartmentOption,
   ScopedProgramOption,
   ScopedSemesterOption,
 } from "@/features/faculty-analytics/lib/scoped-analytics-view-model";
@@ -17,6 +18,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 type ScopedDashboardHeaderProps = {
+  departments: readonly ScopedDepartmentOption[];
+  selectedDepartmentId: string | null;
+  selectedDepartmentLabel: string;
+  onDepartmentChange: (value: string) => void;
   semesters: readonly ScopedSemesterOption[];
   programs: readonly ScopedProgramOption[];
   selectedSemesterId: string | null;
@@ -42,6 +47,10 @@ function getScopeDescription(scopeLabel: ScopedDashboardHeaderProps["scopeLabel"
 }
 
 export function ScopedDashboardHeader({
+  departments,
+  selectedDepartmentId,
+  selectedDepartmentLabel,
+  onDepartmentChange,
   semesters,
   programs,
   selectedSemesterId,
@@ -70,37 +79,6 @@ export function ScopedDashboardHeader({
               <Button
                 variant="outline"
                 className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-48 md:max-w-48"
-                disabled={programs.length === 0}
-              >
-                <span className="truncate">{selectedProgramLabel}</span>
-                <ChevronDown className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
-            >
-              <DropdownMenuRadioGroup
-                value={selectedProgramCode ?? ALL_PROGRAMS_VALUE}
-                onValueChange={onProgramChange}
-              >
-                {programs.map((program) => (
-                  <DropdownMenuRadioItem
-                    key={program.code ?? ALL_PROGRAMS_VALUE}
-                    value={program.code ?? ALL_PROGRAMS_VALUE}
-                    className="font-sans text-sm"
-                  >
-                    {program.label}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-48 md:max-w-48"
                 disabled={semesters.length === 0}
               >
                 <span className="truncate">{selectedSemesterLabel}</span>
@@ -122,6 +100,70 @@ export function ScopedDashboardHeader({
                     className="font-sans text-sm"
                   >
                     {semester.label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          {scopeLabel === "Campus" ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-48 md:max-w-48"
+                  disabled={departments.length === 0}
+                >
+                  <span className="truncate">{selectedDepartmentLabel}</span>
+                  <ChevronDown className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="end"
+                className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
+              >
+                <DropdownMenuRadioGroup
+                  value={selectedDepartmentId ?? ""}
+                  onValueChange={onDepartmentChange}
+                >
+                  {departments.map((department) => (
+                    <DropdownMenuRadioItem
+                      key={department.id || "all-departments"}
+                      value={department.id}
+                      className="font-sans text-sm"
+                    >
+                      {department.label}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-48 md:max-w-48"
+                disabled={programs.length === 0}
+              >
+                <span className="truncate">{selectedProgramLabel}</span>
+                <ChevronDown className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
+            >
+              <DropdownMenuRadioGroup
+                value={selectedProgramCode ?? ALL_PROGRAMS_VALUE}
+                onValueChange={onProgramChange}
+              >
+                {programs.map((program) => (
+                  <DropdownMenuRadioItem
+                    key={program.code ?? ALL_PROGRAMS_VALUE}
+                    value={program.code ?? ALL_PROGRAMS_VALUE}
+                    className="font-sans text-sm"
+                  >
+                    {program.label}
                   </DropdownMenuRadioItem>
                 ))}
               </DropdownMenuRadioGroup>

--- a/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
+++ b/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
@@ -32,8 +32,11 @@ export function ScopedFacultyListScreen({
 }: ScopedFacultyListScreenProps) {
   const [isBatchExportDialogOpen, setIsBatchExportDialogOpen] = useState(false);
   const {
+    departments,
     semesters,
     programs,
+    selectedDepartmentId,
+    selectedDepartmentLabel,
     selectedSemesterId,
     selectedSemesterLabel,
     selectedProgramId,
@@ -44,12 +47,13 @@ export function ScopedFacultyListScreen({
     isLoading,
     isError,
     retry,
+    setSelectedDepartmentId,
     setSelectedSemesterId,
     setSelectedProgramId,
     setSearchValue,
     setCurrentPage,
     setRowsPerPage,
-  } = useScopedFacultyAnalyticsListViewModel({ allowAllPrograms });
+  } = useScopedFacultyAnalyticsListViewModel({ scopeLabel, allowAllPrograms });
   const selectedProgramValue = selectedProgramId ?? (allowAllPrograms ? ALL_PROGRAMS_VALUE : "");
 
   return (
@@ -63,18 +67,18 @@ export function ScopedFacultyListScreen({
             All faculties for the selected semester.
           </p>
         </div>
-        <div className="flex w-full flex-col gap-3 xl:max-w-5xl">
-          <div className="flex w-full flex-col gap-3 md:flex-row md:flex-wrap md:items-center md:justify-end">
+        <div className="w-full xl:max-w-6xl">
+          <div className="grid w-full grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-[auto_minmax(18rem,1fr)_13rem_13rem_13rem]">
             <Button
               type="button"
               variant="brand"
-              className="w-full px-4 py-2.5 font-sans text-sm md:w-auto md:shrink-0"
+              className="w-full px-4 py-2.5 font-sans text-sm xl:w-auto"
               onClick={() => setIsBatchExportDialogOpen(true)}
               disabled={!selectedSemesterId}
             >
               Batch Export PDF
             </Button>
-            <div className="relative w-full md:min-w-[18rem] md:flex-1">
+            <div className="relative w-full xl:min-w-[18rem]">
               <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 value={searchValue}
@@ -84,11 +88,44 @@ export function ScopedFacultyListScreen({
                 aria-label="Search faculty name"
               />
             </div>
+            {scopeLabel === "Campus" ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm"
+                    disabled={departments.length === 0}
+                  >
+                    <span className="truncate">{selectedDepartmentLabel}</span>
+                    <ChevronDown className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="end"
+                  className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-0"
+                >
+                  <DropdownMenuRadioGroup
+                    value={selectedDepartmentId ?? ""}
+                    onValueChange={setSelectedDepartmentId}
+                  >
+                    {departments.map((department) => (
+                      <DropdownMenuRadioItem
+                        key={department.id || "all-departments"}
+                        value={department.id}
+                        className="font-sans text-sm"
+                      >
+                        {department.label}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="outline"
-                  className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-[13rem] md:shrink-0"
+                  className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm"
                   disabled={programs.length === 0}
                 >
                   <span className="truncate">{selectedProgramLabel}</span>
@@ -119,7 +156,7 @@ export function ScopedFacultyListScreen({
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="outline"
-                  className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-[13rem] md:shrink-0"
+                  className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm"
                   disabled={semesters.length === 0}
                 >
                   <span className="truncate">{selectedSemesterLabel}</span>
@@ -183,6 +220,8 @@ export function ScopedFacultyListScreen({
         onOpenChange={setIsBatchExportDialogOpen}
         semesterId={selectedSemesterId}
         semesterLabel={selectedSemesterLabel}
+        departmentId={scopeLabel === "Campus" ? selectedDepartmentId : null}
+        departmentLabel={scopeLabel === "Campus" ? selectedDepartmentLabel : "All Departments"}
         programId={selectedProgramId}
         programs={programs.map((program) => ({
           id: program.id,

--- a/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
+++ b/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
@@ -31,6 +31,10 @@ export function ScopedFacultyListScreen({
   allowAllPrograms = true,
 }: ScopedFacultyListScreenProps) {
   const [isBatchExportDialogOpen, setIsBatchExportDialogOpen] = useState(false);
+  const isCampusScope = scopeLabel === "Campus";
+  const filtersGridClassName = isCampusScope
+    ? "xl:grid-cols-[auto_minmax(18rem,1fr)_13rem_13rem_13rem]"
+    : "xl:grid-cols-[auto_minmax(18rem,1fr)_13rem_13rem]";
   const {
     departments,
     semesters,
@@ -68,7 +72,7 @@ export function ScopedFacultyListScreen({
           </p>
         </div>
         <div className="w-full xl:max-w-6xl">
-          <div className="grid w-full grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-[auto_minmax(18rem,1fr)_13rem_13rem_13rem]">
+          <div className={`grid w-full grid-cols-1 gap-3 md:grid-cols-2 ${filtersGridClassName}`}>
             <Button
               type="button"
               variant="brand"
@@ -88,7 +92,7 @@ export function ScopedFacultyListScreen({
                 aria-label="Search faculty name"
               />
             </div>
-            {scopeLabel === "Campus" ? (
+            {isCampusScope ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
@@ -220,8 +224,8 @@ export function ScopedFacultyListScreen({
         onOpenChange={setIsBatchExportDialogOpen}
         semesterId={selectedSemesterId}
         semesterLabel={selectedSemesterLabel}
-        departmentId={scopeLabel === "Campus" ? selectedDepartmentId : null}
-        departmentLabel={scopeLabel === "Campus" ? selectedDepartmentLabel : "All Departments"}
+        departmentId={isCampusScope ? selectedDepartmentId : null}
+        departmentLabel={isCampusScope ? selectedDepartmentLabel : "All Departments"}
         programId={selectedProgramId}
         programs={programs.map((program) => ({
           id: program.id,

--- a/features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model.ts
+++ b/features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model.ts
@@ -58,10 +58,13 @@ export function useScopedAnalyticsDashboardViewModel(scopeLabel: ScopeLabel) {
       return accessibility.filter((item) => item.isAccessible).map((item) => item.semester);
     },
   });
-  const scopedSemesterOptionsSource =
-    scopeLabel === "Campus"
-      ? (campusHeadSemestersQuery.data ?? [])
-      : (profileSemestersQuery.data?.data ?? []);
+  const scopedSemesterOptionsSource = useMemo(
+    () =>
+      scopeLabel === "Campus"
+        ? (campusHeadSemestersQuery.data ?? [])
+        : (profileSemestersQuery.data?.data ?? []),
+    [campusHeadSemestersQuery.data, profileSemestersQuery.data?.data, scopeLabel]
+  );
 
   const semesters = useMemo(
     () => mapSemesterOptionsToViewModel(scopedSemesterOptionsSource),
@@ -71,10 +74,6 @@ export function useScopedAnalyticsDashboardViewModel(scopeLabel: ScopeLabel) {
     selectedSemesterIdState && semesters.some((semester) => semester.id === selectedSemesterIdState)
       ? selectedSemesterIdState
       : (semesters[0]?.id ?? null);
-  const selectedSemesterSource =
-    scopedSemesterOptionsSource.find((semester) => semester.id === selectedSemesterId) ??
-    scopedSemesterOptionsSource[0] ??
-    null;
 
   const departmentOptionsQuery = useQuery({
     queryKey: ["curriculum", "department-options", selectedSemesterId, token],
@@ -252,7 +251,6 @@ export function useScopedAnalyticsDashboardViewModel(scopeLabel: ScopeLabel) {
       setSelectedDepartmentId(value || null);
       setSelectedProgramCode(null);
     },
-    selectedSemesterCampusId: selectedSemesterSource?.campus.id ?? null,
     setSelectedProgramCode: (value: string) => {
       setSelectedProgramCode(value === ALL_PROGRAMS_VALUE ? null : value);
     },

--- a/features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model.ts
+++ b/features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model.ts
@@ -1,14 +1,20 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import { useMe } from "@/features/auth/hooks/use-me";
 import { useAttentionList } from "@/features/faculty-analytics/hooks/use-attention-list";
+import {
+  fetchDepartmentOptions,
+  fetchSemesters,
+} from "@/features/faculty-analytics/api/faculty-analytics.requests";
 import {
   ALL_PROGRAMS_LABEL,
   ALL_PROGRAMS_VALUE,
 } from "@/features/faculty-analytics/constants/filters";
 import {
+  mapDepartmentOptionsToViewModel,
   mapDepartmentOverviewToDashboardViewModel,
   mapProgramOptionsToViewModel,
   mapSemesterOptionsToViewModel,
@@ -17,26 +23,88 @@ import { useDepartmentOverview } from "@/features/faculty-analytics/hooks/use-de
 import { useProgramOptions } from "@/features/faculty-analytics/hooks/use-program-options";
 import { useSemesterOptions } from "@/features/faculty-analytics/hooks/use-semester-options";
 import { formatRelativeTime } from "@/lib/date";
+import type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-analytics-dashboard-screen";
+import { useAuthStore } from "@/stores/auth-store";
 
-export function useScopedAnalyticsDashboardViewModel() {
+export function useScopedAnalyticsDashboardViewModel(scopeLabel: ScopeLabel) {
   const [selectedSemesterIdState, setSelectedSemesterId] = useState<string | null>(null);
+  const [selectedDepartmentIdState, setSelectedDepartmentId] = useState<string | null>(null);
   const [selectedProgramCodeState, setSelectedProgramCode] = useState<string | null>(null);
   const meQuery = useMe();
-  const campusId = meQuery.data?.campus?.id;
-  const semestersQuery = useSemesterOptions(campusId ? { campusId } : undefined, {
-    enabled: !meQuery.isLoading && !meQuery.isError,
+  const token = useAuthStore((state) => state.token);
+  const profileSemestersQuery = useSemesterOptions(
+    meQuery.data?.campus?.id ? { campusId: meQuery.data.campus.id } : undefined,
+    { enabled: !meQuery.isLoading && !meQuery.isError && scopeLabel !== "Campus" }
+  );
+  const campusHeadSemestersQuery = useQuery({
+    queryKey: ["semesters", "campus-head-accessible", token],
+    enabled: Boolean(token) && scopeLabel === "Campus",
+    queryFn: async () => {
+      const allSemesters = await fetchSemesters();
+      const accessibility = await Promise.all(
+        allSemesters.data.map(async (semester) => {
+          const departments = await fetchDepartmentOptions({
+            semesterId: semester.id,
+            limit: 1,
+          });
+
+          return {
+            semester,
+            isAccessible: departments.data.length > 0,
+          };
+        })
+      );
+
+      return accessibility.filter((item) => item.isAccessible).map((item) => item.semester);
+    },
   });
+  const scopedSemesterOptionsSource =
+    scopeLabel === "Campus"
+      ? (campusHeadSemestersQuery.data ?? [])
+      : (profileSemestersQuery.data?.data ?? []);
+
   const semesters = useMemo(
-    () => mapSemesterOptionsToViewModel(semestersQuery.data?.data ?? []),
-    [semestersQuery.data]
+    () => mapSemesterOptionsToViewModel(scopedSemesterOptionsSource),
+    [scopedSemesterOptionsSource]
   );
   const selectedSemesterId =
     selectedSemesterIdState && semesters.some((semester) => semester.id === selectedSemesterIdState)
       ? selectedSemesterIdState
       : (semesters[0]?.id ?? null);
+  const selectedSemesterSource =
+    scopedSemesterOptionsSource.find((semester) => semester.id === selectedSemesterId) ??
+    scopedSemesterOptionsSource[0] ??
+    null;
+
+  const departmentOptionsQuery = useQuery({
+    queryKey: ["curriculum", "department-options", selectedSemesterId, token],
+    enabled: Boolean(token) && Boolean(selectedSemesterId) && scopeLabel === "Campus",
+    queryFn: () =>
+      fetchDepartmentOptions({
+        semesterId: selectedSemesterId ?? "",
+        limit: 100,
+      }),
+  });
+  const departments = useMemo(
+    () =>
+      scopeLabel === "Campus"
+        ? mapDepartmentOptionsToViewModel(departmentOptionsQuery.data?.data ?? [])
+        : [],
+    [departmentOptionsQuery.data, scopeLabel]
+  );
+  const selectedDepartment =
+    departments.find((department) => department.id === (selectedDepartmentIdState ?? "")) ??
+    departments[0] ??
+    null;
+  const selectedDepartmentId = selectedDepartment?.id || null;
+  const selectedDepartmentCode = selectedDepartment?.code || null;
 
   const programOptionsQuery = useProgramOptions(
-    { semesterId: selectedSemesterId ?? "", limit: 100 },
+    {
+      semesterId: selectedSemesterId ?? "",
+      departmentId: scopeLabel === "Campus" ? (selectedDepartmentId ?? undefined) : undefined,
+      limit: 100,
+    },
     { enabled: Boolean(selectedSemesterId) }
   );
   const programs = useMemo(
@@ -56,31 +124,85 @@ export function useScopedAnalyticsDashboardViewModel() {
     { enabled: Boolean(selectedSemesterId) }
   );
 
+  const filteredOverview = useMemo(() => {
+    if (!overviewQuery.data) {
+      return null;
+    }
+
+    if (scopeLabel !== "Campus" || !selectedDepartmentCode) {
+      return overviewQuery.data;
+    }
+
+    const faculty = overviewQuery.data.faculty.filter(
+      (item) => item.departmentCode === selectedDepartmentCode
+    );
+
+    return {
+      ...overviewQuery.data,
+      faculty,
+      summary: faculty.reduce(
+        (summary, item) => ({
+          totalFaculty: summary.totalFaculty + 1,
+          totalSubmissions: summary.totalSubmissions + item.submissionCount,
+          totalAnalyzed: summary.totalAnalyzed + item.analyzedCount,
+          positiveCount: summary.positiveCount + item.positiveCount,
+          negativeCount: summary.negativeCount + item.negativeCount,
+          neutralCount: summary.neutralCount + item.neutralCount,
+        }),
+        {
+          totalFaculty: 0,
+          totalSubmissions: 0,
+          totalAnalyzed: 0,
+          positiveCount: 0,
+          negativeCount: 0,
+          neutralCount: 0,
+        }
+      ),
+    };
+  }, [overviewQuery.data, scopeLabel, selectedDepartmentCode]);
+
+  const filteredAttentionItems = useMemo(() => {
+    if (scopeLabel !== "Campus" || !selectedDepartmentCode) {
+      return attentionQuery.data?.items ?? [];
+    }
+
+    return (attentionQuery.data?.items ?? []).filter(
+      (item) => item.departmentCode === selectedDepartmentCode
+    );
+  }, [attentionQuery.data?.items, scopeLabel, selectedDepartmentCode]);
+
   const selectedSemester =
     semesters.find((semester) => semester.id === selectedSemesterId) ?? semesters[0] ?? null;
 
-  const dashboardViewModel = overviewQuery.data
+  const dashboardViewModel = filteredOverview
     ? mapDepartmentOverviewToDashboardViewModel({
-        overview: overviewQuery.data,
+        overview: filteredOverview,
         semesters,
         selectedSemesterId,
-        lastUpdatedLabel: overviewQuery.data.lastRefreshedAt
-          ? formatRelativeTime(overviewQuery.data.lastRefreshedAt)
+        lastUpdatedLabel: filteredOverview.lastRefreshedAt
+          ? formatRelativeTime(filteredOverview.lastRefreshedAt)
           : "Not yet available",
       })
     : null;
 
   const isLoading =
     meQuery.isLoading ||
-    semestersQuery.isLoading ||
+    (scopeLabel === "Campus"
+      ? campusHeadSemestersQuery.isLoading
+      : profileSemestersQuery.isLoading) ||
+    (Boolean(selectedSemesterId) && scopeLabel === "Campus" && departmentOptionsQuery.isLoading) ||
     (Boolean(selectedSemesterId) && programOptionsQuery.isLoading) ||
     (Boolean(selectedSemesterId) && overviewQuery.isLoading);
   const isError =
     meQuery.isError ||
-    semestersQuery.isError ||
+    (scopeLabel === "Campus" ? campusHeadSemestersQuery.isError : profileSemestersQuery.isError) ||
+    departmentOptionsQuery.isError ||
     programOptionsQuery.isError ||
     overviewQuery.isError;
   return {
+    departments,
+    selectedDepartmentId,
+    selectedDepartmentLabel: selectedDepartment?.label ?? "All Departments",
     semesters,
     programs,
     selectedSemesterId,
@@ -98,14 +220,21 @@ export function useScopedAnalyticsDashboardViewModel() {
       positiveSentimentRate: 0,
     },
     overallSentiment: dashboardViewModel?.overallSentiment ?? [],
-    attentionItems: attentionQuery.data?.items ?? [],
-    overview: overviewQuery.data ?? null,
+    attentionItems: filteredAttentionItems,
+    overview: filteredOverview ?? null,
     isAttentionLoading: Boolean(selectedSemesterId) && attentionQuery.isLoading,
     isLoading,
     isError,
     retry: () => {
       void meQuery.refetch();
-      void semestersQuery.refetch();
+      if (scopeLabel === "Campus") {
+        void campusHeadSemestersQuery.refetch();
+        if (selectedSemesterId) {
+          void departmentOptionsQuery.refetch();
+        }
+      } else {
+        void profileSemestersQuery.refetch();
+      }
       if (selectedSemesterId) {
         void programOptionsQuery.refetch();
       }
@@ -116,8 +245,14 @@ export function useScopedAnalyticsDashboardViewModel() {
     },
     setSelectedSemesterId: (value: string) => {
       setSelectedSemesterId(value);
+      setSelectedDepartmentId(null);
       setSelectedProgramCode(null);
     },
+    setSelectedDepartmentId: (value: string) => {
+      setSelectedDepartmentId(value || null);
+      setSelectedProgramCode(null);
+    },
+    selectedSemesterCampusId: selectedSemesterSource?.campus.id ?? null,
     setSelectedProgramCode: (value: string) => {
       setSelectedProgramCode(value === ALL_PROGRAMS_VALUE ? null : value);
     },

--- a/features/faculty-analytics/hooks/use-scoped-faculty-analytics-list-view-model.ts
+++ b/features/faculty-analytics/hooks/use-scoped-faculty-analytics-list-view-model.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useDeferredValue, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import { DEFAULT_PAGE_SIZE } from "@/lib/pagination";
 import { useMe } from "@/features/auth/hooks/use-me";
@@ -8,47 +9,111 @@ import {
   ALL_PROGRAMS_LABEL,
   ALL_PROGRAMS_VALUE,
 } from "@/features/faculty-analytics/constants/filters";
+import {
+  fetchDepartmentOptions,
+  fetchSemesters,
+} from "@/features/faculty-analytics/api/faculty-analytics.requests";
 import { useFacultyList } from "@/features/faculty-analytics/hooks/use-faculty-list";
 import {
+  mapDepartmentOptionsToViewModel,
   mapProgramOptionsToViewModel,
   mapSemesterOptionsToViewModel,
 } from "@/features/faculty-analytics/lib/scoped-analytics-view-model";
 import { useProgramOptions } from "@/features/faculty-analytics/hooks/use-program-options";
 import { useSemesterOptions } from "@/features/faculty-analytics/hooks/use-semester-options";
+import type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-analytics-dashboard-screen";
+import { useAuthStore } from "@/stores/auth-store";
 
 type UseScopedFacultyAnalyticsListViewModelOptions = {
+  scopeLabel: ScopeLabel;
   allowAllPrograms?: boolean;
 };
 
 export function useScopedFacultyAnalyticsListViewModel(
-  options?: UseScopedFacultyAnalyticsListViewModelOptions
+  options: UseScopedFacultyAnalyticsListViewModelOptions
 ) {
   const [selectedSemesterIdState, setSelectedSemesterId] = useState<string | null>(null);
+  const [selectedDepartmentIdState, setSelectedDepartmentId] = useState<string | null>(null);
   const [selectedProgramIdState, setSelectedProgramId] = useState<string | null>(null);
   const [searchValue, setSearchValue] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState<number>(DEFAULT_PAGE_SIZE);
-  const allowAllPrograms = options?.allowAllPrograms ?? true;
+  const scopeLabel = options.scopeLabel;
+  const allowAllPrograms = options.allowAllPrograms ?? true;
+  const isCampusScope = scopeLabel === "Campus";
 
   const deferredSearchValue = useDeferredValue(searchValue.trim());
   const meQuery = useMe();
-  const campusId = meQuery.data?.campus?.id;
-  const semestersQuery = useSemesterOptions(campusId ? { campusId } : undefined, {
-    enabled: !meQuery.isLoading && !meQuery.isError,
+  const token = useAuthStore((state) => state.token);
+  const profileSemestersQuery = useSemesterOptions(
+    meQuery.data?.campus?.id ? { campusId: meQuery.data.campus.id } : undefined,
+    { enabled: !meQuery.isLoading && !meQuery.isError && !isCampusScope }
+  );
+  const campusHeadSemestersQuery = useQuery({
+    queryKey: ["semesters", "campus-head-accessible", token],
+    enabled: Boolean(token) && isCampusScope,
+    queryFn: async () => {
+      const allSemesters = await fetchSemesters();
+      const accessibility = await Promise.all(
+        allSemesters.data.map(async (semester) => {
+          const departments = await fetchDepartmentOptions({
+            semesterId: semester.id,
+            limit: 1,
+          });
+
+          return {
+            semester,
+            isAccessible: departments.data.length > 0,
+          };
+        })
+      );
+
+      return accessibility.filter((item) => item.isAccessible).map((item) => item.semester);
+    },
   });
+  const scopedSemesterOptionsSource = useMemo(
+    () =>
+      isCampusScope
+        ? (campusHeadSemestersQuery.data ?? [])
+        : (profileSemestersQuery.data?.data ?? []),
+    [campusHeadSemestersQuery.data, isCampusScope, profileSemestersQuery.data?.data]
+  );
 
   const semesters = useMemo(
-    () => mapSemesterOptionsToViewModel(semestersQuery.data?.data ?? []),
-    [semestersQuery.data]
+    () => mapSemesterOptionsToViewModel(scopedSemesterOptionsSource),
+    [scopedSemesterOptionsSource]
   );
 
   const selectedSemesterId =
     selectedSemesterIdState && semesters.some((semester) => semester.id === selectedSemesterIdState)
       ? selectedSemesterIdState
       : (semesters[0]?.id ?? null);
+  const departmentOptionsQuery = useQuery({
+    queryKey: ["curriculum", "department-options", selectedSemesterId, token],
+    enabled: Boolean(token) && Boolean(selectedSemesterId) && isCampusScope,
+    queryFn: () =>
+      fetchDepartmentOptions({
+        semesterId: selectedSemesterId ?? "",
+        limit: 100,
+      }),
+  });
+  const departments = useMemo(
+    () =>
+      isCampusScope ? mapDepartmentOptionsToViewModel(departmentOptionsQuery.data?.data ?? []) : [],
+    [departmentOptionsQuery.data, isCampusScope]
+  );
+  const selectedDepartment =
+    departments.find((department) => department.id === (selectedDepartmentIdState ?? "")) ??
+    departments[0] ??
+    null;
+  const selectedDepartmentId = selectedDepartment?.id || null;
 
   const programOptionsQuery = useProgramOptions(
-    { semesterId: selectedSemesterId ?? "", limit: 100 },
+    {
+      semesterId: selectedSemesterId ?? "",
+      departmentId: isCampusScope ? (selectedDepartmentId ?? undefined) : undefined,
+      limit: 100,
+    },
     { enabled: Boolean(selectedSemesterId) }
   );
   const programs = useMemo(
@@ -62,6 +127,7 @@ export function useScopedFacultyAnalyticsListViewModel(
   const facultyListQuery = useFacultyList(
     {
       semesterId: selectedSemesterId ?? "",
+      departmentId: isCampusScope ? (selectedDepartmentId ?? undefined) : undefined,
       programId: selectedProgramId ?? undefined,
       search: deferredSearchValue || undefined,
       page: currentPage,
@@ -92,22 +158,26 @@ export function useScopedFacultyAnalyticsListViewModel(
     searchValue,
     isLoading:
       meQuery.isLoading ||
-      semestersQuery.isLoading ||
+      (isCampusScope ? campusHeadSemestersQuery.isLoading : profileSemestersQuery.isLoading) ||
+      (Boolean(selectedSemesterId) && isCampusScope && departmentOptionsQuery.isLoading) ||
       (Boolean(selectedSemesterId) && programOptionsQuery.isLoading) ||
       (Boolean(selectedSemesterId) && facultyListQuery.isLoading),
     isError:
       meQuery.isError ||
-      semestersQuery.isError ||
+      (isCampusScope ? campusHeadSemestersQuery.isError : profileSemestersQuery.isError) ||
+      departmentOptionsQuery.isError ||
       programOptionsQuery.isError ||
       facultyListQuery.isError,
-    isFetching:
-      meQuery.isFetching ||
-      semestersQuery.isFetching ||
-      programOptionsQuery.isFetching ||
-      facultyListQuery.isFetching,
     retry: () => {
       void meQuery.refetch();
-      void semestersQuery.refetch();
+      if (isCampusScope) {
+        void campusHeadSemestersQuery.refetch();
+        if (selectedSemesterId) {
+          void departmentOptionsQuery.refetch();
+        }
+      } else {
+        void profileSemestersQuery.refetch();
+      }
       if (selectedSemesterId) {
         void programOptionsQuery.refetch();
       }
@@ -117,6 +187,15 @@ export function useScopedFacultyAnalyticsListViewModel(
     },
     setSelectedSemesterId: (value: string) => {
       setSelectedSemesterId(value);
+      setSelectedDepartmentId(null);
+      setSelectedProgramId(null);
+      setCurrentPage(1);
+    },
+    departments,
+    selectedDepartmentId,
+    selectedDepartmentLabel: selectedDepartment?.label ?? "All Departments",
+    setSelectedDepartmentId: (value: string) => {
+      setSelectedDepartmentId(value || null);
       setSelectedProgramId(null);
       setCurrentPage(1);
     },

--- a/features/faculty-analytics/lib/scoped-analytics-view-model.ts
+++ b/features/faculty-analytics/lib/scoped-analytics-view-model.ts
@@ -1,5 +1,6 @@
 import { ALL_PROGRAMS_LABEL } from "@/features/faculty-analytics/constants/filters";
 import type {
+  DepartmentOptionDto,
   DepartmentOverviewResponseDto,
   ProgramOptionDto,
   SemesterOptionDto,
@@ -9,6 +10,12 @@ export type ScopedSemesterOption = {
   id: string;
   label: string;
   academicYear?: string;
+};
+
+export type ScopedDepartmentOption = {
+  id: string;
+  code: string;
+  label: string;
 };
 
 export type ScopedSummaryMetrics = {
@@ -54,6 +61,23 @@ export function mapSemesterOptionsToViewModel(
     label: semester.label ?? [semester.code, semester.academicYear].filter(Boolean).join(" • "),
     academicYear: semester.academicYear,
   }));
+}
+
+export function mapDepartmentOptionsToViewModel(
+  departments: DepartmentOptionDto[],
+  allowAllDepartments = true
+): ScopedDepartmentOption[] {
+  const mappedDepartments = departments.map((department) => ({
+    id: department.id,
+    code: department.code,
+    label: department.name?.trim() ? `${department.code} • ${department.name}` : department.code,
+  }));
+
+  if (!allowAllDepartments) {
+    return mappedDepartments;
+  }
+
+  return [{ id: "", code: "", label: "All Departments" }, ...mappedDepartments];
 }
 
 export function mapProgramOptionsToViewModel(

--- a/features/faculty-analytics/types/index.ts
+++ b/features/faculty-analytics/types/index.ts
@@ -57,6 +57,12 @@ export type ProgramOptionDto = {
   departmentId: string;
 };
 
+export type DepartmentOptionDto = {
+  id: string;
+  code: string;
+  name: string | null;
+};
+
 export type PaginationMetaDto = {
   totalItems: number;
   itemCount: number;
@@ -73,6 +79,18 @@ export type ProgramListResponseDto = {
 export type ListProgramsQuery = {
   semesterId: string;
   departmentId?: string;
+  search?: string;
+  page?: number;
+  limit?: number;
+};
+
+export type DepartmentListResponseDto = {
+  data: DepartmentOptionDto[];
+  meta: PaginationMetaDto;
+};
+
+export type ListDepartmentsQuery = {
+  semesterId: string;
   search?: string;
   page?: number;
   limit?: number;
@@ -401,19 +419,18 @@ export type PipelineStatus =
 
 export type RunStatus = "PENDING" | "PROCESSING" | "COMPLETED" | "FAILED";
 
-// FAC-135 Phase A: collapsed scope shape. The canonical pipeline scope now
-// consists of `{ scopeType, scopeId }` plus the mandatory `semesterId`.
-// Legacy fields (facultyId/departmentId/programId/campusId/courseId/
-// questionnaireTypeCode) are gone from the frontend surface entirely —
-// the API still accepts them via a backwards-compat preprocessor but we
-// switch to the canonical shape immediately (hard cutover per TD-2).
+// Canonical explicit scope is `{ scopeType, scopeId }` plus `semesterId`,
+// but scoped dashboards still rely on backend role inference and may send
+// only `semesterId` for create/list flows.
 export type ScopeType = "FACULTY" | "DEPARTMENT" | "CAMPUS";
 
-// POST /analysis/pipelines body: scopeType + scopeId are REQUIRED.
+// For scoped dashboards, `scopeType`/`scopeId` may be omitted and inferred
+// by the backend from the caller role. Faculty self-view still passes them
+// explicitly.
 export type PipelineScopeIds = {
   semesterId: string;
-  scopeType: ScopeType;
-  scopeId: string;
+  scopeType?: ScopeType;
+  scopeId?: string;
   questionnaireVersionId?: string;
 };
 

--- a/features/faculty-analytics/types/index.ts
+++ b/features/faculty-analytics/types/index.ts
@@ -108,6 +108,7 @@ export type AttentionListQuery = {
 
 export type FacultyListQuery = {
   semesterId: string;
+  departmentId?: string;
   programId?: string;
   search?: string;
   page?: number;

--- a/network/endpoints.ts
+++ b/network/endpoints.ts
@@ -12,6 +12,7 @@ export enum Endpoints {
   semesters = "/api/v1/semesters",
 
   // Curriculum
+  curriculumDepartments = "/api/v1/curriculum/departments",
   curriculumPrograms = "/api/v1/curriculum/programs",
 
   // Questionnaires


### PR DESCRIPTION
## Summary
- make the campus head analytics dashboard campus-wide and remove mis-scoped pipeline-only sections from that role
- add campus-head department-aware filtering to the faculties page, including department-constrained program options and batch export scope
- hide the faculty analysis pipeline trigger for campus head while preserving pipeline access for dean and chairperson
- clean up scoped analytics view-model wiring and related dashboard/faculty list UI behavior

## Test plan
- [x] Verify campus head dashboard reflects campus-wide analytics and no longer shows the pipeline trigger, faculty requiring attention, or suggested actions
- [x] Verify dean and chairperson dashboards still show the analysis pipeline trigger and existing pipeline behavior
- [x] Verify campus head faculties page shows a department filter and that changing department narrows program options and faculty results
- [x] Verify campus head batch export uses the selected department and program scope
- [x] Verify faculty analysis page hides the pipeline trigger for campus head only

Closes #102