### PR TITLE
FAC-WEB fix: scope student courses page to current term

### DIFF
--- a/app/(dashboard)/student/courses/page.tsx
+++ b/app/(dashboard)/student/courses/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
+import { useCurrentStudentTerm } from "@/features/enrollments/hooks/use-current-student-term";
 import { useMyEnrollments } from "@/features/enrollments/hooks/use-my-enrollments";
 import { useSelectedCourseStore } from "@/stores/selected-course-store";
 
@@ -22,6 +23,13 @@ function getInitialCoursesViewMode(): CoursesViewMode {
   return storedView === "list" || storedView === "card" ? storedView : "card";
 }
 
+function formatTermLabel(semester: { label?: string; academicYear?: string; code: string }) {
+  const parts: string[] = [];
+  if (semester.label) parts.push(semester.label);
+  if (semester.academicYear) parts.push(`AY ${semester.academicYear}`);
+  return parts.length > 0 ? parts.join(", ") : semester.code;
+}
+
 export default function StudentCoursesPage() {
   const setSelectedCourse = useSelectedCourseStore((state) => state.setSelectedCourse);
   const [viewMode, setViewMode] = useState<CoursesViewMode>(getInitialCoursesViewMode);
@@ -29,24 +37,46 @@ export default function StudentCoursesPage() {
     page: 1,
     limit: 100,
   });
-  const enrolledCourses = data?.data ?? [];
-  const coursesState = isLoading
-    ? "loading"
-    : isError
-      ? "error"
-      : enrolledCourses.length === 0
-        ? "empty"
-        : "ready";
+  const term = useCurrentStudentTerm();
+
+  const allEnrollments = useMemo(() => data?.data ?? [], [data?.data]);
+  const currentTermEnrollments = useMemo(() => {
+    if (term.status !== "ready") return [];
+    return allEnrollments.filter((enrollment) => enrollment.semester?.id === term.semester.id);
+  }, [allEnrollments, term]);
+
+  const isTermLoading = term.status === "loading";
+  const isTermError = term.status === "error";
+
+  const coursesState =
+    isLoading || isTermLoading
+      ? "loading"
+      : isError || isTermError
+        ? "error"
+        : currentTermEnrollments.length === 0
+          ? "empty"
+          : "ready";
+
   const coursesContent =
     coursesState === "ready" ? (
       viewMode === "card" ? (
-        <CourseGrid enrollments={enrolledCourses} onSelectCourse={setSelectedCourse} />
+        <CourseGrid enrollments={currentTermEnrollments} onSelectCourse={setSelectedCourse} />
       ) : (
-        <CourseList enrollments={enrolledCourses} onSelectCourse={setSelectedCourse} />
+        <CourseList enrollments={currentTermEnrollments} onSelectCourse={setSelectedCourse} />
       )
     ) : (
       <CoursesState state={coursesState} />
     );
+
+  const termLabel = term.status === "ready" ? formatTermLabel(term.semester) : null;
+  const subtitle =
+    term.status === "loading" || isLoading
+      ? "Loading your current term..."
+      : termLabel
+        ? `You are currently enrolled in ${currentTermEnrollments.length} ${
+            currentTermEnrollments.length === 1 ? "course" : "courses"
+          } for ${termLabel}.`
+        : "We couldn't determine your current term.";
 
   function handleViewModeChange(nextView: CoursesViewMode) {
     setViewMode(nextView);
@@ -58,9 +88,7 @@ export default function StudentCoursesPage() {
       <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
         <div>
           <h1 className="text-3xl font-bold font-playfair">Courses</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            You are currently enrolled in {enrolledCourses.length} courses this semester
-          </p>
+          <p className="mt-2 text-sm text-muted-foreground">{subtitle}</p>
         </div>
         {coursesState === "ready" ? (
           <CoursesViewToggle value={viewMode} onValueChange={handleViewModeChange} />

--- a/features/enrollments/hooks/use-current-student-term.ts
+++ b/features/enrollments/hooks/use-current-student-term.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useMe } from "@/features/auth/hooks/use-me";
+import { resolveCurrentSemester } from "@/features/enrollments/lib/resolve-current-semester";
+import { useSemesterOptions } from "@/features/faculty-analytics/hooks/use-semester-options";
+import type { SemesterOptionDto } from "@/features/faculty-analytics/types";
+
+export type CurrentStudentTermResult =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "no-campus" }
+  | { status: "no-semester" }
+  | { status: "ready"; semester: SemesterOptionDto };
+
+/**
+ * Resolves the academic term the student is currently in, scoped to their
+ * campus. Chains useMe → useSemesterOptions(campusId) → resolveCurrentSemester.
+ *
+ * Pure frontend resolution: GET /enrollments/me returns every semester a
+ * student has enrollments in, and the student UI needs to show only the
+ * current one (no semester switcher). FAC-146 added start/end dates to the
+ * semester list response, which lets us pick the active term client-side.
+ */
+export function useCurrentStudentTerm(): CurrentStudentTermResult {
+  const meQuery = useMe();
+  const campusId = meQuery.data?.campus?.id;
+
+  const semestersQuery = useSemesterOptions(campusId ? { campusId } : undefined, {
+    enabled: Boolean(campusId),
+  });
+
+  const resolved = useMemo(() => {
+    if (!semestersQuery.data) return null;
+    return resolveCurrentSemester(semestersQuery.data.data);
+  }, [semestersQuery.data]);
+
+  if (meQuery.isLoading || (campusId && semestersQuery.isLoading)) {
+    return { status: "loading" };
+  }
+
+  if (meQuery.isError) {
+    return { status: "error", message: "Unable to load your profile." };
+  }
+
+  if (!campusId) {
+    return { status: "no-campus" };
+  }
+
+  if (semestersQuery.isError) {
+    return { status: "error", message: "Unable to load semesters." };
+  }
+
+  if (!resolved) {
+    return { status: "no-semester" };
+  }
+
+  return { status: "ready", semester: resolved };
+}

--- a/features/enrollments/index.ts
+++ b/features/enrollments/index.ts
@@ -1,3 +1,5 @@
 export * from "@/features/enrollments/api/enrollment.requests";
 export * from "@/features/enrollments/hooks/use-my-enrollments";
+export * from "@/features/enrollments/hooks/use-current-student-term";
+export * from "@/features/enrollments/lib/resolve-current-semester";
 export * from "@/features/enrollments/types";

--- a/features/enrollments/lib/resolve-current-semester.ts
+++ b/features/enrollments/lib/resolve-current-semester.ts
@@ -1,0 +1,34 @@
+import type { SemesterOptionDto } from "@/features/faculty-analytics/types";
+
+/**
+ * Picks the academic term that is currently in progress for the given list of
+ * semesters. "Currently in progress" means `startDate <= now < endDate` (with
+ * a missing `endDate` treated as open-ended). If no semester is active right
+ * now (e.g. between terms), falls back to the most recent semester by
+ * `startDate DESC` so the UI still renders the student's last known term
+ * instead of an empty screen.
+ *
+ * The input is assumed to already be scoped to a single campus by the caller.
+ */
+export function resolveCurrentSemester(
+  semesters: SemesterOptionDto[],
+  now: Date = new Date()
+): SemesterOptionDto | null {
+  if (semesters.length === 0) return null;
+
+  const nowMs = now.getTime();
+
+  const active = semesters.find((semester) => {
+    const start = new Date(semester.startDate).getTime();
+    const end = semester.endDate ? new Date(semester.endDate).getTime() : Number.POSITIVE_INFINITY;
+    return start <= nowMs && nowMs < end;
+  });
+
+  if (active) return active;
+
+  const sorted = [...semesters].sort((a, b) => {
+    return new Date(b.startDate).getTime() - new Date(a.startDate).getTime();
+  });
+
+  return sorted[0] ?? null;
+}

--- a/features/faculty-analytics/types/index.ts
+++ b/features/faculty-analytics/types/index.ts
@@ -35,6 +35,8 @@ export type SemesterOptionDto = {
   code: string;
   label?: string;
   academicYear?: string;
+  startDate: string;
+  endDate?: string;
   campus: {
     id: string;
     name: string;


### PR DESCRIPTION
## Summary

`GET /enrollments/me` returns every enrollment the student has ever had. Before S12526 backfill each student had data for exactly one term, so listing everything was fine — but once past semesters live alongside the current one, the Courses page would render duplicate entries and the *"enrolled in N courses this semester"* subtitle becomes factually wrong.

FAC-146 on the API unblocked a pure-frontend fix: `GET /semesters` now returns `startDate`/`endDate` per term, so we can resolve the current academic term client-side without any backend change, then filter enrollments by matching `semester.id`.

## What changed

- **`features/enrollments/lib/resolve-current-semester.ts`** — pure helper. Picks the semester where `startDate <= now < endDate`; falls back to the most recent by `startDate DESC` so between-term windows still render the student's last known term instead of going blank.
- **`features/enrollments/hooks/use-current-student-term.ts`** — orchestrates `useMe → useSemesterOptions(campusId) → resolveCurrentSemester`. Returns a discriminated union (`loading | error | no-campus | no-semester | ready`) so the page can handle every state explicitly.
- **`features/faculty-analytics/types/index.ts`** — `SemesterOptionDto` gains `startDate: string` + `endDate?: string`, matching the FAC-146 API response.
- **`features/enrollments/index.ts`** — re-exports the new hook and helper.
- **`app/(dashboard)/student/courses/page.tsx`** — filters `enrolledCourses` by `currentSemester.id`, and the subtitle now shows the real term label (e.g. *"You are currently enrolled in 4 courses for Semester 2, AY 2025-2026."*).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — all routes built including `/student/courses`
- [x] Manual local verification as a student

## Notes

- No backend change in this PR — we consume the `startDate`/`endDate` FAC-146 added and match by `semester.id` client-side. For realistic enrollment sizes (≤20 rows) the overhead of returning + filtering is negligible. If we ever need server-side scoping for efficiency or stricter data isolation, it's a straightforward follow-up: add a `semesterId?` query param + campus-scoped default to `GET /enrollments/me` in api.faculytics.
- Unchanged: Faculty / Dean / Chairperson / Campus Head dashboards — they already have a working semester switcher.

Closes #156