### PR TITLE
[RELEASE] FAC-WEB-38 feat:remove analytics pipeline for chairperson(#140)

### DIFF
--- a/features/faculty-analytics/components/batch-report-export-dialog.tsx
+++ b/features/faculty-analytics/components/batch-report-export-dialog.tsx
@@ -98,21 +98,13 @@ export function BatchReportExportDialog({
 
   const effectiveQuestionnaireTypeCode =
     selectedQuestionnaireTypeCode || questionnaireTypes[0]?.code || "";
-
-  function handleOpenChange(nextOpen: boolean) {
-    if (!nextOpen) {
-      setBatchId(null);
-      setCurrentPage(1);
-      setRowsPerPage(DEFAULT_PAGE_SIZE);
-      setSetupMessage(null);
-      setBatchSummary(null);
-      setSelectedProgramId(programId);
-      setSelectedQuestionnaireTypeCode("");
-      generateBatchReportMutation.reset();
-    }
-
-    onOpenChange(nextOpen);
-  }
+  const effectiveQuestionnaireTypeLabel = effectiveQuestionnaireTypeCode
+    ? resolveQuestionnaireTypeLabel(
+        effectiveQuestionnaireTypeCode,
+        questionnaireTypes.find((type) => type.code === effectiveQuestionnaireTypeCode)?.name ??
+          null
+      )
+    : null;
 
   async function handleGenerate() {
     if (!semesterId) {
@@ -154,8 +146,6 @@ export function BatchReportExportDialog({
   }
 
   const batchStatus = batchStatusQuery.data;
-  const selectedQuestionnaireTypeLabel =
-    questionnaireTypes.find((type) => type.code === effectiveQuestionnaireTypeCode)?.name ?? null;
   const selectedProgramLabel =
     programs.find((program) => program.id === selectedProgramId)?.label ??
     programs[0]?.label ??
@@ -166,6 +156,21 @@ export function BatchReportExportDialog({
     batchStatus?.failed ?? 0,
     batchStatus?.skipped ?? 0
   );
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setBatchId(null);
+      setCurrentPage(1);
+      setRowsPerPage(DEFAULT_PAGE_SIZE);
+      setSetupMessage(null);
+      setBatchSummary(null);
+      setSelectedProgramId(programId);
+      setSelectedQuestionnaireTypeCode("");
+      generateBatchReportMutation.reset();
+    }
+
+    onOpenChange(nextOpen);
+  }
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -197,12 +202,7 @@ export function BatchReportExportDialog({
                   <div className="flex items-center justify-between gap-4">
                     <dt className="text-muted-foreground">Questionnaire Type</dt>
                     <dd className="text-right font-medium">
-                      {selectedQuestionnaireTypeCode
-                        ? resolveQuestionnaireTypeLabel(
-                            selectedQuestionnaireTypeCode,
-                            selectedQuestionnaireTypeLabel
-                          )
-                        : "Not selected"}
+                      {effectiveQuestionnaireTypeLabel ?? "Not selected"}
                     </dd>
                   </div>
                 </>
@@ -263,12 +263,7 @@ export function BatchReportExportDialog({
                         }
                       >
                         <span className="truncate">
-                          {effectiveQuestionnaireTypeCode
-                            ? resolveQuestionnaireTypeLabel(
-                                effectiveQuestionnaireTypeCode,
-                                selectedQuestionnaireTypeLabel
-                              )
-                            : "Select questionnaire type"}
+                          {effectiveQuestionnaireTypeLabel ?? "Select questionnaire type"}
                         </span>
                         <ChevronDown className="size-4" />
                       </Button>

--- a/features/faculty-analytics/components/campus-dashboard-sections.tsx
+++ b/features/faculty-analytics/components/campus-dashboard-sections.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ScopedOverallSentimentBarChart } from "@/features/faculty-analytics/components/scoped-charts";
+import { ScopedMetricsGrid } from "@/features/faculty-analytics/components/scoped-metrics-grid";
+import type { DashboardCommonSectionProps } from "@/features/faculty-analytics/components/scoped-dashboard-section-types";
+
+export function CampusDashboardSections({
+  summary,
+  overallSentiment,
+}: Pick<DashboardCommonSectionProps, "summary" | "overallSentiment">) {
+  return (
+    <>
+      <ScopedMetricsGrid summary={summary} />
+      <div className="grid gap-6">
+        <ScopedOverallSentimentBarChart overallSentiment={overallSentiment} />
+      </div>
+    </>
+  );
+}

--- a/features/faculty-analytics/components/department-dashboard-sections.tsx
+++ b/features/faculty-analytics/components/department-dashboard-sections.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PipelineTriggerCard } from "@/features/faculty-analytics/components/pipeline-trigger-card";
+import { RecommendationsCard } from "@/features/faculty-analytics/components/recommendations-card";
+import { ScopedAttentionCard } from "@/features/faculty-analytics/components/scoped-attention-card";
+import { ScopedOverallSentimentBarChart } from "@/features/faculty-analytics/components/scoped-charts";
+import { ScopedMetricsGrid } from "@/features/faculty-analytics/components/scoped-metrics-grid";
+import { ThemesRankedList } from "@/features/faculty-analytics/components/themes-ranked-list";
+import type { DepartmentDashboardSectionsProps } from "@/features/faculty-analytics/components/scoped-dashboard-section-types";
+
+function EmptyThemesPlaceholder() {
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl">Top Themes</CardTitle>
+        <CardDescription>Ranked by comment volume with sentiment breakdown.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
+          <p className="max-w-sm font-sans text-sm text-muted-foreground">
+            Run analysis to surface the strongest feedback themes for this scope.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function EmptyRecommendationsPlaceholder() {
+  return (
+    <Card className="rounded-2xl border-border/70 shadow-sm">
+      <CardHeader>
+        <CardTitle className="font-playfair text-xl">Suggested Actions</CardTitle>
+        <CardDescription>Concrete actions informed by the feedback themes above.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
+          <p className="max-w-sm font-sans text-sm text-muted-foreground">
+            Suggested actions will appear here after a completed analysis run.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function DepartmentDashboardSections({
+  summary,
+  overallSentiment,
+  attentionItems,
+  isAttentionLoading,
+  hasAnalyticsData,
+  scopeLabel,
+  facultiesHref,
+  selectedSemesterId,
+  selectedSemesterLabel,
+  latestPipeline,
+  showPipelineTrigger,
+  themes,
+  showRecommendationPanels,
+  showEmptyInsightsPlaceholder,
+  recommendations,
+}: DepartmentDashboardSectionsProps) {
+  return (
+    <>
+      {showPipelineTrigger && selectedSemesterId ? (
+        <PipelineTriggerCard scope={{ semesterId: selectedSemesterId }} pipeline={latestPipeline} />
+      ) : null}
+
+      <ScopedMetricsGrid summary={summary} />
+
+      <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <ScopedOverallSentimentBarChart overallSentiment={overallSentiment} />
+        {showRecommendationPanels ? (
+          <ThemesRankedList themes={themes} />
+        ) : showEmptyInsightsPlaceholder ? (
+          <EmptyThemesPlaceholder />
+        ) : null}
+      </div>
+
+      <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1.15fr)_minmax(19rem,0.85fr)]">
+        <ScopedAttentionCard
+          items={attentionItems}
+          isLoading={isAttentionLoading}
+          hasAnalyticsData={hasAnalyticsData}
+          scopeLabel={scopeLabel}
+          facultiesHref={facultiesHref}
+          semesterId={selectedSemesterId ?? ""}
+          semesterLabel={selectedSemesterLabel}
+        />
+        {showRecommendationPanels && recommendations ? (
+          <RecommendationsCard recommendations={recommendations} />
+        ) : showEmptyInsightsPlaceholder ? (
+          <EmptyRecommendationsPlaceholder />
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/features/faculty-analytics/components/program-dashboard-sections.tsx
+++ b/features/faculty-analytics/components/program-dashboard-sections.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { ScopedAttentionCard } from "@/features/faculty-analytics/components/scoped-attention-card";
+import { ScopedOverallSentimentBarChart } from "@/features/faculty-analytics/components/scoped-charts";
+import { ScopedMetricsGrid } from "@/features/faculty-analytics/components/scoped-metrics-grid";
+import type { DashboardCommonSectionProps } from "@/features/faculty-analytics/components/scoped-dashboard-section-types";
+
+export function ProgramDashboardSections({
+  summary,
+  overallSentiment,
+  attentionItems,
+  isAttentionLoading,
+  hasAnalyticsData,
+  scopeLabel,
+  facultiesHref,
+  selectedSemesterId,
+  selectedSemesterLabel,
+}: DashboardCommonSectionProps) {
+  return (
+    <>
+      <ScopedMetricsGrid summary={summary} />
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(22rem,0.85fr)]">
+        <ScopedOverallSentimentBarChart overallSentiment={overallSentiment} />
+        <ScopedAttentionCard
+          items={attentionItems}
+          isLoading={isAttentionLoading}
+          hasAnalyticsData={hasAnalyticsData}
+          scopeLabel={scopeLabel}
+          facultiesHref={facultiesHref}
+          semesterId={selectedSemesterId ?? ""}
+          semesterLabel={selectedSemesterLabel}
+        />
+      </div>
+    </>
+  );
+}

--- a/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
+++ b/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx
@@ -2,15 +2,15 @@
 
 import { useMemo } from "react";
 
+import { CampusDashboardSections } from "@/features/faculty-analytics/components/campus-dashboard-sections";
+import { DepartmentDashboardSections } from "@/features/faculty-analytics/components/department-dashboard-sections";
+import { ProgramDashboardSections } from "@/features/faculty-analytics/components/program-dashboard-sections";
 import { ScopedDashboardHeader } from "@/features/faculty-analytics/components/scoped-dashboard-header";
-import { ScopedAttentionCard } from "@/features/faculty-analytics/components/scoped-attention-card";
-import { ScopedOverallSentimentBarChart } from "@/features/faculty-analytics/components/scoped-charts";
 import { ScopedAnalyticsAsyncContent } from "@/features/faculty-analytics/components/scoped-analytics-async-content";
-import { ScopedMetricsGrid } from "@/features/faculty-analytics/components/scoped-metrics-grid";
-import { PipelineTriggerCard } from "@/features/faculty-analytics/components/pipeline-trigger-card";
-import { RecommendationsCard } from "@/features/faculty-analytics/components/recommendations-card";
-import { ThemesRankedList } from "@/features/faculty-analytics/components/themes-ranked-list";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type {
+  DashboardCommonSectionProps,
+  ScopeLabel,
+} from "@/features/faculty-analytics/components/scoped-dashboard-section-types";
 import { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
 import { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
 import { usePipelineStatus } from "@/features/faculty-analytics/hooks/use-pipeline-status";
@@ -38,8 +38,6 @@ function rankedThemesToQualitativeThemes(themes: RankedTheme[]): QualitativeThem
   });
 }
 
-export type ScopeLabel = "Campus" | "Department" | "Program";
-
 const SCOPE_METADATA: Record<
   ScopeLabel,
   {
@@ -61,44 +59,10 @@ const SCOPE_METADATA: Record<
   },
 };
 
-function EmptyThemesPlaceholder() {
-  return (
-    <Card className="rounded-2xl border-border/70 shadow-sm">
-      <CardHeader>
-        <CardTitle className="font-playfair text-xl">Top Themes</CardTitle>
-        <CardDescription>Ranked by comment volume with sentiment breakdown.</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
-          <p className="max-w-sm font-sans text-sm text-muted-foreground">
-            Run analysis to surface the strongest feedback themes for this scope.
-          </p>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function EmptyRecommendationsPlaceholder() {
-  return (
-    <Card className="rounded-2xl border-border/70 shadow-sm">
-      <CardHeader>
-        <CardTitle className="font-playfair text-xl">Suggested Actions</CardTitle>
-        <CardDescription>Concrete actions informed by the feedback themes above.</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-border/70 px-6 text-center">
-          <p className="max-w-sm font-sans text-sm text-muted-foreground">
-            Suggested actions will appear here after a completed analysis run.
-          </p>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
 export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: ScopeLabel }) {
   const isCampusScope = scopeLabel === "Campus";
+  const isProgramScope = scopeLabel === "Program";
+  const supportsAggregatePipeline = scopeLabel === "Department";
   const {
     departments,
     selectedDepartmentId,
@@ -127,16 +91,16 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
     [selectedSemesterId]
   );
   const { latestPipeline } = useLatestPipelineForScope(pipelineQuery, {
-    enabled: !isCampusScope && Boolean(selectedSemesterId),
+    enabled: supportsAggregatePipeline && Boolean(selectedSemesterId),
   });
   const pipelineStatusQuery = usePipelineStatus(latestPipeline?.id ?? null, {
-    enabled: !isCampusScope && Boolean(latestPipeline?.id),
+    enabled: supportsAggregatePipeline && Boolean(latestPipeline?.id),
   });
-  const liveStatus = isCampusScope
+  const liveStatus = !supportsAggregatePipeline
     ? undefined
     : (pipelineStatusQuery.data?.status ?? latestPipeline?.status);
   const recommendationsQuery = usePipelineRecommendations(
-    isCampusScope ? null : (latestPipeline?.id ?? null),
+    supportsAggregatePipeline ? (latestPipeline?.id ?? null) : null,
     liveStatus
   );
   const themes = useMemo(
@@ -147,15 +111,27 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
     [recommendationsQuery.data]
   );
   const showRecommendationPanels =
-    !isCampusScope && liveStatus === "COMPLETED" && themes.length > 0;
+    supportsAggregatePipeline && liveStatus === "COMPLETED" && themes.length > 0;
   const showEmptyInsightsPlaceholder =
-    !isCampusScope && Boolean(selectedSemesterId) && !showRecommendationPanels;
+    supportsAggregatePipeline && Boolean(selectedSemesterId) && !showRecommendationPanels;
 
   const { scopeLower, facultiesHref } = SCOPE_METADATA[scopeLabel];
   const emptyStateDescription =
     semesters.length === 0
       ? "Semester options will appear here once academic terms are available."
       : `No analyzed faculty data is available for the selected semester yet.`;
+  const hasAnalyticsData = overview?.lastRefreshedAt !== null;
+  const commonSectionProps: DashboardCommonSectionProps = {
+    summary,
+    overallSentiment,
+    attentionItems,
+    isAttentionLoading,
+    hasAnalyticsData,
+    scopeLabel,
+    facultiesHref,
+    selectedSemesterId,
+    selectedSemesterLabel,
+  };
 
   return (
     <ScopedAnalyticsAsyncContent
@@ -183,57 +159,26 @@ export function ScopedAnalyticsDashboardScreen({ scopeLabel }: { scopeLabel: Sco
           lastUpdatedLabel={lastUpdatedLabel}
         />
 
-        {!isCampusScope && selectedSemesterId ? (
-          <PipelineTriggerCard
-            scope={{ semesterId: selectedSemesterId }}
-            pipeline={latestPipeline}
-          />
-        ) : null}
-
         {semesters.length === 0 ? (
           <div className="flex min-h-44 flex-col items-center justify-center rounded-lg border border-dashed px-6 text-center">
             <p className="max-w-xl font-sans text-sm text-muted-foreground">
               {emptyStateDescription}
             </p>
           </div>
+        ) : isProgramScope ? (
+          <ProgramDashboardSections {...commonSectionProps} />
+        ) : isCampusScope ? (
+          <CampusDashboardSections summary={summary} overallSentiment={overallSentiment} />
         ) : (
-          <>
-            <ScopedMetricsGrid summary={summary} />
-
-            <div
-              className={
-                isCampusScope
-                  ? "grid gap-6"
-                  : "grid gap-6 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"
-              }
-            >
-              <ScopedOverallSentimentBarChart overallSentiment={overallSentiment} />
-              {isCampusScope ? null : showRecommendationPanels ? (
-                <ThemesRankedList themes={themes} />
-              ) : showEmptyInsightsPlaceholder ? (
-                <EmptyThemesPlaceholder />
-              ) : null}
-            </div>
-
-            {isCampusScope ? null : (
-              <div className="grid gap-6 min-[900px]:grid-cols-[minmax(0,1.15fr)_minmax(19rem,0.85fr)]">
-                <ScopedAttentionCard
-                  items={attentionItems}
-                  isLoading={isAttentionLoading}
-                  hasAnalyticsData={overview?.lastRefreshedAt !== null}
-                  scopeLabel={scopeLabel}
-                  facultiesHref={facultiesHref}
-                  semesterId={selectedSemesterId ?? ""}
-                  semesterLabel={selectedSemesterLabel}
-                />
-                {showRecommendationPanels && recommendationsQuery.data ? (
-                  <RecommendationsCard recommendations={recommendationsQuery.data} />
-                ) : showEmptyInsightsPlaceholder ? (
-                  <EmptyRecommendationsPlaceholder />
-                ) : null}
-              </div>
-            )}
-          </>
+          <DepartmentDashboardSections
+            {...commonSectionProps}
+            latestPipeline={latestPipeline}
+            showPipelineTrigger={supportsAggregatePipeline}
+            themes={themes}
+            showRecommendationPanels={showRecommendationPanels}
+            showEmptyInsightsPlaceholder={showEmptyInsightsPlaceholder}
+            recommendations={recommendationsQuery.data}
+          />
         )}
       </section>
     </ScopedAnalyticsAsyncContent>

--- a/features/faculty-analytics/components/scoped-dashboard-section-types.ts
+++ b/features/faculty-analytics/components/scoped-dashboard-section-types.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import type { useLatestPipelineForScope } from "@/features/faculty-analytics/hooks/use-latest-pipeline-for-scope";
+import type { usePipelineRecommendations } from "@/features/faculty-analytics/hooks/use-pipeline-recommendations";
+import type { useScopedAnalyticsDashboardViewModel } from "@/features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model";
+import type { QualitativeThemeDto } from "@/features/faculty-analytics/types";
+
+export type ScopeLabel = "Campus" | "Department" | "Program";
+
+export type DashboardCommonSectionProps = {
+  summary: ReturnType<typeof useScopedAnalyticsDashboardViewModel>["summary"];
+  overallSentiment: ReturnType<typeof useScopedAnalyticsDashboardViewModel>["overallSentiment"];
+  attentionItems: ReturnType<typeof useScopedAnalyticsDashboardViewModel>["attentionItems"];
+  isAttentionLoading: boolean;
+  hasAnalyticsData: boolean;
+  scopeLabel: ScopeLabel;
+  facultiesHref: string;
+  selectedSemesterId: string | null;
+  selectedSemesterLabel: string;
+};
+
+export type DepartmentDashboardSectionsProps = DashboardCommonSectionProps & {
+  latestPipeline: ReturnType<typeof useLatestPipelineForScope>["latestPipeline"];
+  showPipelineTrigger: boolean;
+  themes: QualitativeThemeDto[];
+  showRecommendationPanels: boolean;
+  showEmptyInsightsPlaceholder: boolean;
+  recommendations: ReturnType<typeof usePipelineRecommendations>["data"];
+};

--- a/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
+++ b/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
@@ -19,7 +19,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
-import type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-analytics-dashboard-screen";
+import type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-dashboard-section-types";
 
 type ScopedFacultyListScreenProps = {
   scopeLabel: ScopeLabel;

--- a/features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model.ts
+++ b/features/faculty-analytics/hooks/use-scoped-analytics-dashboard-view-model.ts
@@ -19,11 +19,11 @@ import {
   mapProgramOptionsToViewModel,
   mapSemesterOptionsToViewModel,
 } from "@/features/faculty-analytics/lib/scoped-analytics-view-model";
+import type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-dashboard-section-types";
 import { useDepartmentOverview } from "@/features/faculty-analytics/hooks/use-department-overview";
 import { useProgramOptions } from "@/features/faculty-analytics/hooks/use-program-options";
 import { useSemesterOptions } from "@/features/faculty-analytics/hooks/use-semester-options";
 import { formatRelativeTime } from "@/lib/date";
-import type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-analytics-dashboard-screen";
 import { useAuthStore } from "@/stores/auth-store";
 
 export function useScopedAnalyticsDashboardViewModel(scopeLabel: ScopeLabel) {

--- a/features/faculty-analytics/hooks/use-scoped-faculty-analytics-list-view-model.ts
+++ b/features/faculty-analytics/hooks/use-scoped-faculty-analytics-list-view-model.ts
@@ -21,7 +21,7 @@ import {
 } from "@/features/faculty-analytics/lib/scoped-analytics-view-model";
 import { useProgramOptions } from "@/features/faculty-analytics/hooks/use-program-options";
 import { useSemesterOptions } from "@/features/faculty-analytics/hooks/use-semester-options";
-import type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-analytics-dashboard-screen";
+import type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-dashboard-section-types";
 import { useAuthStore } from "@/stores/auth-store";
 
 type UseScopedFacultyAnalyticsListViewModelOptions = {

--- a/features/faculty-analytics/index.ts
+++ b/features/faculty-analytics/index.ts
@@ -1,5 +1,5 @@
 export { ScopedAnalyticsDashboardScreen } from "@/features/faculty-analytics/components/scoped-analytics-dashboard-screen";
-export type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-analytics-dashboard-screen";
+export type { ScopeLabel } from "@/features/faculty-analytics/components/scoped-dashboard-section-types";
 export { ScopedFacultyListScreen } from "@/features/faculty-analytics/components/scoped-faculty-list-screen";
 export { FacultyReportScreen } from "@/features/faculty-analytics/components/faculty-report-screen";
 


### PR DESCRIPTION
* feat: removed analytics pipeline trigger in dashboard for chairperson role

* refactor: restrict aggregate pipeline dashboard flow to dean only

* fix: keep batch export questionnaire type summary in sync with effective selection

* refactor: extract scoped dashboard section layouts into dedicated files

* refactor: centralize scoped dashboard types and split dashboard layouts