### PR TITLE
feat: rename topic modeling stage to thematic analysis

### DIFF
--- a/features/faculty-analytics/lib/pipeline-formatting.ts
+++ b/features/faculty-analytics/lib/pipeline-formatting.ts
@@ -19,7 +19,7 @@ export const STAGE_LABELS: Record<StageKey, string> = {
   embeddings: "Embedding check",
   sentiment: "Sentiment analysis",
   sentimentGate: "Sentiment gate",
-  topicModeling: "Topic modeling",
+  topicModeling: "Thematic analysis",
   recommendations: "Recommendations",
 };
 


### PR DESCRIPTION
## Summary
- Renames the `topicModeling` stage label in the analysis pipeline from "Topic modeling" to "Thematic analysis" so the pipeline status modal (and the trigger card / status strip that share the same source) reflect the preferred presentation.

## Test plan
- [ ] Open the analysis pipeline status modal on a faculty's analytics page and confirm the stage now reads "Thematic analysis".
- [ ] Verify the pipeline trigger card and inline status strip display the renamed label.
- [ ] Confirm no other copy referencing the old label was missed in user-facing surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)