### PR TITLE
FAC-WEB feat: surface faculty name in sticky questionnaire progress h…

### DIFF
--- a/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-form.tsx
+++ b/app/(dashboard)/student/courses/[courseId]/evaluation/_components/evaluation-form.tsx
@@ -164,6 +164,7 @@ export function EvaluationForm({
           mode="interactive"
           defaultValues={defaultValues}
           onChange={handleChange}
+          facultyName={facultyName}
           progressTrailing={
             draftStatus !== "idle" ? (
               <Badge

--- a/features/faculty-evaluation/components/faculty-evaluation-form.tsx
+++ b/features/faculty-evaluation/components/faculty-evaluation-form.tsx
@@ -126,6 +126,7 @@ export function FacultyEvaluationForm({
           mode="interactive"
           defaultValues={data.defaultValues}
           onChange={handleChange}
+          facultyName={data.facultyName}
           progressTrailing={
             draftStatus !== "idle" ? (
               <Badge

--- a/features/questionnaires/components/form/questionnaire-form-progress.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-progress.tsx
@@ -11,12 +11,15 @@ type QuestionnaireFormProgressProps = {
   qualitativeRequired: boolean;
   /** Optional slot rendered beside the percentage (e.g. draft status badge). */
   trailing?: React.ReactNode;
+  /** When provided, displays the faculty being evaluated above the progress row. */
+  facultyName?: string;
 };
 
 function QuestionnaireFormProgressBase({
   requiredIds,
   qualitativeRequired,
   trailing,
+  facultyName,
 }: QuestionnaireFormProgressProps) {
   const answeredCount = useAnsweredCountFor(requiredIds);
   const hasQualitativeContent = useHasQualitativeContent();
@@ -27,7 +30,17 @@ function QuestionnaireFormProgressBase({
   const percentage = totalRequired > 0 ? Math.round((answeredCount / totalRequired) * 100) : 0;
 
   return (
-    <div className="sticky top-0 z-20 -mx-4 space-y-2 border-b border-border/60 bg-background px-4 py-3 sm:static sm:mx-0 sm:border-0 sm:bg-transparent sm:p-0">
+    <div className="sticky top-0 z-20 -mx-4 space-y-2 border-b border-border/60 bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:mx-0">
+      {facultyName && (
+        <div className="flex flex-col">
+          <span className="text-[0.62rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground sm:text-[0.68rem]">
+            Evaluating
+          </span>
+          <span className="truncate font-playfair text-sm font-semibold leading-tight text-foreground sm:text-base">
+            {facultyName}
+          </span>
+        </div>
+      )}
       <div className="flex items-center justify-between gap-3 text-sm">
         <p className="truncate text-muted-foreground">
           <span className="font-medium tabular-nums text-foreground">{answeredCount}</span>

--- a/features/questionnaires/components/form/questionnaire-form-renderer.tsx
+++ b/features/questionnaires/components/form/questionnaire-form-renderer.tsx
@@ -28,6 +28,8 @@ type QuestionnaireFormRendererProps = {
   onChange?: (values: QuestionnaireFormValues) => void;
   /** Optional slot rendered beside the progress percentage (e.g. draft status badge). */
   progressTrailing?: React.ReactNode;
+  /** Faculty being evaluated; surfaced inside the sticky progress header. */
+  facultyName?: string;
 };
 
 /**
@@ -49,6 +51,7 @@ export function QuestionnaireFormRenderer({
   defaultValues,
   onChange,
   progressTrailing,
+  facultyName,
 }: QuestionnaireFormRendererProps) {
   const isInteractive = mode === "interactive";
 
@@ -90,6 +93,7 @@ export function QuestionnaireFormRenderer({
             requiredIds={requiredQuestionIds}
             qualitativeRequired={model.qualitative.required}
             trailing={progressTrailing}
+            facultyName={facultyName}
           />
         )}
 


### PR DESCRIPTION
…eader (#132)

Pin the progress bar on both mobile and desktop and add the faculty being evaluated above the answered/total row so respondents keep context as they scroll past the page header card.

https://claude.ai/code/session_01W73AaHtLTqTLzNF1RUSkmr