### PR TITLE
FAC-WEB feat: sticky faculty context header on analysis page (#145)

### DIFF
--- a/features/faculty-analytics/components/faculty-report-screen.tsx
+++ b/features/faculty-analytics/components/faculty-report-screen.tsx
@@ -155,9 +155,9 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
   const hasAnalyticsData = hasFacultyReportAnalyticsData(viewModel.report, viewModel.commentsCount);
 
   return (
-    <section className="max-w-full space-y-6 overflow-x-hidden px-1 pb-4 md:p-8">
-      {/* Title row — mirrors the dashboard / faculty-list header pattern */}
-      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+    <section className="max-w-full space-y-6 overflow-x-clip px-1 pb-4 md:p-8">
+      {/* Title row — sticky so faculty context persists while scrolling */}
+      <div className="sticky top-0 z-20 -mx-1 flex flex-col gap-4 border-b border-border/40 bg-background/80 px-4 py-3 backdrop-blur-md supports-[backdrop-filter]:bg-background/75 md:-mx-8 md:px-8 xl:flex-row xl:items-center xl:justify-between">
         <div className="min-w-0">
           <div className="flex items-center gap-3">
             <Avatar size="lg" className="border border-border/70">
@@ -171,14 +171,12 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
                 {getInitials(viewModel.report.faculty.name)}
               </AvatarFallback>
             </Avatar>
-            <h1 className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl">
+            <h1
+              className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl"
+            >
               {viewModel.report.faculty.name}
             </h1>
           </div>
-          <p className="mt-3 max-w-3xl text-sm text-muted-foreground">
-            Review per-question faculty evaluation results for{" "}
-            <span className="font-medium text-foreground">{viewModel.semesterLabel}</span>.
-          </p>
         </div>
 
         <FacultyReportHeader
@@ -192,6 +190,11 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
           onExport={canExportReport ? () => setIsExportDialogOpen(true) : undefined}
         />
       </div>
+
+      <p className="-mt-2 max-w-3xl text-sm text-muted-foreground">
+        Review per-question faculty evaluation results for{" "}
+        <span className="font-medium text-foreground">{viewModel.semesterLabel}</span>.
+      </p>
 
       <HeadlineMetricsStrip
         overallRating={viewModel.report.overallRating}


### PR DESCRIPTION
* feat: add sticky faculty context header on analysis page

Shows a compact frosted-glass bar (avatar + name + course selector + export button) that fades in when the faculty name scrolls out of view, giving the user persistent context about which faculty they are reviewing.

Uses IntersectionObserver on the title to toggle visibility, following the existing sticky pattern from questionnaire-form-progress.

https://claude.ai/code/session_017VN26i97mc9APZ11xfyNm2

* fix: use callback ref so sticky header observer attaches after data loads

The previous useEffect with [] ran during the loading state when the h1 hadn't mounted yet, so titleRef.current was null and the IntersectionObserver was never set up. Switching to a callback ref ensures the observer is created the moment the faculty name element actually enters the DOM.

https://claude.ai/code/session_017VN26i97mc9APZ11xfyNm2

* refactor: simplify sticky faculty header to pure Tailwind

Replace the IntersectionObserver + callback ref + separate component approach with a single sticky Tailwind row on the existing title div. No JS, no state, no extra file — just sticky/backdrop-blur classes on the header that already contains the avatar, name, and controls.

https://claude.ai/code/session_017VN26i97mc9APZ11xfyNm2

* fix: swap overflow-x-hidden for overflow-x-clip so sticky header works

overflow: hidden (even on one axis) creates a scroll container in CSS, which traps position: sticky — making it stick relative to the section instead of the viewport. overflow-x: clip clips visually without creating a scroll container, so sticky now works against the real scroller.

https://claude.ai/code/session_017VN26i97mc9APZ11xfyNm2

---------