### PR TITLE
FAC-WEB refactor: align positive sentiment with brand blue palette (#…

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -77,9 +77,9 @@
   --brand-neutral: oklch(0.982 0.005 84.15);
   --surface: oklch(0.975 0.002 264.53);
   --surface-alt: oklch(0.96 0.004 264.53);
-  --sentiment-positive: oklch(0.72 0.17 152);
-  --sentiment-positive-soft: oklch(0.96 0.05 152);
-  --sentiment-positive-fg: oklch(0.42 0.14 152);
+  --sentiment-positive: oklch(0.428 0.25 264.53);
+  --sentiment-positive-soft: oklch(0.96 0.05 264.53);
+  --sentiment-positive-fg: oklch(0.42 0.18 264.53);
   --sentiment-neutral: oklch(0.82 0.16 85);
   --sentiment-neutral-soft: oklch(0.97 0.06 90);
   --sentiment-neutral-fg: oklch(0.48 0.13 80);
@@ -125,9 +125,9 @@
   --brand-neutral: oklch(0.2 0.006 264.53);
   --surface: oklch(0.195 0.008 264.53);
   --surface-alt: oklch(0.185 0.01 264.53);
-  --sentiment-positive: oklch(0.72 0.16 152);
-  --sentiment-positive-soft: oklch(0.3 0.06 152);
-  --sentiment-positive-fg: oklch(0.85 0.14 152);
+  --sentiment-positive: oklch(0.68 0.21 264.53);
+  --sentiment-positive-soft: oklch(0.3 0.08 264.53);
+  --sentiment-positive-fg: oklch(0.85 0.14 264.53);
   --sentiment-neutral: oklch(0.8 0.16 85);
   --sentiment-neutral-soft: oklch(0.3 0.06 85);
   --sentiment-neutral-fg: oklch(0.88 0.14 85);

--- a/features/faculty-analytics/lib/sentiment-colors.ts
+++ b/features/faculty-analytics/lib/sentiment-colors.ts
@@ -34,7 +34,7 @@ export const SENTIMENT_FILTER_CHIP_CLASS: Record<SentimentLabel, string> = {
 };
 
 export const SENTIMENT_HEX: Record<SentimentLabel, string> = {
-  positive: "#10b981",
+  positive: "#2f48d4",
   neutral: "#f59e0b",
   negative: "#f43f5e",
 };


### PR DESCRIPTION
…124)

Follow-up to #117: swap the positive sentiment tokens (--sentiment-positive, --sentiment-positive-soft, --sentiment-positive-fg in both light and dark) from green (hue 152) to the app's primary brand-blue (hue 264.53) and update SENTIMENT_HEX.positive for Recharts accordingly.

https://claude.ai/code/session_01LbWKAHngpZQbCVcKSYoBzw