### PR TITLE
[FAC-WEB feat] Improve logout UX: visible button when sidebar collapsed + confirmation dialog

### DIFF
--- a/components/layout/nav-user.tsx
+++ b/components/layout/nav-user.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { LogOut } from "lucide-react";
 import { useRouter } from "next/navigation";
 
@@ -7,6 +8,8 @@ import { Button } from "@/components/ui/button";
 import { useLogout, useMe } from "@/features/auth";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { SidebarMenu, SidebarMenuItem } from "@/components/ui/sidebar";
+import { ConfirmationDialog } from "@/components/shared/confirmation-dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export function NavUser() {
   const router = useRouter();
@@ -23,7 +26,11 @@ export function NavUser() {
     .slice(0, 2)
     .toUpperCase();
 
-  const handleLogout = async () => {
+  const [showLogoutDialog, setShowLogoutDialog] = useState(false);
+
+  const handleLogout = () => setShowLogoutDialog(true);
+
+  const confirmLogout = async () => {
     try {
       await logoutMutation.mutateAsync();
     } catch {
@@ -32,29 +39,59 @@ export function NavUser() {
   };
 
   return (
-    <SidebarMenu>
-      <SidebarMenuItem>
-        <div className="flex w-full items-center gap-2 overflow-hidden rounded-md p-2 group-data-[collapsible=icon]:size-10 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-1">
-          <Avatar className="h-8 w-8 rounded-lg group-data-[collapsible=icon]:-translate-x-1">
-            {userAvatar ? <AvatarImage src={userAvatar} alt={userName} /> : null}
-            <AvatarFallback className="rounded-lg">{userInitials || "U"}</AvatarFallback>
-          </Avatar>
-          <div className="grid min-w-0 flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
-            <span className="truncate font-medium">{userName}</span>
-            <span className="truncate text-xs">{userEmail}</span>
+    <>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <div className="flex w-full items-center gap-2 overflow-hidden rounded-md p-2 group-data-[collapsible=icon]:hidden">
+            <Avatar className="h-8 w-8 rounded-lg">
+              {userAvatar ? <AvatarImage src={userAvatar} alt={userName} /> : null}
+              <AvatarFallback className="rounded-lg">{userInitials || "U"}</AvatarFallback>
+            </Avatar>
+            <div className="grid min-w-0 flex-1 text-left text-sm leading-tight">
+              <span className="truncate font-medium">{userName}</span>
+              <span className="truncate text-xs">{userEmail}</span>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleLogout}
+              className="cursor-pointer shrink-0"
+              aria-label="Log out"
+            >
+              <LogOut className="size-4" />
+              <span className="sr-only">Log out</span>
+            </Button>
           </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleLogout}
-            className="cursor-pointer shrink-0 group-data-[collapsible=icon]:hidden"
-            aria-label="Log out"
-          >
-            <LogOut className="size-4" />
-            <span className="sr-only">Log out</span>
-          </Button>
-        </div>
-      </SidebarMenuItem>
-    </SidebarMenu>
+          <div className="hidden group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:size-10 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:justify-center">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleLogout}
+                  className="cursor-pointer"
+                  aria-label="Log out"
+                >
+                  <LogOut className="size-4" />
+                  <span className="sr-only">Log out</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="right">Log out</TooltipContent>
+            </Tooltip>
+          </div>
+        </SidebarMenuItem>
+      </SidebarMenu>
+      <ConfirmationDialog
+        open={showLogoutDialog}
+        onOpenChange={setShowLogoutDialog}
+        title="Log out?"
+        description="Are you sure you want to log out?"
+        cancelLabel="Cancel"
+        confirmLabel="Log out"
+        confirmVariant="destructive"
+        onConfirm={confirmLogout}
+        isPending={logoutMutation.isPending}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Logout icon now visible in icon-only (collapsed) sidebar mode via a tooltip-wrapped button
- Clicking logout in either mode opens a destructive confirmation dialog before executing the mutation
- Removes the `-translate-x-1` avatar hack that compensated for the hidden button

## Changes

- `components/layout/nav-user.tsx` — split the single container into two sibling divs (one per sidebar state), added `ConfirmationDialog` and `Tooltip` usage

## Related Issue

Closes #133