### PR TITLE
FAC-WEB feat: add global footer to all pages

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,4 +1,5 @@
 import { AuthGuard } from "@/app/(dashboard)/_guards/auth-guard";
+import { AppFooter } from "@/components/layout/app-footer";
 import { AppSidebar } from "@/components/layout/app-sidebar";
 import { DashboardHeader } from "@/components/layout/dashboard-header";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
@@ -13,6 +14,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           <div className="flex flex-1 flex-col overflow-x-clip px-4 py-4 md:px-0 md:py-0">
             {children}
           </div>
+          <AppFooter />
         </SidebarInset>
       </SidebarProvider>
     </AuthGuard>

--- a/app/_components/landing/landing-page.module.css
+++ b/app/_components/landing/landing-page.module.css
@@ -949,56 +949,6 @@
   background: rgba(255, 255, 255, 0.08);
 }
 
-/* ===== Footer ===== */
-.footer {
-  border-top: 1px solid var(--border);
-  padding: 50px 0 40px;
-}
-.footerGrid {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr;
-  gap: 40px;
-  margin-bottom: 40px;
-}
-.footerBrand p {
-  font-size: 14px;
-  color: var(--muted-foreground);
-  line-height: 1.6;
-  max-width: 320px;
-  margin: 16px 0 0;
-}
-.footerCol h5 {
-  font-size: 13px;
-  font-weight: 600;
-  margin: 0 0 14px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--muted-foreground);
-}
-.footerCol ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.footerCol a {
-  font-size: 14px;
-  color: var(--foreground);
-  text-decoration: none;
-}
-.footerCol a:hover {
-  color: var(--brand-blue);
-}
-.footerBottom {
-  display: flex;
-  justify-content: space-between;
-  padding-top: 24px;
-  border-top: 1px solid var(--border);
-  font-size: 13px;
-  color: var(--muted-foreground);
-}
 
 /* ===== Responsive ===== */
 @media (max-width: 960px) {
@@ -1020,10 +970,7 @@
   .stats {
     grid-template-columns: repeat(2, 1fr);
   }
-  .footerGrid {
-    grid-template-columns: 1fr 1fr;
-  }
-  .navLinks {
+.navLinks {
     display: none;
   }
 }

--- a/app/_components/landing/landing-page.tsx
+++ b/app/_components/landing/landing-page.tsx
@@ -22,6 +22,7 @@ import {
   Users,
 } from "lucide-react";
 
+import { AppFooter } from "@/components/layout/app-footer";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
 
 import styles from "./landing-page.module.css";
@@ -676,84 +677,7 @@ export function LandingPage() {
         </div>
       </section>
 
-      <footer className={styles.footer}>
-        <div className={styles.container}>
-          <div className={styles.footerGrid}>
-            <div className={styles.footerBrand}>
-              <div className={styles.navBrand}>
-                <Image
-                  src="/landing/faculytics-owl-logo.png"
-                  alt=""
-                  width={36}
-                  height={36}
-                  style={{ objectFit: "contain" }}
-                />
-                <span style={{ fontWeight: 600, fontSize: 16 }}>Faculytics</span>
-              </div>
-              <p>
-                An undergraduate thesis project by four computing students at the University of Cebu
-                — exploring sentiment analysis and topic modeling on Filipino student feedback. Not
-                a commercial product.
-              </p>
-            </div>
-            <div className={styles.footerCol}>
-              <h5>Product</h5>
-              <ul>
-                <li>
-                  <a href="#product">Analytics</a>
-                </li>
-                <li>
-                  <a href="#product">Sentiment engine</a>
-                </li>
-                <li>
-                  <a href="#product">Topic modeling</a>
-                </li>
-                <li>
-                  <a href="#product">Integrations</a>
-                </li>
-              </ul>
-            </div>
-            <div className={styles.footerCol}>
-              <h5>Institution</h5>
-              <ul>
-                <li>
-                  <a href="#roles">For deans</a>
-                </li>
-                <li>
-                  <a href="#roles">For faculty</a>
-                </li>
-                <li>
-                  <a href="#roles">For admins</a>
-                </li>
-                <li>
-                  <a href="#insights">Case studies</a>
-                </li>
-              </ul>
-            </div>
-            <div className={styles.footerCol}>
-              <h5>Company</h5>
-              <ul>
-                <li>
-                  <a href="#">About</a>
-                </li>
-                <li>
-                  <a href="#">Security</a>
-                </li>
-                <li>
-                  <a href="#">Privacy</a>
-                </li>
-                <li>
-                  <a href="#">Contact</a>
-                </li>
-              </ul>
-            </div>
-          </div>
-          <div className={styles.footerBottom}>
-            <div>© 2026 Faculytics · CtrlAltElite Devs</div>
-            <div>Cebu, Philippines</div>
-          </div>
-        </div>
-      </footer>
+      <AppFooter />
     </>
   );
 }

--- a/app/auth/layout.tsx
+++ b/app/auth/layout.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+import { AppFooter } from "@/components/layout/app-footer";
+
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
-  return <div className="min-h-screen">{children}</div>;
+  return (
+    <div className="min-h-screen flex flex-col">
+      <div className="flex-1">{children}</div>
+      <AppFooter />
+    </div>
+  );
 }

--- a/components/layout/app-footer.tsx
+++ b/components/layout/app-footer.tsx
@@ -1,0 +1,66 @@
+import Image from "next/image";
+
+export function AppFooter() {
+  return (
+    <footer className="border-t border-border pt-[50px] pb-[40px]">
+      <div className="max-w-[1200px] mx-auto px-6">
+        <div className="grid grid-cols-2 lg:grid-cols-[2fr_1fr_1fr_1fr] gap-10 mb-10">
+          <div>
+            <div className="flex items-center gap-[10px] font-semibold text-base">
+              <Image
+                src="/landing/faculytics-owl-logo.png"
+                alt=""
+                width={36}
+                height={36}
+                style={{ objectFit: "contain" }}
+              />
+              <span>Faculytics</span>
+            </div>
+            <p className="text-sm text-muted-foreground leading-relaxed max-w-[320px] mt-4">
+              An undergraduate thesis project by four computing students at the University of Cebu
+              — exploring sentiment analysis and topic modeling on Filipino student feedback. Not
+              a commercial product.
+            </p>
+          </div>
+          <div>
+            <h5 className="text-[13px] font-semibold mb-[14px] uppercase tracking-[0.04em] text-muted-foreground">
+              Product
+            </h5>
+            <ul className="flex flex-col gap-[10px] list-none p-0 m-0">
+              <li><a href="#product" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">Analytics</a></li>
+              <li><a href="#product" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">Sentiment engine</a></li>
+              <li><a href="#product" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">Topic modeling</a></li>
+              <li><a href="#product" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">Integrations</a></li>
+            </ul>
+          </div>
+          <div>
+            <h5 className="text-[13px] font-semibold mb-[14px] uppercase tracking-[0.04em] text-muted-foreground">
+              Institution
+            </h5>
+            <ul className="flex flex-col gap-[10px] list-none p-0 m-0">
+              <li><a href="#roles" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">For deans</a></li>
+              <li><a href="#roles" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">For faculty</a></li>
+              <li><a href="#roles" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">For admins</a></li>
+              <li><a href="#insights" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">Case studies</a></li>
+            </ul>
+          </div>
+          <div>
+            <h5 className="text-[13px] font-semibold mb-[14px] uppercase tracking-[0.04em] text-muted-foreground">
+              Company
+            </h5>
+            <ul className="flex flex-col gap-[10px] list-none p-0 m-0">
+              <li><a href="#" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">About</a></li>
+              <li><a href="#" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">Security</a></li>
+              <li><a href="#" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">Privacy</a></li>
+              <li><a href="#" className="text-sm text-foreground no-underline hover:text-[var(--brand-blue)]">Contact</a></li>
+            </ul>
+          </div>
+        </div>
+        <div className="flex justify-between pt-6 border-t border-border text-[13px] text-muted-foreground">
+          <div>© 2026 Faculytics · CtrlAltElite Devs</div>
+          <div>Cebu, Philippines</div>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
Closes #137

## Summary

- Extracts the landing page footer into a shared `AppFooter` component (`components/layout/app-footer.tsx`) with Tailwind styles, removing the CSS module dependency
- Replaces the inline `<footer>` in `landing-page.tsx` with `<AppFooter />`
- Removes the now-unused footer CSS rules from `landing-page.module.css`
- Adds `<AppFooter />` to the dashboard layout (`app/(dashboard)/layout.tsx`) inside `<SidebarInset>` after page content
- Adds `<AppFooter />` to the auth layout (`app/auth/layout.tsx`) below children

## Test plan

- [ ] Visit `/` — landing page footer renders as before
- [ ] Visit `/auth/login` — footer appears at the bottom of the page
- [ ] Log in and navigate any dashboard route — footer is visible below page content, respects sidebar inset
- [ ] Toggle sidebar collapse — footer stays in place
- [ ] Check dark/light mode — footer reads cleanly in both themes
- [ ] Resize to mobile — footer collapses to 2-column grid