### PR TITLE
FAC-WEB refactor: swap attention and themes card positions for balanced grid

### DIFF
--- a/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
+++ b/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
@@ -61,37 +61,39 @@ const SCOPE_METADATA: Record<
   },
 };
 
-function EmptyInsightsPlaceholder() {
+function EmptyThemesPlaceholder() {
   return (
-    <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-      <Card className="rounded-2xl border-border/70 shadow-sm">
-        <CardHeader>
-          <CardTitle className="font-playfair text-xl">Top Themes</CardTitle>
-          <CardDescription>Ranked by comment volume with sentiment breakdown.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
-            <p className="max-w-sm font-sans text-sm text-muted-foreground">
-              Run analysis to surface the strongest feedback themes for this scope.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl">Top Themes</CardTitle>
+        <CardDescription>Ranked by comment volume with sentiment breakdown.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
+          <p className="max-w-sm font-sans text-sm text-muted-foreground">
+            Run analysis to surface the strongest feedback themes for this scope.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
-      <Card className="rounded-2xl border-border/70 shadow-sm">
-        <CardHeader>
-          <CardTitle className="font-playfair text-xl">Suggested Actions</CardTitle>
-          <CardDescription>Concrete actions informed by the feedback themes above.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
-            <p className="max-w-sm font-sans text-sm text-muted-foreground">
-              Suggested actions will appear here after a completed analysis run.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+function EmptyRecommendationsPlaceholder() {
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl">Suggested Actions</CardTitle>
+        <CardDescription>Concrete actions informed by the feedback themes above.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
+          <p className="max-w-sm font-sans text-sm text-muted-foreground">
+            Suggested actions will appear here after a completed analysis run.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -202,11 +204,19 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
               className={
                 isCampusScope
                   ? "grid gap-6"
-                  : "grid gap-6 min-[900px]:grid-cols-[minmax(0,1.15fr)_minmax(19rem,0.85fr)]"
+                  : "grid gap-6 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"
               }
             >
               <ScopedOverallSentimentBarChart overallSentiment={overallSentiment} />
-              {isCampusScope ? null : (
+              {isCampusScope ? null : showRecommendationPanels ? (
+                <ThemesRankedList themes={themes} />
+              ) : showEmptyInsightsPlaceholder ? (
+                <EmptyThemesPlaceholder />
+              ) : null}
+            </div>
+
+            {isCampusScope ? null : (
+              <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1.15fr)_minmax(19rem,0.85fr)]">
                 <ScopedAttentionCard
                   items={attentionItems}
                   isLoading={isAttentionLoading}
@@ -216,19 +226,13 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
                   semesterId={selectedSemesterId ?? ""}
                   semesterLabel={selectedSemesterLabel}
                 />
-              )}
-            </div>
-
-            {showRecommendationPanels ? (
-              <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-                <ThemesRankedList themes={themes} />
-                {recommendationsQuery.data ? (
+                {showRecommendationPanels && recommendationsQuery.data ? (
                   <RecommendationsCard recommendations={recommendationsQuery.data} />
+                ) : showEmptyInsightsPlaceholder ? (
+                  <EmptyRecommendationsPlaceholder />
                 ) : null}
               </div>
-            ) : null}
-
-            {showEmptyInsightsPlaceholder ? <EmptyInsightsPlaceholder /> : null}
+            )}
           </>
         )}
       </section>


### PR DESCRIPTION
## Summary

- Swaps the grid positions of **Faculty Requiring Attention** and **Top Themes** on the scoped analytics dashboard so the two similarly-tall cards (Faculty Requiring Attention + Suggested Actions) sit on the same row and the two shorter cards (Sentiment + Top Themes) sit on the other.
- Splits `EmptyInsightsPlaceholder` into `EmptyThemesPlaceholder` and `EmptyRecommendationsPlaceholder` so each row renders its own empty state when the pipeline hasn't completed.
- Moves the asymmetric `1.15fr / 0.85fr` column ratio (required by the attention card's `19rem` min-width) from row 1 to row 2. Row 1 now uses a symmetric `1fr / 1fr`.

### Before / After

| | Row 1 | Row 2 |
|---|---|---|
| Before | Sentiment + Faculty Requiring Attention | Top Themes + Suggested Actions |
| After | Sentiment + Top Themes | Faculty Requiring Attention + Suggested Actions |

Campus scope behavior is unchanged (only the Sentiment chart renders).

Closes #114.

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Dean dashboard (Department scope), pre-pipeline: Sentiment + empty Top Themes placeholder in row 1; Faculty Requiring Attention + empty Suggested Actions placeholder in row 2
- [ ] Dean dashboard, post-pipeline complete: full 2×2 grid with the new pairing
- [ ] Chairperson dashboard (Program scope) matches Dean behavior
- [ ] Campus Head dashboard: only Sentiment chart renders; no row 2
- [ ] Viewport below 900px: grids collapse to single column; cards remain readable