### PR TITLE
FAC-WEB feat: show academic year alongside semester labels (#154)

### DIFF
--- a/features/faculty-analytics/components/scoped-dashboard-header.tsx
+++ b/features/faculty-analytics/components/scoped-dashboard-header.tsx
@@ -78,7 +78,7 @@ export function ScopedDashboardHeader({
             <DropdownMenuTrigger asChild>
               <Button
                 variant="outline"
-                className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-48 md:max-w-48"
+                className="w-full min-w-0 justify-between px-4 py-2.5 font-sans text-sm md:w-64 md:max-w-64"
                 disabled={semesters.length === 0}
               >
                 <span className="truncate">{selectedSemesterLabel}</span>

--- a/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
+++ b/features/faculty-analytics/hooks/use-faculty-report-detail-view-model.ts
@@ -25,6 +25,7 @@ import {
   type SentimentLabel,
 } from "@/features/faculty-analytics/types";
 import { useQuestionnaireTypes } from "@/features/questionnaires/hooks/use-questionnaire-types";
+import { formatSemesterDisplay } from "@/lib/format-semester";
 import { resolvePageSizeOption } from "@/lib/pagination";
 import { useActiveRole } from "@/features/auth/hooks/use-active-role";
 import { getRoleConfig } from "@/features/auth/lib/role-route";
@@ -347,9 +348,9 @@ export function useFacultyReportDetailViewModel({
 
   const report = reportQuery.data ?? null;
   const reportTitle = report?.faculty.name || facultyNameParam || "Faculty report";
-  const semesterLabel =
-    report?.semester.label ||
-    (semesterLabelParam.trim().length > 0 ? semesterLabelParam : "Selected semester");
+  const reportDerivedLabel = report?.semester ? formatSemesterDisplay(report.semester) : null;
+  const urlDerivedLabel = semesterLabelParam.trim().length > 0 ? semesterLabelParam : null;
+  const semesterLabel = reportDerivedLabel ?? urlDerivedLabel ?? "Selected semester";
   const questionnaireTypeLabel = resolveFacultyReportQuestionnaireTypeLabel(
     report?.questionnaireType.code ?? questionnaireTypeCode ?? "",
     report?.questionnaireType.name ?? selectedQuestionnaireType?.name

--- a/features/faculty-analytics/lib/scoped-analytics-view-model.ts
+++ b/features/faculty-analytics/lib/scoped-analytics-view-model.ts
@@ -6,11 +6,11 @@ import type {
   ProgramOptionDto,
   SemesterOptionDto,
 } from "@/features/faculty-analytics/types";
+import { formatSemesterDisplay } from "@/lib/format-semester";
 
 export type ScopedSemesterOption = {
   id: string;
   label: string;
-  academicYear?: string;
 };
 
 export type ScopedDepartmentOption = {
@@ -59,8 +59,7 @@ export function mapSemesterOptionsToViewModel(
 ): ScopedSemesterOption[] {
   return semesters.map((semester) => ({
     id: semester.id,
-    label: semester.label ?? [semester.code, semester.academicYear].filter(Boolean).join(" • "),
-    academicYear: semester.academicYear,
+    label: formatSemesterDisplay(semester),
   }));
 }
 

--- a/lib/format-semester.ts
+++ b/lib/format-semester.ts
@@ -1,0 +1,14 @@
+export type SemesterLike = {
+  label?: string | null;
+  academicYear?: string | null;
+  code?: string | null;
+};
+
+export const SEMESTER_UNKNOWN_LABEL = "Unknown Semester";
+const ACADEMIC_YEAR_UNKNOWN_SUFFIX = "(year unknown)";
+
+export function formatSemesterDisplay(semester: SemesterLike): string {
+  const head = semester.label?.trim() || semester.code?.trim() || SEMESTER_UNKNOWN_LABEL;
+  const year = semester.academicYear?.trim();
+  return year ? `${head} • ${year}` : `${head} ${ACADEMIC_YEAR_UNKNOWN_SUFFIX}`;
+}


### PR DESCRIPTION
Compose "Semester 2 • 2025-2026" via a shared formatSemesterDisplay util at lib/format-semester.ts, wired into two composition points: mapSemesterOptionsToViewModel (propagates to the three semester dropdowns and every downstream selectedSemesterLabel consumer) and useFacultyReportDetailViewModel (the faculty-report sticky header, which reads report?.semester.label directly and bypasses the ViewModel chain). Drops the now-redundant academicYear field from ScopedSemesterOption and widens the dashboard-header semester trigger to md:w-64 so the longer composed label doesn't truncate at md+ viewports.

The API already ships academicYear on every semester DTO — this is presentation-only. Fallback to "(year unknown)" when academicYear is absent, surfacing data gaps instead of silently dropping the year.

Closes #153