### PR TITLE
FAC-WEB fix: improve attention flag badge contrast in light mode

### DIFF
--- a/features/faculty-analytics/components/scoped-attention-card.tsx
+++ b/features/faculty-analytics/components/scoped-attention-card.tsx
@@ -43,17 +43,17 @@ const FLAG_STYLES: Record<
   declining_trend: {
     label: "Declining Trend",
     icon: TrendingDown,
-    className: "border-amber-500/30 bg-amber-500/10 text-amber-200",
+    className: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200",
   },
   quant_qual_gap: {
     label: "Quant-Qual Gap",
     icon: Waves,
-    className: "border-sky-500/30 bg-sky-500/10 text-sky-200",
+    className: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200",
   },
   low_coverage: {
     label: "Low Coverage",
     icon: AlertTriangle,
-    className: "border-rose-500/30 bg-rose-500/10 text-rose-200",
+    className: "border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-200",
   },
 };
 


### PR DESCRIPTION
Closes #120.

## Summary

- Updates the three attention-flag badges in `FLAG_STYLES` on the scoped **Faculty Requiring Attention** card so their foreground text uses a dark shade (`text-{color}-700`) in light mode and retains the original light shade (`text-{color}-200`) under the `dark:` prefix.
- Fixes the unreadable **Quant-Qual Gap** badge and applies the same treatment to **Declining Trend** and **Low Coverage** for consistency.
- Background/border tints (`bg-{color}-500/10`, `border-{color}-500/30`) are unchanged — they already read well in both themes.

## Files touched

- `features/faculty-analytics/components/scoped-attention-card.tsx`

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Sign in as a Dean (or Chairperson), open the scoped analytics dashboard, confirm the Faculty Requiring Attention card renders flagged faculty
- [ ] Light mode: `Quant-Qual Gap` / `Declining Trend` / `Low Coverage` labels are clearly readable on their tinted fill
- [ ] Dark mode: badges look identical to the prior design (light text on tinted fill)
