### PR TITLE
FAC-WEB refactor: rename user-facing "Faculties" label to "Faculty" (#148)

### DIFF
--- a/features/auth/lib/role-route.ts
+++ b/features/auth/lib/role-route.ts
@@ -45,7 +45,7 @@ const ROLE_CONFIG: Record<AppRole, RoleConfig> = {
     routePrefix: "/dean",
     navItems: [
       { title: "Dashboard", url: "/dean/dashboard", icon: LayoutDashboard },
-      { title: "Faculties", url: "/dean/faculties", icon: ChartNoAxesColumn },
+      { title: "Faculty", url: "/dean/faculties", icon: ChartNoAxesColumn },
       { title: "Evaluation", url: "/dean/evaluation", icon: NotebookPen },
     ],
   },
@@ -55,7 +55,7 @@ const ROLE_CONFIG: Record<AppRole, RoleConfig> = {
     routePrefix: "/chairperson",
     navItems: [
       { title: "Dashboard", url: "/chairperson/dashboard", icon: LayoutDashboard },
-      { title: "Faculties", url: "/chairperson/faculties", icon: Building2 },
+      { title: "Faculty", url: "/chairperson/faculties", icon: Building2 },
       { title: "Evaluation", url: "/chairperson/evaluation", icon: NotebookPen },
     ],
   },
@@ -65,7 +65,7 @@ const ROLE_CONFIG: Record<AppRole, RoleConfig> = {
     routePrefix: "/campus-head",
     navItems: [
       { title: "Dashboard", url: "/campus-head/dashboard", icon: LayoutDashboard },
-      { title: "Faculties", url: "/campus-head/faculties", icon: ChartNoAxesColumn },
+      { title: "Faculty", url: "/campus-head/faculties", icon: ChartNoAxesColumn },
     ],
   },
   [APP_ROLES.ADMIN]: {

--- a/features/faculty-analytics/components/faculty-report-header.tsx
+++ b/features/faculty-analytics/components/faculty-report-header.tsx
@@ -47,7 +47,7 @@ export function FacultyReportHeader({
           variant="outline"
           className="w-full justify-center px-4 py-2.5 font-sans text-sm sm:w-auto sm:justify-start"
         >
-          <Link href={backHref}>Back to faculties</Link>
+          <Link href={backHref}>Back to faculty</Link>
         </Button>
       ) : null}
 

--- a/features/faculty-analytics/components/faculty-report-screen.tsx
+++ b/features/faculty-analytics/components/faculty-report-screen.tsx
@@ -122,7 +122,7 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
         </div>
         <ScopedAnalyticsErrorState
           onRetry={viewModel.goBackToFaculties}
-          message="Missing semester context. Start from the faculties list to open a faculty report."
+          message="Missing semester context. Start from the faculty list to open a faculty report."
         />
       </section>
     );
@@ -171,9 +171,7 @@ export function FacultyReportScreen({ facultyId }: FacultyReportScreenProps) {
                 {getInitials(viewModel.report.faculty.name)}
               </AvatarFallback>
             </Avatar>
-            <h1
-              className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl"
-            >
+            <h1 className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl">
               {viewModel.report.faculty.name}
             </h1>
           </div>

--- a/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
+++ b/features/faculty-analytics/components/scoped-faculty-list-screen.tsx
@@ -65,10 +65,10 @@ export function ScopedFacultyListScreen({
       <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
         <div className="min-w-0">
           <h1 className="font-playfair text-2xl font-semibold tracking-tight sm:text-3xl">
-            Faculties
+            Faculty
           </h1>
           <p className="mt-4 max-w-3xl font-sans text-sm text-muted-foreground sm:mt-5">
-            All faculties for the selected semester.
+            All faculty for the selected semester.
           </p>
         </div>
         <div className="w-full xl:max-w-6xl">
@@ -191,10 +191,10 @@ export function ScopedFacultyListScreen({
         </div>
       </div>
 
-      {isLoading ? <ScopedAnalyticsLoadingState message="Loading faculties..." /> : null}
+      {isLoading ? <ScopedAnalyticsLoadingState message="Loading faculty..." /> : null}
 
       {!isLoading && isError ? (
-        <ScopedAnalyticsErrorState onRetry={retry} message="Unable to load the faculties list." />
+        <ScopedAnalyticsErrorState onRetry={retry} message="Unable to load the faculty list." />
       ) : null}
 
       {!isLoading && !isError && facultyList.length === 0 ? (

--- a/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
+++ b/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
@@ -373,7 +373,7 @@ export function useFacultyReportDetailViewModel({
   const backHref = isFacultySelf
     ? (roleConfig?.homePath ?? "/faculty/analytics")
     : `${roleConfig?.routePrefix ?? "/dean"}/faculties`;
-  const backLabel = "Back to Faculties";
+  const backLabel = "Back to Faculty";
 
   return {
     backHref,


### PR DESCRIPTION
Updates sidebar nav, page heading, loading/error messages, and back-link text across dean/chairperson/campus-head views to use "Faculty" instead of the plural. URL routes, directory names, and internal code identifiers are intentionally left unchanged.

https://claude.ai/code/session_0189NiAhxiopdY9pEiieUawr