### PR TITLE
FAC-WEB refactor: unify sentiment palette and switch neutral to amber  (#118)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,6 +10,15 @@
   --color-brand-neutral: var(--brand-neutral);
   --color-surface: var(--surface);
   --color-surface-alt: var(--surface-alt);
+  --color-sentiment-positive: var(--sentiment-positive);
+  --color-sentiment-positive-soft: var(--sentiment-positive-soft);
+  --color-sentiment-positive-fg: var(--sentiment-positive-fg);
+  --color-sentiment-neutral: var(--sentiment-neutral);
+  --color-sentiment-neutral-soft: var(--sentiment-neutral-soft);
+  --color-sentiment-neutral-fg: var(--sentiment-neutral-fg);
+  --color-sentiment-negative: var(--sentiment-negative);
+  --color-sentiment-negative-soft: var(--sentiment-negative-soft);
+  --color-sentiment-negative-fg: var(--sentiment-negative-fg);
   --font-playfair: var(--font-playfair);
 
   --color-background: var(--background);
@@ -68,6 +77,15 @@
   --brand-neutral: oklch(0.982 0.005 84.15);
   --surface: oklch(0.975 0.002 264.53);
   --surface-alt: oklch(0.96 0.004 264.53);
+  --sentiment-positive: oklch(0.72 0.17 152);
+  --sentiment-positive-soft: oklch(0.96 0.05 152);
+  --sentiment-positive-fg: oklch(0.42 0.14 152);
+  --sentiment-neutral: oklch(0.82 0.16 85);
+  --sentiment-neutral-soft: oklch(0.97 0.06 90);
+  --sentiment-neutral-fg: oklch(0.48 0.13 80);
+  --sentiment-negative: oklch(0.65 0.22 20);
+  --sentiment-negative-soft: oklch(0.96 0.04 20);
+  --sentiment-negative-fg: oklch(0.44 0.18 20);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -107,6 +125,15 @@
   --brand-neutral: oklch(0.2 0.006 264.53);
   --surface: oklch(0.195 0.008 264.53);
   --surface-alt: oklch(0.185 0.01 264.53);
+  --sentiment-positive: oklch(0.72 0.16 152);
+  --sentiment-positive-soft: oklch(0.3 0.06 152);
+  --sentiment-positive-fg: oklch(0.85 0.14 152);
+  --sentiment-neutral: oklch(0.8 0.16 85);
+  --sentiment-neutral-soft: oklch(0.3 0.06 85);
+  --sentiment-neutral-fg: oklch(0.88 0.14 85);
+  --sentiment-negative: oklch(0.7 0.2 22);
+  --sentiment-negative-soft: oklch(0.3 0.06 22);
+  --sentiment-negative-fg: oklch(0.82 0.14 22);
   --background: oklch(0.17 0.006 264.53);
   --foreground: oklch(0.93 0.005 264.53);
   --card: oklch(0.21 0.008 264.53);
@@ -205,6 +232,29 @@
 
   .badge-status-negative {
     @apply border-red-200 bg-red-50 px-2.5 py-1 font-medium text-red-700 dark:border-red-900/70 dark:bg-red-950/20 dark:text-red-300;
+  }
+
+  /* ── Faculytics: Sentiment pill variants ─────────────────────────── */
+
+  .badge-sentiment-positive {
+    border-color: color-mix(in oklab, var(--sentiment-positive) 35%, transparent);
+    background-color: var(--sentiment-positive-soft);
+    color: var(--sentiment-positive-fg);
+    @apply px-2.5 py-1 font-medium;
+  }
+
+  .badge-sentiment-neutral {
+    border-color: color-mix(in oklab, var(--sentiment-neutral) 40%, transparent);
+    background-color: var(--sentiment-neutral-soft);
+    color: var(--sentiment-neutral-fg);
+    @apply px-2.5 py-1 font-medium;
+  }
+
+  .badge-sentiment-negative {
+    border-color: color-mix(in oklab, var(--sentiment-negative) 35%, transparent);
+    background-color: var(--sentiment-negative-soft);
+    color: var(--sentiment-negative-fg);
+    @apply px-2.5 py-1 font-medium;
   }
 
   .badge-interpretation-excellent {

--- a/features/faculty-analytics/components/faculty-analysis-hero.tsx
+++ b/features/faculty-analytics/components/faculty-analysis-hero.tsx
@@ -9,6 +9,10 @@ import {
   formatFacultyReportScore,
   getFacultyReportInterpretationTextClass,
 } from "@/features/faculty-analytics/lib/faculty-report-detail";
+import {
+  SENTIMENT_LABEL,
+  SENTIMENT_SOLID_CLASS,
+} from "@/features/faculty-analytics/lib/sentiment-colors";
 import { cn } from "@/lib/utils";
 import type {
   PipelineStatus,
@@ -32,18 +36,6 @@ type FacultyAnalysisHeroProps = {
   onClearSentiment: () => void;
   onClearTheme: () => void;
   onClearAll: () => void;
-};
-
-const SENTIMENT_SWATCH: Record<SentimentLabel, string> = {
-  positive: "bg-emerald-600",
-  neutral: "bg-muted-foreground/50",
-  negative: "bg-rose-600",
-};
-
-const SENTIMENT_LABEL: Record<SentimentLabel, string> = {
-  positive: "Positive",
-  neutral: "Neutral",
-  negative: "Negative",
 };
 
 const SEGMENT_ORDER: SentimentLabel[] = ["positive", "neutral", "negative"];
@@ -163,7 +155,7 @@ export function FacultyAnalysisHero({
                     onClick={() => onSentimentClick(isActive ? null : sentiment)}
                     className={cn(
                       "h-full transition-all hover:brightness-110",
-                      SENTIMENT_SWATCH[sentiment],
+                      SENTIMENT_SOLID_CLASS[sentiment],
                       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
                       isActive ? "brightness-110 ring-2 ring-ring ring-offset-1" : "",
                       sentimentFilter && !isActive ? "opacity-40" : ""
@@ -186,7 +178,7 @@ export function FacultyAnalysisHero({
                       <span
                         className={cn(
                           "inline-block h-2 w-2 rounded-full",
-                          SENTIMENT_SWATCH[sentiment]
+                          SENTIMENT_SOLID_CLASS[sentiment]
                         )}
                       />
                       <span>{SENTIMENT_LABEL[sentiment]}</span>
@@ -233,7 +225,7 @@ export function FacultyAnalysisHero({
               <span
                 className={cn(
                   "inline-block h-1.5 w-1.5 rounded-full",
-                  SENTIMENT_SWATCH[sentimentFilter]
+                  SENTIMENT_SOLID_CLASS[sentimentFilter]
                 )}
               />
               <span>Sentiment · {SENTIMENT_LABEL[sentimentFilter]}</span>

--- a/features/faculty-analytics/components/faculty-analysis-sentiment-strip.tsx
+++ b/features/faculty-analytics/components/faculty-analysis-sentiment-strip.tsx
@@ -4,6 +4,10 @@ import { X } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  SENTIMENT_LABEL,
+  SENTIMENT_SOLID_CLASS,
+} from "@/features/faculty-analytics/lib/sentiment-colors";
 import { cn } from "@/lib/utils";
 import type { SentimentDistributionDto, SentimentLabel } from "@/features/faculty-analytics/types";
 
@@ -15,18 +19,6 @@ type FacultyAnalysisSentimentStripProps = {
   onClearSentiment: () => void;
   onClearTheme: () => void;
   onClearAll: () => void;
-};
-
-const SWATCH: Record<SentimentLabel, string> = {
-  positive: "bg-emerald-600",
-  neutral: "bg-muted-foreground/50",
-  negative: "bg-rose-600",
-};
-
-const LABEL: Record<SentimentLabel, string> = {
-  positive: "Positive",
-  neutral: "Neutral",
-  negative: "Negative",
 };
 
 const ORDER: SentimentLabel[] = ["positive", "neutral", "negative"];
@@ -72,13 +64,13 @@ export function FacultyAnalysisSentimentStrip({
                   onClick={() => onSentimentClick(isActive ? null : s)}
                   className={cn(
                     "h-full transition-all hover:brightness-110",
-                    SWATCH[s],
+                    SENTIMENT_SOLID_CLASS[s],
                     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
                     isActive ? "brightness-110 ring-2 ring-ring ring-offset-1" : "",
                     sentimentFilter && !isActive ? "opacity-40" : ""
                   )}
                   style={{ width: `${widthPct}%` }}
-                  aria-label={`Filter comments to ${LABEL[s].toLowerCase()} sentiment, ${count} submissions`}
+                  aria-label={`Filter comments to ${SENTIMENT_LABEL[s].toLowerCase()} sentiment, ${count} submissions`}
                   aria-pressed={isActive}
                 />
               );
@@ -91,8 +83,10 @@ export function FacultyAnalysisSentimentStrip({
               const pct = Math.round((count / total) * 100);
               return (
                 <div key={s} className="flex items-center gap-1.5">
-                  <span className={cn("inline-block h-2 w-2 rounded-full", SWATCH[s])} />
-                  <span>{LABEL[s]}</span>
+                  <span
+                    className={cn("inline-block h-2 w-2 rounded-full", SENTIMENT_SOLID_CLASS[s])}
+                  />
+                  <span>{SENTIMENT_LABEL[s]}</span>
                   <span className="tabular-nums text-foreground">{count}</span>
                   <span className="tabular-nums text-muted-foreground/70">({pct}%)</span>
                 </div>
@@ -127,14 +121,17 @@ export function FacultyAnalysisSentimentStrip({
               className="gap-1 rounded-full border-border bg-background px-3 py-1 text-xs"
             >
               <span
-                className={cn("inline-block h-1.5 w-1.5 rounded-full", SWATCH[sentimentFilter])}
+                className={cn(
+                  "inline-block h-1.5 w-1.5 rounded-full",
+                  SENTIMENT_SOLID_CLASS[sentimentFilter]
+                )}
               />
-              <span>Sentiment · {LABEL[sentimentFilter]}</span>
+              <span>Sentiment · {SENTIMENT_LABEL[sentimentFilter]}</span>
               <button
                 type="button"
                 onClick={onClearSentiment}
                 className="ml-1 rounded-full p-0.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                aria-label={`Clear sentiment filter ${LABEL[sentimentFilter]}`}
+                aria-label={`Clear sentiment filter ${SENTIMENT_LABEL[sentimentFilter]}`}
               >
                 <X className="h-3 w-3" />
               </button>

--- a/features/faculty-analytics/components/faculty-report-comments.tsx
+++ b/features/faculty-analytics/components/faculty-report-comments.tsx
@@ -7,12 +7,15 @@ import { PaginationFooter } from "@/components/shared/pagination-footer";
 import { ScopedAnalyticsEmptyState } from "@/features/faculty-analytics/components/scoped-analytics-empty-state";
 import { ScopedAnalyticsErrorState } from "@/features/faculty-analytics/components/scoped-analytics-error-state";
 import { ScopedAnalyticsLoadingState } from "@/features/faculty-analytics/components/scoped-analytics-loading-state";
+import {
+  SENTIMENT_BADGE_CLASS,
+  SENTIMENT_LABEL,
+} from "@/features/faculty-analytics/lib/sentiment-colors";
 import { cn } from "@/lib/utils";
 import type {
   FacultyReportCommentDto,
   PaginationMetaDto,
   QualitativeThemeDto,
-  SentimentLabel,
 } from "@/features/faculty-analytics/types";
 import { formatDateTime } from "@/lib/date";
 
@@ -27,18 +30,6 @@ type FacultyReportCommentsProps = {
   onPageChange: (page: number) => void;
   onRowsPerPageChange: (value: number) => void;
   themes?: QualitativeThemeDto[];
-};
-
-const SENTIMENT_CLASSES: Record<SentimentLabel, string> = {
-  positive: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
-  neutral: "bg-muted text-muted-foreground",
-  negative: "bg-rose-100 text-rose-800 dark:bg-rose-950/40 dark:text-rose-300",
-};
-
-const SENTIMENT_LABELS: Record<SentimentLabel, string> = {
-  positive: "Positive",
-  neutral: "Neutral",
-  negative: "Negative",
 };
 
 export function FacultyReportComments({
@@ -113,11 +104,11 @@ export function FacultyReportComments({
                         <Badge
                           variant="outline"
                           className={cn(
-                            "rounded-full border-none px-2 py-0.5 font-sans text-[0.7rem] font-medium",
-                            SENTIMENT_CLASSES[comment.sentiment]
+                            "rounded-full px-2 py-0.5 font-sans text-[0.7rem]",
+                            SENTIMENT_BADGE_CLASS[comment.sentiment]
                           )}
                         >
-                          {SENTIMENT_LABELS[comment.sentiment]}
+                          {SENTIMENT_LABEL[comment.sentiment]}
                         </Badge>
                       ) : null}
                       {visibleThemes.map((label) => (

--- a/features/faculty-analytics/components/feedback-filter-bar.tsx
+++ b/features/faculty-analytics/components/feedback-filter-bar.tsx
@@ -10,6 +10,10 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  SENTIMENT_FILTER_CHIP_CLASS,
+  SENTIMENT_LABEL,
+} from "@/features/faculty-analytics/lib/sentiment-colors";
 import { cn } from "@/lib/utils";
 import type { QualitativeThemeDto, SentimentLabel } from "@/features/faculty-analytics/types";
 
@@ -23,26 +27,7 @@ type FeedbackFilterBarProps = {
   disabledReason?: string;
 };
 
-const SENTIMENT_OPTIONS: { value: SentimentLabel; label: string; chipClass: string }[] = [
-  {
-    value: "positive",
-    label: "Positive",
-    chipClass:
-      "data-[active=true]:bg-emerald-100 data-[active=true]:text-emerald-800 data-[active=true]:border-emerald-300",
-  },
-  {
-    value: "neutral",
-    label: "Neutral",
-    chipClass:
-      "data-[active=true]:bg-muted data-[active=true]:text-foreground data-[active=true]:border-border",
-  },
-  {
-    value: "negative",
-    label: "Negative",
-    chipClass:
-      "data-[active=true]:bg-rose-100 data-[active=true]:text-rose-800 data-[active=true]:border-rose-300",
-  },
-];
+const SENTIMENT_OPTIONS: SentimentLabel[] = ["positive", "neutral", "negative"];
 
 export function FeedbackFilterBar({
   themes,
@@ -83,22 +68,22 @@ export function FeedbackFilterBar({
         <span className="font-sans text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
           Sentiment
         </span>
-        {SENTIMENT_OPTIONS.map((option) => {
-          const isActive = sentimentFilter === option.value;
+        {SENTIMENT_OPTIONS.map((value) => {
+          const isActive = sentimentFilter === value;
           return (
             <button
-              key={option.value}
+              key={value}
               type="button"
               data-active={isActive}
               disabled={disabled}
-              onClick={() => handleSentimentClick(option.value)}
+              onClick={() => handleSentimentClick(value)}
               className={cn(
                 "rounded-full border border-border bg-background px-3 py-1 font-sans text-xs transition-colors",
                 "hover:bg-muted disabled:cursor-not-allowed disabled:hover:bg-background",
-                option.chipClass
+                SENTIMENT_FILTER_CHIP_CLASS[value]
               )}
             >
-              {option.label}
+              {SENTIMENT_LABEL[value]}
             </button>
           );
         })}

--- a/features/faculty-analytics/components/headline-metrics-strip.tsx
+++ b/features/faculty-analytics/components/headline-metrics-strip.tsx
@@ -2,6 +2,7 @@
 
 import { AnimatedNumber } from "@/components/animated-number";
 import { getFacultyReportInterpretationTextClass } from "@/features/faculty-analytics/lib/faculty-report-detail";
+import { SENTIMENT_SOLID_CLASS } from "@/features/faculty-analytics/lib/sentiment-colors";
 import { cn } from "@/lib/utils";
 import type { SentimentDistributionDto } from "@/features/faculty-analytics/types";
 
@@ -24,9 +25,18 @@ function SentimentMiniBar({ distribution }: { distribution: SentimentDistributio
       aria-label={`${distribution.positive} positive, ${distribution.neutral} neutral, ${distribution.negative} negative`}
       className="flex h-2 w-full max-w-xs overflow-hidden rounded-full bg-muted"
     >
-      <span className="block bg-emerald-400" style={{ width: pct(distribution.positive) }} />
-      <span className="block bg-amber-300" style={{ width: pct(distribution.neutral) }} />
-      <span className="block bg-rose-400" style={{ width: pct(distribution.negative) }} />
+      <span
+        className={cn("block", SENTIMENT_SOLID_CLASS.positive)}
+        style={{ width: pct(distribution.positive) }}
+      />
+      <span
+        className={cn("block", SENTIMENT_SOLID_CLASS.neutral)}
+        style={{ width: pct(distribution.neutral) }}
+      />
+      <span
+        className={cn("block", SENTIMENT_SOLID_CLASS.negative)}
+        style={{ width: pct(distribution.negative) }}
+      />
     </div>
   );
 }

--- a/features/faculty-analytics/components/scoped-charts.tsx
+++ b/features/faculty-analytics/components/scoped-charts.tsx
@@ -10,20 +10,21 @@ import {
   type ChartConfig,
 } from "@/components/ui/chart";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { SENTIMENT_HEX } from "@/features/faculty-analytics/lib/sentiment-colors";
 import { useIsMobile } from "@/lib/use-mobile";
 
 const overallSentimentChartConfig = {
   positive: {
     label: "Positive",
-    color: "#5b8cff",
+    color: SENTIMENT_HEX.positive,
   },
   neutral: {
     label: "Neutral",
-    color: "#d1d5db",
+    color: SENTIMENT_HEX.neutral,
   },
   negative: {
     label: "Negative",
-    color: "#facc15",
+    color: SENTIMENT_HEX.negative,
   },
 } satisfies ChartConfig;
 

--- a/features/faculty-analytics/components/sentiment-stacked-bar.tsx
+++ b/features/faculty-analytics/components/sentiment-stacked-bar.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  SENTIMENT_LABEL,
+  SENTIMENT_RING_ACTIVE_CLASS,
+  SENTIMENT_RING_HOVER_CLASS,
+  SENTIMENT_SOLID_CLASS,
+} from "@/features/faculty-analytics/lib/sentiment-colors";
 import { cn } from "@/lib/utils";
 import type { SentimentDistributionDto, SentimentLabel } from "@/features/faculty-analytics/types";
 
@@ -8,30 +14,6 @@ type SentimentStackedBarProps = {
   distribution: SentimentDistributionDto;
   activeSentiment: SentimentLabel | null;
   onSegmentClick: (sentiment: SentimentLabel | null) => void;
-};
-
-const SEGMENT_STYLES: Record<
-  SentimentLabel,
-  { fill: string; ringActive: string; ringInactive: string; label: string }
-> = {
-  positive: {
-    fill: "bg-emerald-500",
-    ringActive: "ring-2 ring-emerald-600 ring-offset-1",
-    ringInactive: "hover:ring-2 hover:ring-emerald-400/60",
-    label: "Positive",
-  },
-  neutral: {
-    fill: "bg-muted-foreground/40",
-    ringActive: "ring-2 ring-muted-foreground ring-offset-1",
-    ringInactive: "hover:ring-2 hover:ring-muted-foreground/60",
-    label: "Neutral",
-  },
-  negative: {
-    fill: "bg-rose-500",
-    ringActive: "ring-2 ring-rose-600 ring-offset-1",
-    ringInactive: "hover:ring-2 hover:ring-rose-400/60",
-    label: "Negative",
-  },
 };
 
 const SEGMENT_ORDER: SentimentLabel[] = ["positive", "neutral", "negative"];
@@ -68,7 +50,6 @@ export function SentimentStackedBar({
               const count = distribution[sentiment];
               if (count === 0) return null;
               const widthPct = (count / total) * 100;
-              const style = SEGMENT_STYLES[sentiment];
               const isActive = activeSentiment === sentiment;
 
               return (
@@ -78,13 +59,15 @@ export function SentimentStackedBar({
                   onClick={() => onSegmentClick(isActive ? null : sentiment)}
                   className={cn(
                     "h-full transition-all",
-                    style.fill,
-                    isActive ? style.ringActive : style.ringInactive,
+                    SENTIMENT_SOLID_CLASS[sentiment],
+                    isActive
+                      ? SENTIMENT_RING_ACTIVE_CLASS[sentiment]
+                      : SENTIMENT_RING_HOVER_CLASS[sentiment],
                     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
                     "cursor-pointer"
                   )}
                   style={{ width: `${widthPct}%` }}
-                  aria-label={`Filter comments to ${style.label.toLowerCase()} sentiment, ${count} submissions`}
+                  aria-label={`Filter comments to ${SENTIMENT_LABEL[sentiment].toLowerCase()} sentiment, ${count} submissions`}
                   aria-pressed={isActive}
                 />
               );
@@ -93,16 +76,18 @@ export function SentimentStackedBar({
         )}
 
         <dl className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-1 font-sans text-xs tabular-nums text-muted-foreground">
-          {SEGMENT_ORDER.map((sentiment) => {
-            const style = SEGMENT_STYLES[sentiment];
-            return (
-              <div key={sentiment} className="flex items-center gap-2">
-                <span className={cn("inline-block h-2.5 w-2.5 rounded-full", style.fill)} />
-                <dt className="font-medium text-foreground">{style.label}</dt>
-                <dd>{distribution[sentiment]}</dd>
-              </div>
-            );
-          })}
+          {SEGMENT_ORDER.map((sentiment) => (
+            <div key={sentiment} className="flex items-center gap-2">
+              <span
+                className={cn(
+                  "inline-block h-2.5 w-2.5 rounded-full",
+                  SENTIMENT_SOLID_CLASS[sentiment]
+                )}
+              />
+              <dt className="font-medium text-foreground">{SENTIMENT_LABEL[sentiment]}</dt>
+              <dd>{distribution[sentiment]}</dd>
+            </div>
+          ))}
         </dl>
       </CardContent>
     </Card>

--- a/features/faculty-analytics/components/theme-explorer-card.tsx
+++ b/features/faculty-analytics/components/theme-explorer-card.tsx
@@ -8,6 +8,11 @@ import { PaginationFooter } from "@/components/shared/pagination-footer";
 import { ScopedAnalyticsErrorState } from "@/features/faculty-analytics/components/scoped-analytics-error-state";
 import { ScopedAnalyticsLoadingState } from "@/features/faculty-analytics/components/scoped-analytics-loading-state";
 import { useFacultyReportComments } from "@/features/faculty-analytics/hooks/use-faculty-report-comments";
+import {
+  SENTIMENT_BADGE_CLASS,
+  SENTIMENT_LABEL,
+  SENTIMENT_SOLID_CLASS,
+} from "@/features/faculty-analytics/lib/sentiment-colors";
 import { themeRowAnchorId } from "@/features/faculty-analytics/lib/theme-anchor";
 import { cn } from "@/lib/utils";
 import { formatDateTime } from "@/lib/date";
@@ -29,32 +34,6 @@ type ThemeExplorerCardProps = {
   sentimentFilter: SentimentLabel | null;
   matchingAction: RecommendedActionDto | null;
   redactComments?: boolean;
-};
-
-const DOMINANT_ACCENT: Record<SentimentLabel, string> = {
-  negative: "bg-rose-600",
-  neutral: "bg-muted-foreground/50",
-  positive: "bg-emerald-600",
-};
-
-const SEGMENT_COLOR: Record<SentimentLabel, string> = {
-  negative: "bg-rose-600",
-  neutral: "bg-muted-foreground/50",
-  positive: "bg-emerald-600",
-};
-
-const SENTIMENT_LABEL: Record<SentimentLabel, string> = {
-  positive: "Positive",
-  neutral: "Neutral",
-  negative: "Negative",
-};
-
-const SENTIMENT_COMMENT_BADGE: Record<SentimentLabel, string> = {
-  positive:
-    "border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-300",
-  neutral: "border-border bg-muted text-muted-foreground",
-  negative:
-    "border-rose-200 bg-rose-50 text-rose-900 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-300",
 };
 
 const PRIORITY_VARIANT: Record<
@@ -146,7 +125,7 @@ export function ThemeExplorerCard({
       {/* dominant-sentiment accent rail */}
       <div
         aria-hidden
-        className={cn("absolute left-0 top-0 h-full w-1", DOMINANT_ACCENT[dominant])}
+        className={cn("absolute left-0 top-0 h-full w-1", SENTIMENT_SOLID_CLASS[dominant])}
       />
 
       <button
@@ -179,7 +158,7 @@ export function ThemeExplorerCard({
                 s.count === 0 ? null : (
                   <span
                     key={s.key}
-                    className={cn("h-full", SEGMENT_COLOR[s.key])}
+                    className={cn("h-full", SENTIMENT_SOLID_CLASS[s.key])}
                     style={{ width: `${s.widthPct}%` }}
                     aria-label={`${SENTIMENT_LABEL[s.key]}: ${s.count}`}
                   />
@@ -188,15 +167,15 @@ export function ThemeExplorerCard({
             </div>
             <div className="flex gap-3 text-xs tabular-nums text-muted-foreground">
               <span className="flex items-center gap-1">
-                <span className={cn("h-1.5 w-1.5 rounded-full", SEGMENT_COLOR.negative)} />
+                <span className={cn("h-1.5 w-1.5 rounded-full", SENTIMENT_SOLID_CLASS.negative)} />
                 {theme.sentimentSplit.negative}
               </span>
               <span className="flex items-center gap-1">
-                <span className={cn("h-1.5 w-1.5 rounded-full", SEGMENT_COLOR.neutral)} />
+                <span className={cn("h-1.5 w-1.5 rounded-full", SENTIMENT_SOLID_CLASS.neutral)} />
                 {theme.sentimentSplit.neutral}
               </span>
               <span className="flex items-center gap-1">
-                <span className={cn("h-1.5 w-1.5 rounded-full", SEGMENT_COLOR.positive)} />
+                <span className={cn("h-1.5 w-1.5 rounded-full", SENTIMENT_SOLID_CLASS.positive)} />
                 {theme.sentimentSplit.positive}
               </span>
             </div>
@@ -304,7 +283,7 @@ export function ThemeExplorerCard({
                                         variant="outline"
                                         className={cn(
                                           "rounded-full px-2 py-0.5 text-[0.65rem] uppercase tracking-wider",
-                                          SENTIMENT_COMMENT_BADGE[c.sentiment]
+                                          SENTIMENT_BADGE_CLASS[c.sentiment]
                                         )}
                                       >
                                         {SENTIMENT_LABEL[c.sentiment]}
@@ -402,7 +381,7 @@ export function ThemeExplorerCard({
                                 <span
                                   className={cn(
                                     "inline-block h-2 w-2 rounded-full",
-                                    SEGMENT_COLOR[s]
+                                    SENTIMENT_SOLID_CLASS[s]
                                   )}
                                 />
                                 {SENTIMENT_LABEL[s]}
@@ -414,7 +393,7 @@ export function ThemeExplorerCard({
                             </div>
                             <div className="h-1 overflow-hidden rounded-full bg-muted">
                               <span
-                                className={cn("block h-full", SEGMENT_COLOR[s])}
+                                className={cn("block h-full", SENTIMENT_SOLID_CLASS[s])}
                                 style={{ width: `${pct}%` }}
                               />
                             </div>

--- a/features/faculty-analytics/components/theme-sentiment-matrix.tsx
+++ b/features/faculty-analytics/components/theme-sentiment-matrix.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { SENTIMENT_SOLID_CLASS } from "@/features/faculty-analytics/lib/sentiment-colors";
 import { cn } from "@/lib/utils";
 import { themeRowAnchorId } from "@/features/faculty-analytics/lib/theme-anchor";
 import type { QualitativeThemeDto, SentimentLabel } from "@/features/faculty-analytics/types";
@@ -11,12 +12,6 @@ type ThemeSentimentMatrixProps = {
   activeThemeLabel: string | null;
   onCellClick: (themeLabel: string, sentiment: SentimentLabel | null) => void;
   onRowLabelClick?: (themeLabel: string) => void;
-};
-
-const SENTIMENT_COLORS: Record<SentimentLabel, string> = {
-  negative: "bg-rose-500",
-  neutral: "bg-muted-foreground/40",
-  positive: "bg-emerald-500",
 };
 
 const CELL_HEADERS: { key: SentimentLabel; label: string }[] = [
@@ -138,7 +133,7 @@ export function ThemeSentimentMatrix({
                             aria-hidden="true"
                             className={cn(
                               "h-1.5 w-full rounded-full",
-                              count > 0 ? SENTIMENT_COLORS[key] : "bg-muted"
+                              count > 0 ? SENTIMENT_SOLID_CLASS[key] : "bg-muted"
                             )}
                             style={{ width: count > 0 ? `${Math.max(10, width)}%` : "100%" }}
                           />

--- a/features/faculty-analytics/components/themes-ranked-list.tsx
+++ b/features/faculty-analytics/components/themes-ranked-list.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { SENTIMENT_SOLID_CLASS } from "@/features/faculty-analytics/lib/sentiment-colors";
+import { cn } from "@/lib/utils";
 import type { QualitativeThemeDto } from "@/features/faculty-analytics/types";
 
 type ThemesRankedListProps = {
@@ -38,17 +40,17 @@ export function ThemesRankedList({ themes, maxVisible = 10 }: ThemesRankedListPr
                 </div>
                 <div className="flex h-2 overflow-hidden rounded-full bg-muted">
                   <span
-                    className="h-full bg-emerald-500"
+                    className={cn("h-full", SENTIMENT_SOLID_CLASS.positive)}
                     style={{ width: `${pos}%` }}
                     aria-label={`positive ${pos.toFixed(0)}%`}
                   />
                   <span
-                    className="h-full bg-muted-foreground/40"
+                    className={cn("h-full", SENTIMENT_SOLID_CLASS.neutral)}
                     style={{ width: `${neu}%` }}
                     aria-label={`neutral ${neu.toFixed(0)}%`}
                   />
                   <span
-                    className="h-full bg-rose-500"
+                    className={cn("h-full", SENTIMENT_SOLID_CLASS.negative)}
                     style={{ width: `${neg}%` }}
                     aria-label={`negative ${neg.toFixed(0)}%`}
                   />

--- a/features/faculty-analytics/lib/scoped-analytics-view-model.ts
+++ b/features/faculty-analytics/lib/scoped-analytics-view-model.ts
@@ -1,4 +1,5 @@
 import { ALL_PROGRAMS_LABEL } from "@/features/faculty-analytics/constants/filters";
+import { SENTIMENT_HEX } from "@/features/faculty-analytics/lib/sentiment-colors";
 import type {
   DepartmentOptionDto,
   DepartmentOverviewResponseDto,
@@ -131,17 +132,17 @@ export function mapDepartmentOverviewToDashboardViewModel({
       {
         label: "Positive",
         value: toSentimentRate(overview.summary.positiveCount, totalSentiment),
-        color: "#5b8cff",
+        color: SENTIMENT_HEX.positive,
       },
       {
         label: "Neutral",
         value: toSentimentRate(overview.summary.neutralCount, totalSentiment),
-        color: "#d1d5db",
+        color: SENTIMENT_HEX.neutral,
       },
       {
         label: "Negative",
         value: toSentimentRate(overview.summary.negativeCount, totalSentiment),
-        color: "#facc15",
+        color: SENTIMENT_HEX.negative,
       },
     ],
   };

--- a/features/faculty-analytics/lib/sentiment-colors.ts
+++ b/features/faculty-analytics/lib/sentiment-colors.ts
@@ -1,0 +1,46 @@
+import type { SentimentLabel } from "@/features/faculty-analytics/types";
+
+export const SENTIMENT_SOLID_CLASS: Record<SentimentLabel, string> = {
+  positive: "bg-sentiment-positive",
+  neutral: "bg-sentiment-neutral",
+  negative: "bg-sentiment-negative",
+};
+
+export const SENTIMENT_RING_ACTIVE_CLASS: Record<SentimentLabel, string> = {
+  positive: "ring-2 ring-sentiment-positive ring-offset-1",
+  neutral: "ring-2 ring-sentiment-neutral ring-offset-1",
+  negative: "ring-2 ring-sentiment-negative ring-offset-1",
+};
+
+export const SENTIMENT_RING_HOVER_CLASS: Record<SentimentLabel, string> = {
+  positive: "hover:ring-2 hover:ring-sentiment-positive/60",
+  neutral: "hover:ring-2 hover:ring-sentiment-neutral/60",
+  negative: "hover:ring-2 hover:ring-sentiment-negative/60",
+};
+
+export const SENTIMENT_BADGE_CLASS: Record<SentimentLabel, string> = {
+  positive: "badge-sentiment-positive",
+  neutral: "badge-sentiment-neutral",
+  negative: "badge-sentiment-negative",
+};
+
+export const SENTIMENT_FILTER_CHIP_CLASS: Record<SentimentLabel, string> = {
+  positive:
+    "data-[active=true]:bg-sentiment-positive-soft data-[active=true]:text-sentiment-positive-fg data-[active=true]:border-sentiment-positive/40",
+  neutral:
+    "data-[active=true]:bg-sentiment-neutral-soft data-[active=true]:text-sentiment-neutral-fg data-[active=true]:border-sentiment-neutral/40",
+  negative:
+    "data-[active=true]:bg-sentiment-negative-soft data-[active=true]:text-sentiment-negative-fg data-[active=true]:border-sentiment-negative/40",
+};
+
+export const SENTIMENT_HEX: Record<SentimentLabel, string> = {
+  positive: "#10b981",
+  neutral: "#f59e0b",
+  negative: "#f43f5e",
+};
+
+export const SENTIMENT_LABEL: Record<SentimentLabel, string> = {
+  positive: "Positive",
+  neutral: "Neutral",
+  negative: "Negative",
+};


### PR DESCRIPTION
Centralizes positive/neutral/negative colors behind CSS variables in globals.css and a new sentiment-colors.ts constants module, replacing 10+ inconsistent inline shades across analytics components. Neutral now reads as amber instead of gray, and the Dean overall-sentiment chart aligns with the green/amber/red convention used elsewhere.