### PR TITLE
FAC-WEB feat: show academic year alongside semester labels

### DIFF
--- a/features/faculty-analytics/components/scoped-dashboard-header.tsx
+++ b/features/faculty-analytics/components/scoped-dashboard-header.tsx
@@ -78,7 +78,7 @@ export function ScopedDashboardHeader({
             <DropdownMenuTrigger asChild>
               <Button
                 variant="outline"
-                className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-48 md:max-w-48"
+                className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-64 md:max-w-64"
                 disabled={semesters.length === 0}
               >
                 <span className="truncate">{selectedSemesterLabel}</span>

--- a/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
+++ b/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
@@ -25,6 +25,7 @@ import {
   type SentimentLabel,
 } from "@/features/faculty-analytics/types";
 import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import { formatSemesterDisplay } from "@/lib/format-semester";
 import { resolvePageSizeOption } from "@/lib/pagination";
 import { useActiveRole } from "@/features/auth/hooks/use-active-role";
 import { getRoleConfig } from "@/features/auth/lib/role-route";
@@ -347,9 +348,9 @@ export function useFacultyReportDetailViewModel({
 
   const report = reportQuery.data ?? null;
   const reportTitle = report?.faculty.name || facultyNameParam || "Faculty report";
-  const semesterLabel =
-    report?.semester.label ||
-    (semesterLabelParam.trim().length > 0 ? semesterLabelParam : "Selected semester");
+  const reportDerivedLabel = report?.semester ? formatSemesterDisplay(report.semester) : null;
+  const urlDerivedLabel = semesterLabelParam.trim().length > 0 ? semesterLabelParam : null;
+  const semesterLabel = reportDerivedLabel ?? urlDerivedLabel ?? "Selected semester";
   const questionnaireTypeLabel = resolveFacultyReportQuestionnaireTypeLabel(
     report?.questionnaireType.code ?? questionnaireTypeCode ?? "",
     report?.questionnaireType.name ?? selectedQuestionnaireType?.name

--- a/features/faculty-analytics/lib/scoped-analytics-view-model.ts
+++ b/features/faculty-analytics/lib/scoped-analytics-view-model.ts
@@ -6,11 +6,11 @@ import type {
   ProgramOptionDto,
   SemesterOptionDto,
 } from "@/features/faculty-analytics/types";
+import { formatSemesterDisplay } from "@/lib/format-semester";
 
 export type ScopedSemesterOption = {
   id: string;
   label: string;
-  academicYear?: string;
 };
 
 export type ScopedDepartmentOption = {
@@ -59,8 +59,7 @@ export function mapSemesterOptionsToViewModel(
 ): ScopedSemesterOption[] {
   return semesters.map((semester) => ({
     id: semester.id,
-    label: semester.label ?? [semester.code, semester.academicYear].filter(Boolean).join(" • "),
-    academicYear: semester.academicYear,
+    label: formatSemesterDisplay(semester),
   }));
 }
 

--- a/lib/format-semester.ts
+++ b/lib/format-semester.ts
@@ -1,0 +1,14 @@
+export type SemesterLike = {
+  label?: string | null;
+  academicYear?: string | null;
+  code?: string | null;
+};
+
+export const SEMESTER_UNKNOWN_LABEL = "Unknown Semester";
+const ACADEMIC_YEAR_UNKNOWN_SUFFIX = "(year unknown)";
+
+export function formatSemesterDisplay(semester: SemesterLike): string {
+  const head = semester.label?.trim() || semester.code?.trim() || SEMESTER_UNKNOWN_LABEL;
+  const year = semester.academicYear?.trim();
+  return year ? `${head} • ${year}` : `${head} ${ACADEMIC_YEAR_UNKNOWN_SUFFIX}`;
+}


### PR DESCRIPTION
Closes #153.

## Summary

- Add shared `formatSemesterDisplay` util at `lib/format-semester.ts` composing `label` + `academicYear` into `"Semester 2 • 2025-2026"` (bullet `•` matches the existing separator convention).
- Wire the util into `mapSemesterOptionsToViewModel` — propagates the composed label to all three semester dropdowns (dashboard header, scoped faculty list, faculty-evaluation toolbar) and every downstream `selectedSemesterLabel` consumer (tab empty states, export dialogs, attention cards, section headers, faculty cards, evaluate action menus).
- Wire the util into `useFacultyReportDetailViewModel` — the faculty-report sticky header reads `report?.semester.label` off the report response and bypasses the ViewModel chain.
- Drop the now-redundant `academicYear` field from `ScopedSemesterOption` to prevent consumers from accidentally rendering both sides of the composed string.
- Widen the dashboard-header semester dropdown trigger from `md:w-48` to `md:w-64` so the longer composed label fits without truncation.

No API / backend changes — the backend already ships `academicYear` on every semester DTO; this is purely presentation.

## Why

Current UI shows bare `Semester 2` in dropdowns and headers — ambiguous when data spans multiple academic years (`Semester 2 of 2024-2025` vs `Semester 2 of 2025-2026`).

## Fallback behavior

- `label` + `academicYear` present → `"Semester 2 • 2025-2026"`
- `label` present, `academicYear` absent → `"Semester 2 (year unknown)"`
- `label` absent, `code` + `academicYear` present → `"S22526 • 2025-2026"` (preserves the pre-existing fallback)
- everything absent → `"Unknown Semester (year unknown)"`

Whitespace-only values are treated as missing.

## Quality gates

- `bun run typecheck` ✅
- `bun run lint` ✅ (including `no-nested-ternary` — the report-detail fallback chain was refactored to named consts)
- `bun run build` ✅ (28/28 pages)

## Test plan

- [ ] Dean / scoped analytics dashboard — semester dropdown trigger + items show the composed label; trigger is wide enough to avoid ellipsis at md+ viewports
- [ ] Dean / faculty list screen — semester dropdown shows composed label
- [ ] Dean/Faculty / faculty-evaluation toolbar — semester dropdown shows composed label
- [ ] Faculty / `/faculty/analytics` — sticky header on the faculty report screen shows composed label
- [ ] Dean / per-faculty report screen — same sticky header, same composed format
- [ ] Spot-check one downstream `selectedSemesterLabel` consumer per grouping (tab empty state, export dialog, attention card, section header, faculty card, evaluate action menu) — each inherits the composed label from the ViewModel
- [ ] URL round-trip: land on `/faculty/analytics` with no `semesterId`, confirm the URL bar has `?semesterId=<uuid>&semesterLabel=Semester+2+%E2%80%A2+2025-2026`; copy-paste into a new tab and verify the sticky header decodes correctly
- [ ] On a 13–14" viewport (~900–1000px content width with sidebar open), open the Campus-scope dashboard (four dropdowns on one row). If layout wraps awkwardly, drop `md:w-64` to `md:w-56` (224px still fits the composed label at text-sm)
- [ ] If any seeded semester rows have `academic_year IS NULL`, verify they render as `"Semester 2 (year unknown)"` (or inject via DevTools React Query cache)

## Tech-spec

`api.faculytics/_bmad-output/implementation-artifacts/tech-spec-semester-label-with-academic-year.md`

## Follow-ups (not this PR)

- `admin.faculytics` copy of the util (separate ticket)
- Server-rendered faculty PDF reports — compose on the backend if that format should also change
- Align the three semester response DTO optionality variants (`SemesterFilterResponseDto` required vs `SemesterShortResponseDto` / `SemesterItemResponseDto` optional) — API-side audit