### PR TITLE
FAC-WEB feat: pre-submit answer review dialog for student evaluations

### DIFF
--- a/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-form.tsx
+++ b/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-form.tsx
@@ -23,6 +23,7 @@ import { collectRequiredIds } from "@/features/questionnaires/lib/evaluation-val
 import type { QuestionnaireFormValues } from "@/features/questionnaires/types";
 
 import { EvaluationPageShell } from "./evaluation-page-shell";
+import { EvaluationReviewDialog } from "./evaluation-review-dialog";
 
 type EvaluationFormProps = {
   courseId: string;
@@ -53,6 +54,8 @@ export function EvaluationForm({
 }: EvaluationFormProps) {
   const formValuesRef = useRef<QuestionnaireFormValues | null>(null);
   const [draftStatus, setDraftStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [showReviewDialog, setShowReviewDialog] = useState(false);
+  const [reviewValues, setReviewValues] = useState<QuestionnaireFormValues | null>(null);
   const [showSuccessDialog, setShowSuccessDialog] = useState(false);
 
   const meQuery = useMe();
@@ -74,12 +77,11 @@ export function EvaluationForm({
     [debouncedSave]
   );
 
-  const handleSubmit = useCallback(() => {
+  const handleOpenReview = useCallback(() => {
     const values = formValuesRef.current;
     if (!values) return;
 
-    const respondentId = meQuery.data?.id;
-    if (!respondentId) {
+    if (!meQuery.data?.id) {
       toast.error("Unable to identify your account. Please try again.");
       return;
     }
@@ -101,6 +103,20 @@ export function EvaluationForm({
       return;
     }
 
+    setReviewValues(values);
+    setShowReviewDialog(true);
+  }, [meQuery.data?.id, model]);
+
+  const handleConfirmSubmit = useCallback(() => {
+    const values = reviewValues;
+    if (!values) return;
+
+    const respondentId = meQuery.data?.id;
+    if (!respondentId) {
+      toast.error("Unable to identify your account. Please try again.");
+      return;
+    }
+
     cancelAutoSave();
     mutate(
       {
@@ -113,7 +129,10 @@ export function EvaluationForm({
         qualitativeComment: values.qualitativeComment || undefined,
       },
       {
-        onSuccess: () => setShowSuccessDialog(true),
+        onSuccess: () => {
+          setShowReviewDialog(false);
+          setShowSuccessDialog(true);
+        },
       }
     );
   }, [
@@ -122,7 +141,7 @@ export function EvaluationForm({
     semester.id,
     courseId,
     meQuery.data?.id,
-    model,
+    reviewValues,
     cancelAutoSave,
     mutate,
   ]);
@@ -170,7 +189,7 @@ export function EvaluationForm({
         <Button
           variant="brand"
           size="lg"
-          onClick={handleSubmit}
+          onClick={handleOpenReview}
           disabled={isPending}
           className="w-full sm:w-auto"
         >
@@ -184,6 +203,15 @@ export function EvaluationForm({
           )}
         </Button>
       </div>
+
+      <EvaluationReviewDialog
+        open={showReviewDialog}
+        onOpenChange={setShowReviewDialog}
+        model={model}
+        values={reviewValues}
+        isSubmitting={isPending}
+        onConfirm={handleConfirmSubmit}
+      />
 
       <Dialog open={showSuccessDialog} onOpenChange={setShowSuccessDialog}>
         <DialogContent

--- a/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-review-dialog.tsx
+++ b/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-review-dialog.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { QuestionnaireFormSummary } from "@/features/questionnaires/components/form/questionnaire-form-summary";
+import type {
+  QuestionnaireBuilderPreviewModel,
+  QuestionnaireFormValues,
+} from "@/features/questionnaires/types";
+
+type EvaluationReviewDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  model: QuestionnaireBuilderPreviewModel;
+  values: QuestionnaireFormValues | null;
+  isSubmitting: boolean;
+  onConfirm: () => void;
+};
+
+export function EvaluationReviewDialog({
+  open,
+  onOpenChange,
+  model,
+  values,
+  isSubmitting,
+  onConfirm,
+}: EvaluationReviewDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (isSubmitting && !next) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent
+        className="max-w-3xl"
+        onInteractOutside={(e) => {
+          if (isSubmitting) e.preventDefault();
+        }}
+        onEscapeKeyDown={(e) => {
+          if (isSubmitting) e.preventDefault();
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle className="font-playfair text-xl">Review your evaluation</DialogTitle>
+          <DialogDescription>
+            Please review your answers below. You can go back to edit them or confirm to submit.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[60vh] overflow-y-auto pr-1">
+          {values ? (
+            <QuestionnaireFormSummary model={model} values={values} />
+          ) : (
+            <p className="text-sm text-muted-foreground">No answers to review.</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSubmitting}
+            className="w-full sm:w-auto"
+          >
+            Edit
+          </Button>
+          <Button
+            variant="brand"
+            onClick={onConfirm}
+            disabled={isSubmitting || !values}
+            className="w-full sm:w-auto"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Submitting...
+              </>
+            ) : (
+              "Confirm & Submit"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/questionnaires/components/form/questionnaire-form-stacked.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-stacked.tsx
@@ -5,6 +5,7 @@ import { Check } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import {
+  LIKERT_LABELS,
   LIKERT_OPTIONS,
   YES_NO_OPTIONS,
   YES_NO_VALUE_MAP,
@@ -22,14 +23,6 @@ type QuestionnaireFormStackedProps = {
   questions: QuestionnaireBuilderPreviewQuestion[];
   questionType: BuilderQuestionType;
   mode: QuestionnaireFormMode;
-};
-
-const LIKERT_LABELS: Record<string, string> = {
-  "1": "Strongly Disagree",
-  "2": "Disagree",
-  "3": "Neutral",
-  "4": "Agree",
-  "5": "Strongly Agree",
 };
 
 function getSelectedOptionKey(value: number | undefined, isLikert: boolean): string {

--- a/features/questionnaires/components/form/questionnaire-form-summary.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-summary.tsx
@@ -1,0 +1,154 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { LIKERT_LABELS, YES_NO_REVERSE_MAP } from "@/features/questionnaires/constants/builder";
+import type {
+  BuilderQuestionType,
+  QuestionnaireBuilderPreviewModel,
+  QuestionnaireBuilderPreviewQuestion,
+  QuestionnaireBuilderPreviewSection,
+  QuestionnaireFormAnswers,
+  QuestionnaireFormValues,
+} from "@/features/questionnaires/types";
+
+type QuestionnaireFormSummaryProps = {
+  model: QuestionnaireBuilderPreviewModel;
+  values: QuestionnaireFormValues;
+};
+
+function formatAnswer(
+  question: QuestionnaireBuilderPreviewQuestion,
+  answers: QuestionnaireFormAnswers
+): { text: string; answered: boolean } {
+  const value = answers[question.id];
+  if (value === undefined) {
+    return { text: "Not answered", answered: false };
+  }
+  if (question.type === "LIKERT_1_5") {
+    const label = LIKERT_LABELS[String(value)];
+    return { text: label ? `${value} – ${label}` : String(value), answered: true };
+  }
+  if (question.type === "YES_NO") {
+    return { text: YES_NO_REVERSE_MAP[value] ?? String(value), answered: true };
+  }
+  return { text: String(value), answered: true };
+}
+
+function SectionSummary({
+  section,
+  answers,
+  isChild = false,
+}: {
+  section: QuestionnaireBuilderPreviewSection;
+  answers: QuestionnaireFormAnswers;
+  isChild?: boolean;
+}) {
+  const isLeaf = section.questions.length > 0;
+  const isInternal = section.children.length > 0;
+
+  return (
+    <div
+      className={
+        isChild ? "space-y-3 pl-3 sm:pl-6" : "space-y-3 rounded-2xl border bg-background p-4 sm:p-5"
+      }
+    >
+      <h3 className="font-playfair text-lg leading-tight font-semibold tracking-tight text-foreground sm:text-xl">
+        {section.title}
+      </h3>
+
+      {isLeaf && (
+        <SectionAnswerTable
+          questions={section.questions}
+          questionType={section.questions[0]?.type ?? "LIKERT_1_5"}
+          answers={answers}
+        />
+      )}
+
+      {isInternal && (
+        <div className="space-y-3">
+          {section.children.map((child) => (
+            <SectionSummary key={child.id} section={child} answers={answers} isChild />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SectionAnswerTable({
+  questions,
+  questionType,
+  answers,
+}: {
+  questions: QuestionnaireBuilderPreviewQuestion[];
+  questionType: BuilderQuestionType;
+  answers: QuestionnaireFormAnswers;
+}) {
+  const answerColumnLabel = questionType === "YES_NO" ? "Response" : "Rating";
+
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[65%]">Question</TableHead>
+            <TableHead>{answerColumnLabel}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {questions.map((question) => {
+            const { text, answered } = formatAnswer(question, answers);
+            return (
+              <TableRow key={question.id}>
+                <TableCell className="align-top text-sm font-normal whitespace-normal">
+                  {question.prompt || "Untitled question"}
+                </TableCell>
+                <TableCell
+                  className={
+                    "align-top text-sm font-medium tabular-nums " +
+                    (answered ? "" : "text-muted-foreground italic")
+                  }
+                >
+                  {text}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export function QuestionnaireFormSummary({ model, values }: QuestionnaireFormSummaryProps) {
+  const trimmedComment = values.qualitativeComment.trim();
+
+  return (
+    <div className="space-y-5">
+      {model.sections.map((section) => (
+        <SectionSummary key={section.id} section={section} answers={values.answers} />
+      ))}
+
+      {model.qualitative.enabled && (
+        <Card className="gap-3">
+          <CardHeader>
+            <CardTitle className="font-playfair text-lg">Comments</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {trimmedComment ? (
+              <p className="text-sm whitespace-pre-wrap text-foreground">{trimmedComment}</p>
+            ) : (
+              <p className="text-sm text-muted-foreground italic">No comment provided</p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/features/questionnaires/constants/builder.ts
+++ b/features/questionnaires/constants/builder.ts
@@ -13,3 +13,11 @@ export const YES_NO_OPTIONS = ["Yes", "No"] as const;
 export const YES_NO_VALUE_MAP: Record<string, number> = { Yes: 5, No: 1 };
 
 export const YES_NO_REVERSE_MAP: Record<number, string> = { 5: "Yes", 1: "No" };
+
+export const LIKERT_LABELS: Record<string, string> = {
+  "1": "Strongly Disagree",
+  "2": "Disagree",
+  "3": "Neutral",
+  "4": "Agree",
+  "5": "Strongly Agree",
+};


### PR DESCRIPTION
## Summary

- Adds a **review confirmation dialog** between the **Submit Evaluation** button and the actual `useSubmitEvaluation` mutation so students can verify their answers before final submission.
- New `QuestionnaireFormSummary` renders each leaf section as a 2-column `Question | Rating` (or `Response`) shadcn `Table`; the qualitative comment is shown as plain text below in a Card. Recurses through nested sections; works for any questionnaire type.
- Existing required-question and required-comment validation still runs first — the review dialog only opens once validation passes.
- Lifted `LIKERT_LABELS` from `questionnaire-form-stacked.tsx` into `features/questionnaires/constants/builder.ts` so the stacked input and the new summary share the same wording.

## Files

- `features/questionnaires/components/form/questionnaire-form-summary.tsx` (new)
- `app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-review-dialog.tsx` (new)
- `app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-form.tsx` (split submit handler into `handleOpenReview` + `handleConfirmSubmit`)
- `features/questionnaires/components/form/questionnaire-form-stacked.tsx` (import lift)
- `features/questionnaires/constants/builder.ts` (added `LIKERT_LABELS`)

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] As a student on a course with an active questionnaire: answer LIKERT questions + add a comment → click **Submit Evaluation** → review dialog opens with all answers in a table and the comment below
- [ ] Click **Edit** → dialog closes, no network request fires, form state preserved
- [ ] Re-open and click **Confirm & Submit** → spinner shows, request fires once, success dialog appears, "Back to Courses" navigates correctly
- [ ] Leave a required question blank → toast appears, review dialog does **not** open
- [ ] Repeat with YES/NO questions and a questionnaire with nested sections to confirm formatting + recursion
- [ ] Mobile width: dialog is usable, table scrolls horizontally if needed

Closes #29.
Closes #108.