### PR TITLE
FAC-WEB feat: route attention card action to faculty analysis

### DIFF
--- a/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
+++ b/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
@@ -213,6 +213,8 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
                   hasAnalyticsData={overview?.lastRefreshedAt !== null}
                   scopeLabel={scopeLabel}
                   facultiesHref={facultiesHref}
+                  semesterId={selectedSemesterId ?? ""}
+                  semesterLabel={selectedSemesterLabel}
                 />
               )}
             </div>

--- a/features/faculty-analytics/components/scoped-attention-card.tsx
+++ b/features/faculty-analytics/components/scoped-attention-card.tsx
@@ -7,6 +7,7 @@ import type { AttentionFlagDto, AttentionItemDto } from "@/features/faculty-anal
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { buildScopedFacultyAnalysisHref } from "@/features/faculty-analytics/lib/faculty-analysis-routes";
 import { cn } from "@/lib/utils";
 
 type ScopedAttentionCardProps = {
@@ -15,6 +16,8 @@ type ScopedAttentionCardProps = {
   hasAnalyticsData: boolean;
   scopeLabel: "Campus" | "Department" | "Program";
   facultiesHref: string;
+  semesterId: string;
+  semesterLabel: string;
 };
 
 function getAttentionScopeCopy(scopeLabel: ScopedAttentionCardProps["scopeLabel"]) {
@@ -93,6 +96,8 @@ export function ScopedAttentionCard({
   hasAnalyticsData,
   scopeLabel,
   facultiesHref,
+  semesterId,
+  semesterLabel,
 }: ScopedAttentionCardProps) {
   const topItems = items.slice(0, 5);
 
@@ -122,6 +127,13 @@ export function ScopedAttentionCard({
           <div className="space-y-3">
             {topItems.map((item) => {
               const primaryFlag = getPrimaryFlag(item.flags);
+              const analysisHref = buildScopedFacultyAnalysisHref({
+                facultyId: item.facultyId,
+                facultyName: item.facultyName,
+                semesterId,
+                semesterLabel,
+                scopeLabel,
+              });
 
               return (
                 <div
@@ -144,8 +156,8 @@ export function ScopedAttentionCard({
                         size="sm"
                         className="h-auto px-0 py-0 font-sans text-brand-blue hover:text-brand-blue"
                       >
-                        <Link href={facultiesHref}>
-                          View List
+                        <Link href={analysisHref}>
+                          View Faculty
                           <ArrowRight className="size-4" />
                         </Link>
                       </Button>


### PR DESCRIPTION
Closes #111

## Summary

- Renamed the per-item action button on the scoped **Faculty Requiring Attention** card from `View List` to `View Faculty`.
- The button now navigates to that specific faculty member's analysis screen for the currently selected semester via the existing `buildScopedFacultyAnalysisHref()` helper, instead of routing to the generic faculty list.
- The overflow `View all flagged faculty` footer button (shown when more than 5 items exist) is unchanged and still routes to the list page.

## Changes

- `features/faculty-analytics/components/scoped-attention-card.tsx` — added `semesterId` and `semesterLabel` props, build per-item `analysisHref`, swapped label.
- `features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx` — passes `selectedSemesterId` and `selectedSemesterLabel` through to the card.

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Sign in as Dean → open dashboard → confirm each flagged faculty row shows `View Faculty →` and lands on `/dean/faculties/<facultyId>/analysis?...`
- [ ] Sign in as Chairperson → confirm the same flow lands on `/chairperson/faculties/<facultyId>/analysis?...`
- [ ] When more than 5 flagged items exist, confirm the footer `View all flagged faculty` button still routes to the role's faculty list page